### PR TITLE
NewModes: Add missing attributes for VehicleModelProfile.

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_fleetEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_fleetEquipment_version.xsd
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_nm_fleetEquipment_version">
 	<xsd:include schemaLocation="netex_nm_fleetEquipment_support.xsd"/>
+	<xsd:include schemaLocation="../netex_utility/netex_units.xsd"/>
 	<xsd:include schemaLocation="../netex_responsibility/netex_responsibility_version.xsd"/>
 	<!-- ======================================================================= -->
 	<xsd:annotation>
@@ -131,6 +132,16 @@ Rail transport, Roads and Road transport
 			<xsd:element name="ChildSeat" type="ChildSeatEnumeration" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Type of Child seat.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="RangeBetweenRefuelling" type="DistanceType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Maximum range between refuelling for vehicles of the MODEL PROFILE..</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="IsPortable" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether vehicle can be carried easily, e.g., scooter, skateboard, collapsible bicycle.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>


### PR DESCRIPTION
Two attributes on VehicleModelProfiel  found in the spec UML are missing from the XSD 
- RangeBetweenRefuelling  and IsPortable