### PR TITLE
FareClassEnumeration secondClass remove trailing space

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_support.xsd
@@ -116,7 +116,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>pti23_6</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
-			<xsd:enumeration value="secondClass ">
+			<xsd:enumeration value="secondClass">
 				<xsd:annotation>
 					<xsd:documentation>pti23_7</xsd:documentation>
 				</xsd:annotation>


### PR DESCRIPTION
Is causing parsing errors in the NeTEx Java model
