### PR TITLE
Remove duplicate include of netex_serviceCalendarFrame_version.xsd

### DIFF
--- a/xsd/netex_framework/netex_frames/netex_all_frames_framework.xsd
+++ b/xsd/netex_framework/netex_frames/netex_all_frames_framework.xsd
@@ -5,7 +5,6 @@
 	<xsd:include schemaLocation="netex_commonFrame_version.xsd"/>
 	<xsd:include schemaLocation="netex_compositeFrame_version.xsd"/>
 	<xsd:include schemaLocation="netex_serviceCalendarFrame_version.xsd"/>
-	<xsd:include schemaLocation="netex_serviceCalendarFrame_version.xsd"/>
 	<xsd:include schemaLocation="netex_resourceFrame_version.xsd"/>
 	<xsd:include schemaLocation="netex_generalFrame_version.xsd"/>
 </xsd:schema>


### PR DESCRIPTION
Minor cleanup removing duplicate xsd:include of schemaLocation "netex_serviceCalendarFrame_version.xsd" in frames_framework

NB: Albeit a file rarely edited, please verify that there is no include missing here; a minor chance this was a copy/paste intended for another schema not yet included?