### PR TITLE
Add allowed value 'proposed'

### DIFF
--- a/xsd/netex_framework/netex_responsibility/netex_version_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_version_support.xsd
@@ -129,6 +129,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="draft"/>
+			<xsd:enumeration value="proposed"/>
 			<xsd:enumeration value="versioned"/>
 			<xsd:enumeration value="deprecated"/>
 			<xsd:enumeration value="other"/>


### PR DESCRIPTION
NeTEx part 1 chapter _7.3.4.4.2.3 VersionStatus – Allowed Values_ documents that the VersionStatusEnumeration should include 'proposed' ("_This version is comprehensive but not yet validated._")

NB: Implemented value "other" is **not** currently documented in the spec.
