### PR TITLE
Fix JourneyFrequencyGroup to verify id+version uniqueness for both ty…

### DIFF
--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -5684,12 +5684,12 @@ Provides a general purpose wrapper for NeTEx data content.</xsd:documentation>
 		</xsd:unique>
 		<!-- =====JourneyFrequencyGroup Key ========================== -->
 		<xsd:keyref name="JourneyFrequencyGroup_KeyRef" refer="netex:JourneyFrequencyGroup_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:JourneyFrequencyGroupRef "/>
+			<xsd:selector xpath=".//netex:JourneyFrequencyGroupRef"/>
 			<xsd:field xpath="@ref"/>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="JourneyFrequencyGroup_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:HeadwayJourneyGroup "/>
+			<xsd:selector xpath=".//netex:HeadwayJourneyGroup | .//netex:RhythmicalJourneyGroup"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
@@ -5710,7 +5710,7 @@ Provides a general purpose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="HeadwayJourneyGroup_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:HeadwayJourneyGroup |.//netex:RhythmicalJourneyGroup "/>
+			<xsd:selector xpath=".//netex:HeadwayJourneyGroup"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
@@ -5731,7 +5731,7 @@ Provides a general purpose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="RhythmicalJourneyGroup_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:RhythmicalJourneyGroup "/>
+			<xsd:selector xpath=".//netex:RhythmicalJourneyGroup"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>


### PR DESCRIPTION
Found a bug in the id+version uniqueness check for JourneyFrequencyGroupRef when referring to a RhythmicalJourneyGroup type object. Only references to HeadwayJourneyGroup type objects were correctly checked.

This error was due to the RhythmicalJourneyGroup _incorrectly_ being on the HeadwayJourneyGroup_AnyVersionedKey constraint check.