### PR TITLE
Add support for CUSTOMER ACCOUNT LOG ENTRIES on a CUSTOMER ACCOUNT

### DIFF
--- a/examples/functions/fares/rail/Netex_era_distance_ro.xml
+++ b/examples/functions/fares/rail/Netex_era_distance_ro.xml
@@ -8005,6 +8005,14 @@ c
 											<Description>Account opened</Description>
 											<Date>2005-08-08T09:00:00Z</Date>
 										</CustomerRegistration>
+										<NoAccessRightsOnAccount id="tfc_cd:AC00000001@NoAccessRightsOnAccount" version="01">
+											<Description>Account attempted validated, but no access rights were found</Description>
+											<Date>2005-08-09T09:00:00Z</Date>
+										</NoAccessRightsOnAccount>
+										<InsufficientAccessRightsOnAccount id="tfc_cd:AC00000001@InsufficientAccessRightsOnAccount" version="01">
+											<Description>Account attempted validated, but the unused access rights on the account did not match validation requirements</Description>
+											<Date>2005-08-09T09:00:00Z</Date>
+										</InsufficientAccessRightsOnAccount>
 										<CustomerDeregistration id="tfc_cd:AC00000001@Deregistration" version="01">
 											<Description>Account closed</Description>
 											<Date>2009-08-08T09:00:00Z</Date>

--- a/examples/functions/fares/rail/Netex_era_distance_ro.xml
+++ b/examples/functions/fares/rail/Netex_era_distance_ro.xml
@@ -8000,6 +8000,16 @@ c
 											</fareContractEntries>
 										</FareContract>
 									</fareContracts>
+									<customerAccountEntries>
+										<CustomerRegistration id="tfc_cd:AC00000001@Registration" version="01">
+											<Description>Account opened</Description>
+											<Date>2005-08-08T09:00:00Z</Date>
+										</CustomerRegistration>
+										<CustomerDeregistration id="tfc_cd:AC00000001@Deregistration" version="01">
+											<Description>Account closed</Description>
+											<Date>2009-08-08T09:00:00Z</Date>
+										</CustomerDeregistration>
+									</customerAccountEntries>
 								</CustomerAccount>
 							</customerAccounts>
 						</Customer>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_accountUse_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_accountUse_support.xsd
