### PR TITLE
Add new construction GroupOfTariffzones

### DIFF
--- a/examples/functions/grouping/Netex_GroupingExample_General_01.xml
+++ b/examples/functions/grouping/Netex_GroupingExample_General_01.xml
@@ -23,6 +23,7 @@ This is shows use ofGrouping oif entities  in the same file
 Version History 
        Group changes to show all versions of each basic  entity (Stop, Link, Srevice pattern, DAY TYPE)
 
+       2021-01-25 - Added example use of GroupOfTariffZones
  
 (C) 2010-2019 Crown Copyright CEN
 -->
@@ -75,5 +76,21 @@ Version History
 				</GeneralGroupOfEntities>
 			</groupsOfEntities>
 		</ResourceFrame>
+		<SiteFrame version="any" id="mybus:ExampleGroupOfTariffZones">
+			<groupsOfTariffZones>
+				<GroupOfTariffZones version="any" id="mybus:InnerOslo">
+					<members>
+						<TariffZoneRef versionRef="EXTERNAL" ref="mybus:ZoneA"/>
+						<TariffZoneRef versionRef="EXTERNAL" ref="mybus:ZoneB"/>
+					</members>
+				</GroupOfTariffZones>
+				<GroupOfTariffZones version="any" id="mybus:GreaterOslo">
+					<members>
+						<TariffZoneRef versionRef="EXTERNAL" ref="mybus:ZoneC"/>
+						<TariffZoneRef versionRef="EXTERNAL" ref="mybus:ZoneD"/>
+					</members>
+				</GroupOfTariffZones>
+			</groupsOfTariffZones>
+		</SiteFrame>
 	</dataObjects>
 </PublicationDelivery>

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -1068,6 +1068,27 @@
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====GroupOfTariffZones============================== -->
+		<!-- =====GroupOfTariffZones unique========================== -->
+		<xsd:unique name="GroupOfTariffZones_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [GroupOfTariffZones Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:GroupOfTariffZones"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====GroupOfTariffZones Key ========================== -->
+		<xsd:keyref name="GroupOfTariffZones_KeyRef" refer="netex:GroupOfTariffZones_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:GroupOfTariffZonesRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="GroupOfTariffZones_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:GroupOfTariffZones"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
 		<!-- =====TypeOfProjection============================== -->
 		<!-- =====TypeOfProjection unique========================== -->
 		<xsd:unique name="TypeOfProjection_UniqueBy_Id_Version">

--- a/xsd/NeTEx_publication_timetable.xsd
+++ b/xsd/NeTEx_publication_timetable.xsd
@@ -1020,6 +1020,27 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====GroupOfTariffZones============================== -->
+		<!-- =====GroupOfTariffZones unique========================== -->
+		<xsd:unique name="GroupOfTariffZones_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [GroupOfTariffZones Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:GroupOfTariffZones"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====GroupOfTariffZones Key ========================== -->
+		<xsd:keyref name="GroupOfTariffZones_KeyRef" refer="netex:GroupOfTariffZones_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:GroupOfTariffZonesRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="GroupOfTariffZones_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:GroupOfTariffZones"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
 		<!-- =====TypeOfProjection============================== -->
 		<!-- =====TypeOfProjection unique========================== -->
 		<xsd:unique name="TypeOfProjection_UniqueBy_Id_Version">

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
@@ -30,6 +30,9 @@
 				<Date>
 					<Modified>2019-02-25</Modified>UK-18 Introduce a dummy TariffZone_ type to workaround substitutiongroup restrictions  in XML spy
 				</Date>
+				<Date>
+					<Modified>2021-01-25</Modified>Add GroupOfTariffZones
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines ZONE types.</p>
 				</Description>
@@ -248,6 +251,82 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
+	<!-- ==  GROUP OF TARIFF ZONEs ============================================== -->
+	<xsd:element name="GroupOfTariffZones" abstract="false" substitutionGroup="GroupOfEntities">
+		<xsd:annotation>
+			<xsd:documentation>A grouping of TARIFF ZONEs which will be commonly referenced for a specific purpose.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="GroupOfTariffZones_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="GroupOfEntitiesGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="GroupOfTariffZonesGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="GroupOfTariffZonesIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="GroupOfTariffZones_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for GROUP OF LINES.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="GroupOfEntities_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="GroupOfTariffZonesGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="GroupOfTariffZonesGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for GROUP OF LINES.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="members" type="tariffZoneRefs_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>TARIFF ZONEs in GROUP OF TARIFF ZONEs.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:element name="GroupOfTariffZonesRef" type="GroupOfTariffZonesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a GROUP OF TARIFF ZONEs.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="GroupOfTariffZonesRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a GROUP OF TARIFF ZONEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="GroupOfEntitiesRefStructure">
+				<xsd:attribute name="ref" type="GroupOfTariffZonesIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a GROUP OF TARIFF ZONEs.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="GroupOfTariffZonesIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a GROUP OF TARIFF ZONEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="GroupOfEntitiesIdType"/>
+	</xsd:simpleType>
 	<!-- ======================================================================= -->
 	<xsd:element name="TypeOfZone" abstract="false" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
@@ -280,7 +280,7 @@ Rail transport, Roads and Road transport
 	</xsd:element>
 	<xsd:complexType name="GroupOfTariffZones_VersionStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for GROUP OF LINES.</xsd:documentation>
+			<xsd:documentation>Type for GROUP OF TARIFF ZONEs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="GroupOfEntities_VersionStructure">
@@ -292,7 +292,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:group name="GroupOfTariffZonesGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for GROUP OF LINES.</xsd:documentation>
+			<xsd:documentation>Elements for GROUP OF TARIFF ZONEs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="members" type="tariffZoneRefs_RelStructure" minOccurs="0">

--- a/xsd/netex_part_1/part1_frames/netex_siteFrame_version.xsd
+++ b/xsd/netex_part_1/part1_frames/netex_siteFrame_version.xsd
@@ -217,7 +217,25 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>TARIFF ZONEs in frame.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="groupsOfTariffZones" type="groupsOfTariffZonesInFrame_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>GROUPs of TARIFF ZONEs in frame.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
+	<xsd:complexType name="groupsOfTariffZonesInFrame_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for containment in frame of GROUP OF TARIFF ZONEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="GroupOfTariffZones" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -91,6 +91,9 @@
 				<Date>
 					<Modified>2019-04-18</Modified>FIX  - SUpport Place to Place travel (ADDRESS and TOPOGRAPHICAL PLACE) : Add AddressRef ,  TopoographiPlaceRef and PlaceUseEnum.
 				</Date>
+				<Date>
+					<Modified>2021-01-25</Modified>Add GroupOfTariffZonesRef to NetworkValidityParametersGroup
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the FARE ACCESS RIGHT PARAMETER types.</p>
@@ -393,6 +396,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="GroupOfLinesRef" minOccurs="0"/>
 			<xsd:element ref="LineRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfLineRef" minOccurs="0"/>
+			<xsd:element ref="GroupOfTariffZonesRef" minOccurs="0"/>
 			<xsd:element ref="TariffZoneRef" minOccurs="0"/>
 			<xsd:element ref="FareZoneRef" minOccurs="0"/>
 			<xsd:element ref="FareSectionRef" minOccurs="0"/>


### PR DESCRIPTION
In parameter assignments for products/fares it helps reduce the number of entries necessary by referring to a group instead of referencing each tariff zone separately.

This has been discussed with @nick-knowles today.