### PR TITLE
Added documentation for OrganisationTypeEnumeration

### DIFF
--- a/xsd/netex_framework/netex_genericFramework/netex_organisation_support-v1.1.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_organisation_support-v1.1.xsd
@@ -317,16 +317,56 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Allowed values for ORGANISATION TYPE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
-			<xsd:enumeration value="authority"/>
-			<xsd:enumeration value="operator"/>
-			<xsd:enumeration value="railOperator"/>
-			<xsd:enumeration value="railFreightOperator"/>
-			<xsd:enumeration value="statutoryBody"/>
-			<xsd:enumeration value="facilityOperator"/>
-			<xsd:enumeration value="travelAgent"/>
-			<xsd:enumeration value="servicedOrganisation"/>
-			<xsd:enumeration value="retailConsortium"/>
-			<xsd:enumeration value="other"/>
+			<xsd:enumeration value="authority">
+				<xsd:annotation>
+					<xsd:documentation>ORGANISATION is a Transport Authority or Agency.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="operator">
+				<xsd:annotation>
+					<xsd:documentation>ORGANISATION is a Public Transport OPERATOR.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="railOperator">
+				<xsd:annotation>
+					<xsd:documentation>ORGANISATION is a Rail OPERATOR.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="railFreightOperator">
+				<xsd:annotation>
+					<xsd:documentation>ORGANISATION is a rail freight OPERATOR.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="statutoryBody">
+				<xsd:annotation>
+					<xsd:documentation>ORGANISATION is a statutory body or government department.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="facilityOperator">
+				<xsd:annotation>
+					<xsd:documentation>ORGANISATION operates a facility such as a station.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="travelAgent">
+				<xsd:annotation>
+					<xsd:documentation>ORGANISATION is a Travel Agent.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="servicedOrganisation">
+				<xsd:annotation>
+					<xsd:documentation>ORGANISATION is a business or organisation served by public transport.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="retailConsortium">
+				<xsd:annotation>
+					<xsd:documentation>ORGANISATION is a trade association representing independent retailers.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="other">
+				<xsd:annotation>
+					<xsd:documentation>Other type of ORGANISATION.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<!-- ======================================================================= -->


### PR DESCRIPTION
Minor improvement by adding documentation (from NeTEx Part 1, Table- 53 - OrganisationType - Allowed Values) to OrganisationTypeEnumeration
_As "retailConsortium" was missing from the table in the NeTEx spec, its description is a best effort on my part_