@@ -168,4 +168,56 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
+	<!-- ====NO ACCESS RIGHTS ON ACCOUNT.======================================================== -->
+	<xsd:simpleType name="NoAccessRightsOnAccountIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="CustomerAccountEntryIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="NoAccessRightsOnAccountRef" type="NoAccessRightsOnAccountRefStructure" abstract="false" substitutionGroup="CustomerAccountEntryRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="NoAccessRightsOnAccountRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Reference to a NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="CustomerAccountEntryRefStructure">
+				<xsd:attribute name="ref" type="NoAccessRightsOnAccountIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====INSUFFICIENT ACCESS RIGHTS ON ACCOUNT.======================================================== -->
+	<xsd:simpleType name="InsufficientAccessRightsOnAccountIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="CustomerAccountEntryIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="InsufficientAccessRightsOnAccountRef" type="InsufficientAccessRightsOnAccountRefStructure" abstract="false" substitutionGroup="CustomerAccountEntryRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="InsufficientAccessRightsOnAccountRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Reference to a NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="CustomerAccountEntryRefStructure">
+				<xsd:attribute name="ref" type="InsufficientAccessRightsOnAccountIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
 </xsd:schema>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_accountUse_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_accountUse_support.xsd
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by Nicholas Knowles Knowles (Kizoom Ltd) -->
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_accountUse_support">
+	<xsd:include schemaLocation="../../netex_framework/netex_genericFramework/netex_loggable_support.xsd"/>
+	<!-- =============================================================== -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>Arne Seime</Creator>
+				<Date>
+					<Created>2020-11-20</Created>
+					Align with TM
+					Add CustomerAccountEntry as a base type for Customer Account log entries
+					Add CustomerRegistrationEntry and CustomerDeregistrationEntry as concrete CustomerAccountEntries
+				</Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the CUSTOMER ACCOUNT LOG ENTRY types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Rights>Unclassified
+					 <Copyright>CEN, Crown Copyright 2009-2020</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel, VDV, TransXChange, NEPTUNE, BISON and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx CUSTOMER ACCOUNT USE identifier types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>NeTEx: CUSTOMER ACCOUNT USE identifier types.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ====TYPE OF CUSTOMER ACCOUNT ENTRY================================================== -->
+	<xsd:complexType name="typeOfCustomerAccountEntryRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of TYPEs OF CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="TypeOfCustomerAccountEntryRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="TypeOfCustomerAccountEntryIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a TYPE OF CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="TypeOfValueIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="TypeOfCustomerAccountEntryRef" type="TypeOfCustomerAccountEntryRefStructure" substitutionGroup="TypeOfEntityRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a TYPE OF CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="TypeOfCustomerAccountEntryRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Reference to a TYPE OF CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="TypeOfValueRefStructure">
+				<xsd:attribute name="ref" type="TypeOfCustomerAccountEntryIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a TYPE OF CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====CUSTOMER ACCOUNT ENTRY.======================================================== -->
+	<xsd:simpleType name="CustomerAccountEntryIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="LogEntryIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="CustomerAccountEntryRef" type="CustomerAccountEntryRefStructure" substitutionGroup="LogEntryRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="CustomerAccountEntryRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Reference to a CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="LogEntryRefStructure">
+				<xsd:attribute name="ref" type="CustomerAccountEntryIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====CUSTOMER REGISTRATION.======================================================== -->
+	<xsd:simpleType name="CustomerRegistrationIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a CUSTOMER REGISTRATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="CustomerAccountEntryIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="CustomerRegistrationRef" type="CustomerRegistrationRefStructure" abstract="false" substitutionGroup="CustomerAccountEntryRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a CUSTOMER REGISTRATION.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="CustomerRegistrationRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Reference to a CUSTOMER REGISTRATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="CustomerAccountEntryRefStructure">
+				<xsd:attribute name="ref" type="CustomerRegistrationIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a CUSTOMER REGISTRATION.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====CUSTOMER DEREGISTRATION.======================================================== -->
+	<xsd:simpleType name="CustomerDeregistrationIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a CUSTOMER DEREGISTRATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="CustomerAccountEntryIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="CustomerDeregistrationRef" type="CustomerDeregistrationRefStructure" abstract="false" substitutionGroup="CustomerAccountEntryRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a CUSTOMER DEREGISTRATION.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="CustomerDeregistrationRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Reference to a CUSTOMER DEREGISTRATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="CustomerAccountEntryRefStructure">
+				<xsd:attribute name="ref" type="CustomerDeregistrationIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a CUSTOMER DEREGISTRATION.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_accountUse_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_accountUse_version.xsd
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_accouuntUse_version">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:gml="http://www.opengis.net/gml/3.2" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1"
+	id="netex_accouuntUse_version">
 	<xsd:include schemaLocation="netex_accountUse_support.xsd"/>
 	<xsd:include schemaLocation="netex_customerPurchasePackage_version.xsd"/>
 	<!-- ======================================================================= -->
@@ -15,6 +17,13 @@
 					Align with TM
 					Add CustomerAccountEntry as a base type for Customer Account log entries
 					Add CustomerRegistrationEntry and CustomerDeregistrationEntry as concrete CustomerAccountEntries
+				</Date>
+				<Date>
+					<Created>2021-08-09</Created>
+					Add NoAccessRightsOnAccount similar to FareContractEntry NoAccessRights (not in Netex yet) to signal that no 
+					access rights exists on any FareContract on the account that can be activated
+					Add InsufficientAccessRightsOnAccount similar to FareContractEntry InsufficientAccessRights (not in Netex yet) to signal that 
+					activatable access rights exists on any of the FareContracts on the account, but cannot be activated as they do not match requirements (due to wrong farezone, outside valid dates/time of day etc)
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -52,6 +61,22 @@
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: ACCOUNT USE types.</xsd:documentation>
 	</xsd:annotation>
+	<xsd:group name="CustomerAccountEntryLocationGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements specifying where event originated.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="StopPlaceRef">
+				<xsd:annotation><xsd:documentation>StopPlace where activitiy leading to event happened</xsd:documentation></xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ServiceJourneyRef">
+				<xsd:annotation><xsd:documentation>ServiceJourney where activitiy leading to event happened</xsd:documentation></xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="DistanceMatrixElementRef">
+				<xsd:annotation><xsd:documentation>DistanceMatrixElement where activitiy leading to event happened</xsd:documentation></xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
 	<!-- ====CUSTOMER ACCOUNT ENTRY-->
 	<xsd:complexType name="customerAccountEntries_RelStructure">
 		<xsd:annotation>
@@ -74,7 +99,6 @@
 	<xsd:element name="CustomerAccountEntry" abstract="true" substitutionGroup="CustomerAccountEntry_">
 		<xsd:annotation>
 			<xsd:documentation>A log entry describing an event referring to the life of a CUSTOMER ACCOUNT: customer registration, deregistration, account suspension/re-enabling etc
