### PR TITLE
Set max occurs on GroupOfStopPlaces in groupsOfStopPlacesInFrame

### DIFF
--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version-v1.1.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version-v1.1.xsd
@@ -104,7 +104,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="GroupOfStopPlaces"/>
+					<xsd:element ref="GroupOfStopPlaces" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>


### PR DESCRIPTION
There is an issue with having more than one GroupOfStopPlaces in a frame.
This pull request sets `maxOccurs="unbounded"` in complexType groupsOfStopPlacesInFrame_RelStructure for the sequence of element GroupOfStopPlaces.