### PR TITLE
fix parent of AbstractDiscoveryRequestStructure

### DIFF
--- a/xsd/siri/siri_requests-v2.0.xsd
+++ b/xsd/siri/siri_requests-v2.0.xsd
@@ -81,6 +81,9 @@
 					Structure
 					Added AbstractRequiredReferencingItemStructure
 				</Date>
+				<Date><Modified>2018-04-12</Modified>
+					AbstractDiscoveryRequestStructure extends AuthenticatedRequestStructure instead of RequestStructure to avoid duplicates of RequestorEndpointGroup
+				</Date>
 				<Description>
 					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common request processing elements</p>
 				</Description>
@@ -1046,7 +1049,7 @@ Rail transport, Roads and road transport
 			<xsd:documentation>Requests for stop reference data for use in service requests.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="RequestStructure">
+			<xsd:extension base="AuthenticatedRequestStructure">
 				<xsd:sequence>
 					<xsd:group ref="RequestorEndpointGroup"/>
 				</xsd:sequence>


### PR DESCRIPTION
AbstractDiscoveryRequestStructure extends AuthenticatedRequestStructure instead of RequestStructure to avoid duplicates fields of RequestorEndpointGroup