### PR TITLE
Added value 'replaced' to ServiceAlterationEnum due to need in Norway

### DIFF
--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_support-v1.1.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_support-v1.1.xsd
@@ -437,6 +437,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="extraJourney"/>
 			<xsd:enumeration value="cancellation"/>
 			<xsd:enumeration value="planned"/>
+			<xsd:enumeration value="replaced"/>
 		</xsd:restriction>
 	</xsd:simpleType>
 </xsd:schema>


### PR DESCRIPTION
Due to the need for external systems to keep track of ServiceJourneys being replanned and/or replaced (e.g. replacement bus for train service etc.), we need to be able to annotate original ServiceJourney with ServiceAlteration "replaced" flag.