-				
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
@@ -222,6 +246,94 @@
 	<xsd:group name="CustomerDeregistrationGroup">
 		<xsd:annotation>
 			<xsd:documentation>Elements for CUSTOMER DEREGISTRATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<!-- No specific content -->
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== NO ACCESS RIGHTS ON ACCOUNT ================================================ -->
+	<xsd:element name="NoAccessRightsOnAccount" abstract="false" substitutionGroup="CustomerAccountEntry_">
+		<xsd:annotation>
+			<xsd:documentation>A NO ACCESS RIGHTS ON ACCOUNT ENTRY records the detection of a passenger without any valid ticket.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="NoAccessRightsOnAccount_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+							<xsd:group ref="LogEntryGroup"/>
+							<xsd:group ref="CustomerAccountEntryGroup"/>
+							<xsd:group ref="NoAccessRightsOnAccountGroup"/>
+							<xsd:group ref="CustomerAccountEntryLocationGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="NoAccessRightsOnAccountIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="NoAccessRightsOnAccount_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="CustomerAccountEntry_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="NoAccessRightsOnAccountGroup"/>
+					<xsd:group ref="CustomerAccountEntryLocationGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="NoAccessRightsOnAccountGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<!-- No specific content -->
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== INSUFFICIENT ACCESS RIGHTS ON ACCOUNT ================================================ -->
+	<xsd:element name="InsufficientAccessRightsOnAccount" abstract="false" substitutionGroup="CustomerAccountEntry_">
+		<xsd:annotation>
+			<xsd:documentation>INSUFFICIENT ACCESS RIGHTS ENTRY records the result of the comparison between one or several CONTROL ENTRies 
+				and the theoretical access rights attached to the TRAVEL DOCUMENT controlled, detecting insufficient rights to consume and possibly 
+				providing a DEBIT or one or more OFFENCEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="InsufficientAccessRightsOnAccount_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+							<xsd:group ref="LogEntryGroup"/>
+							<xsd:group ref="CustomerAccountEntryGroup"/>
+							<xsd:group ref="InsufficientAccessRightsOnAccountGroup"/>
+							<xsd:group ref="CustomerAccountEntryLocationGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="InsufficientAccessRightsOnAccountIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="InsufficientAccessRightsOnAccount_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="CustomerAccountEntry_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="InsufficientAccessRightsOnAccountGroup"/>
+					<xsd:group ref="CustomerAccountEntryLocationGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="InsufficientAccessRightsOnAccountGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for NO ACCESS RIGHTS ON ACCOUNT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<!-- No specific content -->

