### PR TITLE
Fixed incorrect doc-strings for attrs 'modification' and 'status'

### DIFF
--- a/xsd/netex_framework/netex_responsibility/netex_version_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_version_support.xsd
@@ -101,25 +101,24 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>This is a definition of a new entity.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
-			<xsd:enumeration value="delete">
-				<xsd:annotation>
-					<xsd:documentation>This is a deletion of an existing entity.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:enumeration>
 			<xsd:enumeration value="revise">
 				<xsd:annotation>
 					<xsd:documentation>This is a revision to an existing entity. All values are replaced.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
+			<xsd:enumeration value="delete">
+				<xsd:annotation>
+					<xsd:documentation>This is a deletion of an existing entity.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="unchanged">
 				<xsd:annotation>
-					<xsd:documentation>This is a repeat of the values to an entity that has not change since the previous version.  All values are replaced.</xsd:documentation>
+					<xsd:documentation>This is a repeat of the values to an entity that has not change since the previous version. All values are replaced.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="delta">
 				<xsd:annotation>
-					<xsd:documentation>This is  just the changes to a previous version of an entity. Optional values are only provided if they have changed.  
-					</xsd:documentation>
+					<xsd:documentation>This is just the changes to a previous version of an entity. Optional values are only provided if they have changed.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 		</xsd:restriction>
@@ -161,7 +160,7 @@ Rail transport, Roads and Road transport
 		</xsd:attribute>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new">
 			<xsd:annotation>
-				<xsd:documentation>Nature of last modification: new, revise, delete, unchanged (default is new).</xsd:documentation>
+				<xsd:documentation>Nature of last modification: new, revise, delete, unchanged, delta. Default is "new".</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="version" type="VersionIdType" use="optional">
@@ -171,7 +170,7 @@ Rail transport, Roads and Road transport
 		</xsd:attribute>
 		<xsd:attribute name="status" type="StatusEnumeration" use="optional" default="active">
 			<xsd:annotation>
-				<xsd:documentation>Whether ENTITY is currently in use. Default is "released"</xsd:documentation>
+				<xsd:documentation>Whether ENTITY is currently in use. Default is "active".</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="derivedFromVersionRef" type="VersionIdType" use="optional">


### PR DESCRIPTION
Corrected errors/inconsistencies in the annotations (<xsd:documentation> for 'modification' and 'status'. 
And additionally re-ordered enumeration values in ModificationEnumeration to match NeTEx spec, as well as fixing improper spacing in their doc-strings. 

(Minor cleanup only, NO functional change in the XSD.)