### PR TITLE
Fix PriceRuleStepResultStructure's id attribute

### DIFF
--- a/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
@@ -335,7 +335,11 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PricingRuleRef"/>
 		</xsd:sequence>
-		<xsd:attribute ref="id"/>
+		<xsd:attribute name="id" type="ObjectIdType" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>Identifier of PriceRuleStepResult</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="order" type="xsd:integer">
 			<xsd:annotation>
 				<xsd:documentation>ordrer of step.</xsd:documentation>


### PR DESCRIPTION
Change PriceRuleStepResultStructure's id attribute to be of type *ObjectIdType* instead of referring to "id". Because jaxb generation of the model causes generated netex xml to have an undesired namespace prefix.

@syversenkr can probably elaborate.