--- a/xsd/netex_part_3/part3_salesTransactions/netex_accountUse_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_accountUse_version.xsd
@@ -66,7 +66,7 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerAccountEntry_" type="DataManagedObjectStructure" substitutionGroup="DataManagedObject">
+	<xsd:element name="CustomerAccountEntry_" abstract="true" type="DataManagedObjectStructure" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type for CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_accountUse_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_accountUse_version.xsd
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_accouuntUse_version">
+	<xsd:include schemaLocation="netex_accountUse_support.xsd"/>
+	<xsd:include schemaLocation="netex_customerPurchasePackage_version.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>Arne Seime</Creator>
+				<Date>
+					<Created>2020-11-20</Created>
+					Align with TM
+					Add CustomerAccountEntry as a base type for Customer Account log entries
+					Add CustomerRegistrationEntry and CustomerDeregistrationEntry as concrete CustomerAccountEntries
+				</Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the CUSTOMER ACCOUNT LOG ENTRY types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Rights>Unclassified
+					<Copyright>CEN, Crown Copyright 2009-2020</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel, VDV, TransXChange, NEPTUNE, BISON and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+						Air transport, Airports,
+						Ports and maritime transport, Ferries (marine),
+						Public transport, Bus services, Coach services, Bus stops and stations,
+						Rail transport, Railway stations and track, Train services, Underground trains,
+						Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+						Rail transport, Roads and Road transport
+					</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx CUSTOMER ACCOUNT USE identifier types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>NeTEx: ACCOUNT USE types.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ====CUSTOMER ACCOUNT ENTRY-->
+	<xsd:complexType name="customerAccountEntries_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of CUSTOMER ACCOUNT ENTRYs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="CustomerAccountEntryRef"/>
+					<xsd:element ref="CustomerAccountEntry_"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="CustomerAccountEntry_" type="DataManagedObjectStructure" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>Dummy type for CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="CustomerAccountEntry" abstract="true" substitutionGroup="CustomerAccountEntry_">
+		<xsd:annotation>
+			<xsd:documentation>A log entry describing an event referring to the life of a CUSTOMER ACCOUNT: customer registration, deregistration, account suspension/re-enabling etc
+				
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="CustomerAccountEntry_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LogEntryGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="CustomerAccountEntryGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="CustomerAccountEntryIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of ENTITY.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="CustomerAccountEntry_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="LogEntry_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="CustomerAccountEntryGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="CustomerAccountEntryGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for CUSTOMER ACCOUNT ENTRY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="IsValid" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether CUSTOMER ACCOUNT ENTRY is valid.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="TypeOfCustomerAccountEntryRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>A classification of CUSTOMER ACCOUNT ENTRYs.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="CustomerAccountRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====CUSTOMER REGISTRATION ================================================ -->
+	<xsd:element name="CustomerRegistration" abstract="false" substitutionGroup="CustomerAccountEntry_">
+		<xsd:annotation>
+			<xsd:documentation>A CUSTOMER REGISTRATION ENTRY records the registering of a customer and the creating of an account</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="CustomerRegistration_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LogEntryGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="CustomerAccountEntryGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="CustomerRegistrationGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="CustomerRegistrationIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="CustomerRegistration_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CUSTOMER REGISTRATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="CustomerAccountEntry_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="CustomerRegistrationGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="CustomerRegistrationGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for CUSTOMER REGISTRATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<!-- No specific content -->
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====CUSTOMER DEREGISTRATION ================================================ -->
+	<xsd:element name="CustomerDeregistration" abstract="false" substitutionGroup="CustomerAccountEntry_">
+		<xsd:annotation>
+			<xsd:documentation>A CUSTOMER DEREGISTRATION ENTRY records the clearing of all personal details of a customer and the closing of an account</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="CustomerDeregistration_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LogEntryGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="CustomerAccountEntryGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="CustomerDeregistrationGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="CustomerDeregistrationIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="CustomerDeregistration_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CUSTOMER DEREGISTRATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="CustomerAccountEntry_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="CustomerDeregistrationGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="CustomerDeregistrationGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for CUSTOMER DEREGISTRATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<!-- No specific content -->
+		</xsd:sequence>
+	</xsd:group>
+</xsd:schema>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
@@ -8,6 +8,7 @@
 	<xsd:include schemaLocation="netex_customerEligibility_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_securityList_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_address_version.xsd"/>
+	<xsd:include schemaLocation="netex_accountUse_version.xsd"/>
 	<!-- ======================================================================= -->
 	<xsd:annotation>
 		<xsd:appinfo>
@@ -49,6 +50,10 @@
 						Remove FareContractEntries from CustomerAccount  : Use relationship on FareCOntract
 						Add email to CustomerContact details
 						Add customerPurchasePackageRefs to CustomerAccount. This canbe derived from FarContractEntries
+				</Date>
+				<Date>
+					<Modified>2020-11-20</Modified>  Align with TM
+					Add customerAccountEntries to CustomerAccount to store CUSTOMER ACCOUNT LOG entries 
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -684,8 +689,14 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>CUSTOMER PURCHASE PACKAGES  for CUSTOMER ACCOUT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="customerAccountEntries" type="customerAccountEntries_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>LOG ENTRIES for CUSTOMER ACCOUNT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
+
 	<!-- ====TYPE OF CUSTOMER ACCOUNT ======================================== -->
 	<xsd:complexType name="typesOfCustomerAccount_RelStructure">
 		<xsd:annotation>


### PR DESCRIPTION
Currently there is a `LogEntry` extension hierarchy like

`LogEntry -> FareContractEntry -> SalesTransaction/TravelSpecification` etc. This pertains to things that happen on a FARE CONTRACT. 

In TM6 part 5 CUSTOMER ACCOUNT USE EVENTS (chapter 5.10.6.2) are described. These events and entries log activity on the CUSTOMER ACCOUNT itself such as registration, deregistration, profile modification etc.

This PR adds another "branch" `CustomerAccountEntry` extending `LogEntry` and the first 2 events mentioned under  chapter 5.10.6.2.2.

`LogEntry -> CustomerAccountEntry -> CustomerRegistration/CustomerDeregistration`

More LogEntries will be added as separate PRs later if this PR is merged.

Excerpt from TM6 part 5 page 134:


> CUSTOMER ACCOUNT ENTRies record actions by the TRANSPORT CUSTOMER (that is, CUSTOMER ACCOUNT EVENTs) to set up or modify the account of a customer. Note that an account may pre-exist and be used for other transactions than the purchase of travel.
>- A CUSTOMER REGISTRATION ENTRY records the registering of a customer and the creating of an account.
>- A CUSTOMER DEREGISTRATION ENTRY records the clearing of all personal details of a customer and the closing of an account.

