### PR TITLE
Need to specify more than one ActivationMeans

### DIFF
--- a/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
@@ -53,6 +53,9 @@
 				<Date>
 					<Modified>2019-04-02</Modified>Doc tidy Add  new vale _cap_ to  UsageValidityType			
 				</Date>
+				<Date>
+					<Modified>2020-12-10</Modified>FIX - Add ActivationMeansListOfEnumerations
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the Travel USAGE PARAMETER  types.</p>
@@ -366,9 +369,15 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
+	<xsd:simpleType name="ActivationMeansListOfEnumerations">
+		<xsd:annotation>
+			<xsd:documentation>List of values for ACTIVATION MEANS.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:list itemType="ActivationMeansEnumeration"/>
+	</xsd:simpleType>
 	<xsd:simpleType name="ActivationMeansEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for Activation Means</xsd:documentation>
+			<xsd:documentation>Allowed values for ACTIVATION MEANS.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="noneRequired"/>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_version.xsd
@@ -38,6 +38,9 @@
 				<Date>
 				<Modified>2019-04-01</Modified>EURA-52, EURA40 *FARES*  Add   attribute ActivationMeans to UsageValidityPeriod as previously intended.
 				</Date>
+				<Date>
+					<Modified>2020-12-10</Modified>FIX - Make ActivationMeans into list
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the Travel USAGE PARAMETER  types.</p>
@@ -433,9 +436,9 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Duration of  USAGE VALIDITY PERIOD.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="ActivationMeans" type="ActivationMeansEnumeration" minOccurs="0">
+			<xsd:element name="ActivationMeans" type="ActivationMeansListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Means of activatiing start of period.</xsd:documentation>
+					<xsd:documentation>Means of activating start of period.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="UsageValidityPeriodFixedPeriodGroup">


### PR DESCRIPTION
Currently it is only possible to define a single activation mean for a usage validity period.

This PR adds support for multiple values

This PR has been discussed with @nick-knowles 