### PR TITLE
Allow OperatingPeriodRef to reference to UicOperatingPeriod

### DIFF
--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -2805,7 +2805,7 @@
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="OperatingPeriod_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:OperatingPeriod"/>
+			<xsd:selector xpath=".//netex:OperatingPeriod | .//netex:UicOperatingPeriod"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>

--- a/xsd/NeTEx_publication_timetable.xsd
+++ b/xsd/NeTEx_publication_timetable.xsd
@@ -2736,7 +2736,7 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="OperatingPeriod_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:OperatingPeriod"/>
+			<xsd:selector xpath=".//netex:OperatingPeriod | .//netex:UicOperatingPeriod"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>


### PR DESCRIPTION
EPIP profile uses UicOperatingPeriod, sadly we cannot use the current XSD because it does not allow OperatingPeriodRef to reference UicOperatingPeriod.