### PR TITLE
Include (Normal)DatedVehicleJourney in timetableframe

### DIFF
--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -102,16 +102,18 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="VehicleJourney"/>
+					<xsd:element ref="DatedVehicleJourney"/>
+					<xsd:element ref="NormalDatedVehicleJourney"/>
+					<xsd:element ref="ServiceJourney"/>
 					<xsd:element ref="DatedServiceJourney"/>
 					<xsd:element ref="DeadRun"/>
-					<xsd:element ref="ServiceJourney"/>
 					<xsd:element ref="SpecialService"/>
 					<xsd:element ref="TemplateServiceJourney">
 						<xsd:annotation>
 							<xsd:documentation>A VEHICLE JOURNEY with a set of frequencies that may be used to represent a set of similar journeys differing only by their time of departure.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="VehicleJourney"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>


### PR DESCRIPTION
Specified in the standard and objects are defined in netex_datedVehicleJourney_version.xsd but currently unavailable as vehicleJourneys types in TimetableFrame due to XSD implementation error.
Recommending these to be added per Basecamp/email exchange with @nick-knowles