### PR TITLE
Remove duplicate include

### DIFF
--- a/xsd/netex_framework/netex_frames/netex_all_frames_framework.xsd
+++ b/xsd/netex_framework/netex_frames/netex_all_frames_framework.xsd
@@ -5,7 +5,6 @@
 	<xsd:include schemaLocation="netex_commonFrame_version.xsd"/>
 	<xsd:include schemaLocation="netex_compositeFrame_version.xsd"/>
 	<xsd:include schemaLocation="netex_serviceCalendarFrame_version.xsd"/>
-	<xsd:include schemaLocation="netex_serviceCalendarFrame_version.xsd"/>
 	<xsd:include schemaLocation="netex_resourceFrame_version.xsd"/>
 	<xsd:include schemaLocation="netex_generalFrame_version.xsd"/>
 </xsd:schema>

--- a/xsd/netex_framework/netex_responsibility/netex_version_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_version_support.xsd
@@ -101,25 +101,24 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>This is a definition of a new entity.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
-			<xsd:enumeration value="delete">
-				<xsd:annotation>
-					<xsd:documentation>This is a deletion of an existing entity.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:enumeration>
 			<xsd:enumeration value="revise">
 				<xsd:annotation>
 					<xsd:documentation>This is a revision to an existing entity. All values are replaced.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
+			<xsd:enumeration value="delete">
+				<xsd:annotation>
+					<xsd:documentation>This is a deletion of an existing entity.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="unchanged">
 				<xsd:annotation>
-					<xsd:documentation>This is a repeat of the values to an entity that has not change since the previous version.  All values are replaced.</xsd:documentation>
+					<xsd:documentation>This is a repeat of the values to an entity that has not change since the previous version. All values are replaced.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="delta">
 				<xsd:annotation>
-					<xsd:documentation>This is  just the changes to a previous version of an entity. Optional values are only provided if they have changed.  
-					</xsd:documentation>
+					<xsd:documentation>This is just the changes to a previous version of an entity. Optional values are only provided if they have changed.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 		</xsd:restriction>
@@ -161,7 +160,7 @@ Rail transport, Roads and Road transport
 		</xsd:attribute>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new">
 			<xsd:annotation>
-				<xsd:documentation>Nature of last modification: new, revise, delete, unchanged (default is new).</xsd:documentation>
+				<xsd:documentation>Nature of last modification: new, revise, delete, unchanged, delta. Default is "new".</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="version" type="VersionIdType" use="optional">
@@ -171,7 +170,7 @@ Rail transport, Roads and Road transport
 		</xsd:attribute>
 		<xsd:attribute name="status" type="StatusEnumeration" use="optional" default="active">
 			<xsd:annotation>
-				<xsd:documentation>Whether ENTITY is currently in use. Default is "released"</xsd:documentation>
+				<xsd:documentation>Whether ENTITY is currently in use. Default is "active".</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="derivedFromVersionRef" type="VersionIdType" use="optional">

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -250,7 +250,10 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TariffRef" minOccurs="0"/>
 			<xsd:element ref="FareStructureElementRef" minOccurs="0"/>
 			<xsd:element ref="FareElementInSequenceRef" minOccurs="0"/>
-			<xsd:element ref="DistanceMatrixElementRef" minOccurs="0"/>
+			<xsd:choice  minOccurs="0">
+				<xsd:element ref="DistanceMatrixElementRef"/>
+				<xsd:element ref="DistanceMatrixElement"/>
+			</xsd:choice>
 			<xsd:element ref="DistanceMatrixElementInverseRef" minOccurs="0"/>
 			<xsd:element ref="DistanceMatrixElementView" minOccurs="0"/>
 			<xsd:element ref="SalesOfferPackageRef" minOccurs="0"/>


### PR DESCRIPTION
Minor cleanup removing duplicate xsd:include of schemaLocation "netex_serviceCalendarFrame_version.xsd" in the frames_framework xsd
NB: Albeit a file rarely edited, please verify that there is no include missing here; a minor chance this was a copy/paste intended for another schema not yet included?