### PR TITLE
Add animalsAllowed to NuisanceFacilityEnumeration

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
@@ -478,6 +478,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="noSmoking"/>
 			<xsd:enumeration value="familyArea"/>
 			<xsd:enumeration value="childfreeArea"/>
+			<xsd:enumeration value="animalsAllowed"/>
 			<xsd:enumeration value="noAnimals"/>
 			<xsd:enumeration value="breastfeedingFriendly"/>
 			<xsd:enumeration value="mobilePhoneUseZone"/>


### PR DESCRIPTION
_See issue #233_

As documented in NeTEx part - 1 7.7.14.4.2 Accommodation Facilities 

Further NuisanceFacilityEnumeration consolidation requested:

- "animalsAllowed" present in UML and now added to the XSD is missing in NuisanceFacilityType – AllowedValues
- "noAnimals" is present in UML and XSD, but not listed in NuisanceFacilityType – AllowedValues
- "breastfeedingFriendly" is present in XSD but missing in both UML and NuisanceFacilityType – AllowedValues

_And "other" is missing in the XSD, instead implemented as "unknown"_ 

In this case "other" makes more sense semantically (_as not specified equals unknown_), but if deprecating "unknown" this enumeration type is no longer backwards compatible. 

Have therefore not added this enumeration to the XSD, would still recommend replacing "unknown" with "other". 

If not, the UML and NuisanceFacilityType – AllowedValues must be updated to "unknown", or the type should contain both enumeration values.