### PR TITLE
New modes add bay to vehicle sharing assignment

### DIFF
--- a/NeTEx.spp
+++ b/NeTEx.spp
@@ -736,6 +736,7 @@
 					</Folder>
 				</Folder>
 				<Folder FolderName="newModes">
+					<File FilePath="examples\functions\newModes\NewModes-CarClubExample.xml" HomeFolder="Yes"/>
 					<File FilePath="examples\functions\newModes\NewModes-CarPoolingExample.xml" HomeFolder="Yes"/>
 					<File FilePath="examples\functions\newModes\NewModes-ChauffeuredServiceExample.xml" HomeFolder="Yes"/>
 					<File FilePath="examples\functions\newModes\NewModes-CycleSharingExample.xml" HomeFolder="Yes"/>

--- a/examples/functions/newModes/NewModes-CarClubExample.xml
+++ b/examples/functions/newModes/NewModes-CarClubExample.xml
@@ -1,0 +1,1249 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<PublicationDelivery version="1.2.2" xsi:schemaLocation="http://www.netex.org.uk/netex ../../../xsd/NeTEx_publication.xsd" xmlns="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<!-- NewModes example of an car club car  sharing scheme
+         Cars available from parking stations ALpha & Beta in Area metropolis
+         SHort term use - can be returned anywhere 
+             
+         Products (1) Care club    hire, 
+                      Stepped pricing TIME INTERVALs  2 hours
+0.5 day
+													 1 day  
+													 2 day
+													3 day
+                      Penalty fees for late return , loss etc 
+                      SALES PACKAGES  (a) membership
+                                      (b) mobile app for preregistered users.
+ 
+	 
+
+(C) CEN 2021
+-->
+	<PublicationTimestamp>2021-12-17T09:30:47.0Z</PublicationTimestamp>
+	<ParticipantRef>SYS001</ParticipantRef>
+	<!-- ======WHAT WAS REQUESTED ========== -->
+	<PublicationRequest version="1.0">
+		<RequestTimestamp>2021-12-17T09:30:46.0Z</RequestTimestamp>
+		<ParticipantRef>SYS002</ParticipantRef>
+		<Description>Request for Carclub tariff</Description>
+		<topics>
+			<NetworkFrameTopic>
+				<selectionValidityConditions>
+					<AvailabilityCondition version="any" id="r1">
+						<FromDate>2021-01-01T00:00:00Z</FromDate>
+					</AvailabilityCondition>
+				</selectionValidityConditions>
+				<NetworkFilterByValue>
+					<LayerRef ref="fxc:fareNetwork_fareProducts_farePrices"/>
+					<objectReferences>
+						<OperatorRef version="any" ref="coc:MCR"/>
+						<VehicleSharingRef version="any" ref="car_club"/>
+					</objectReferences>
+				</NetworkFilterByValue>
+			</NetworkFrameTopic>
+		</topics>
+	</PublicationRequest>
+	<PublicationRefreshInterval>P1M</PublicationRefreshInterval>
+	<Description>Example of Car Club   with prices</Description>
+	<!-- =============== RESULTS =========== -->
+	<dataObjects>
+		<CompositeFrame version="1.0" id="mc:car_club_example" dataSourceRef="mc:my_car" responsibilitySetRef="mc:tariffs">
+			<ValidBetween>
+				<FromDate>2021-01-01T00:00:00</FromDate>
+				<ToDate>2021-12-31T12:00:00</ToDate>
+			</ValidBetween>
+			<Name>Car Club  Example</Name>
+			<Description>This is an example showing how one might encode   a Car Club scheme "My Car"  in NeTEx.  It includes some  prices.</Description>
+			<!--==== CODESPACEs ==== -->
+			<codespaces>
+				<CodespaceRef ref="mc_data"/>
+			</codespaces>
+			<!--==== FRAME DEFAULTS ==== -->
+			<FrameDefaults>
+				<!---  The default means that actually we could leave off all id s that belong to the mc: namespace. -->
+				<DefaultCodespaceRef ref="mc_data"/>
+				<DefaultDataSourceRef ref="mc:my_car" version="any"/>
+				<DefaultCurrency>EUR</DefaultCurrency>
+			</FrameDefaults>
+			<frames>
+				<!--==== OPERATOR COMMON RESOURCES==== -->
+				<ResourceFrame version="1.0" id="mc:car_club_example" responsibilitySetRef="mc:network_data">
+					<Name>Operator specific  common resources</Name>
+					<codespaces>
+						<Codespace id="mc_data">
+							<Xmlns>mc</Xmlns>
+							<XmlnsUrl>http://www.mycar.com</XmlnsUrl>
+							<Description>Mycar data</Description>
+						</Codespace>
+					</codespaces>
+					<dataSources>
+						<DataSource id="mc:my_car" version="any">
+							<Email>feedback@mycar.com</Email>
+						</DataSource>
+					</dataSources>
+					<!-- ========Responsibility Sets========== -->
+					<responsibilitySets>
+						<ResponsibilitySet version="any" id="mc:tariffs">
+							<Name>Operator Tariffs</Name>
+							<roles>
+								<ResponsibilityRoleAssignment version="any" id="mc:tariff_data@creates">
+									<DataRoleType>creates</DataRoleType>
+									<StakeholderRoleType>FareManagement</StakeholderRoleType>
+									<ResponsibleOrganisationRef ref="coc:MCR" version="any">My Car</ResponsibleOrganisationRef>
+								</ResponsibilityRoleAssignment>
+							</roles>
+						</ResponsibilitySet>
+						<ResponsibilitySet version="any" id="mc:network_data">
+							<Name>Operator data</Name>
+							<roles>
+								<ResponsibilityRoleAssignment version="any" id="mc:network_data@creates">
+									<DataRoleType>creates</DataRoleType>
+									<StakeholderRoleType>Planning</StakeholderRoleType>
+									<ResponsibleOrganisationRef ref="coc:MCR" version="any">My Car</ResponsibleOrganisationRef>
+								</ResponsibilityRoleAssignment>
+							</roles>
+						</ResponsibilitySet>
+					</responsibilitySets>
+					<!--==== CODE VALUES  ==== -->
+					<typesOfValue>
+						<ValueSet version="any" id="AllBranding" classOfValues="Branding">
+							<Name>MyCar</Name>
+							<values>
+								<Branding version="any" id="myBrand">
+									<Name>My Car</Name>
+									<Url>https://www.mycar.com/static/images/colorways/myc/logo.png</Url>
+								</Branding>
+							</values>
+						</ValueSet>
+					</typesOfValue>
+					<contacts>
+						<Contact version="any" id="MCR">
+							<ContactDetails>
+								<Email>info@mycar.com</Email>
+								<Phone>+32 1293 449191</Phone>
+							</ContactDetails>
+							<ContactType>information</ContactType>
+						</Contact>
+					</contacts>
+					<organisations>
+						<!-- ==== ORGANISATIONS ==== -->
+						<Operator version="any" id="coc:MCR">
+							<PublicCode>MBK</PublicCode>
+							<Name>My Car</Name>
+							<ShortName>My Car</ShortName>
+							<TradingName>My Car Gmbh</TradingName>
+							<ContactDetails>
+								<ContactRef version="any" ref="MCR"/>
+							</ContactDetails>
+							<OrganisationType>operator</OrganisationType>
+							<relatedOrganisations>
+								<RelatedOrganisation version="any" id="coc:MCR">
+									<OnlineServiceOperatorRef version="any" ref="floggit"/>
+									<OrganisationRoleType>distributor</OrganisationRoleType>
+								</RelatedOrganisation>
+							</relatedOrganisations>
+							<Address>
+								<Street>Alpha1</Street>
+								<Town>Metropolis</Town>
+								<PostCode>RH10 9UA</PostCode>
+								<PostalRegion>Metroland</PostalRegion>
+							</Address>
+							<PrimaryMode>selfDrive</PrimaryMode>
+							<SelfDriveSubmode>hireCar</SelfDriveSubmode>
+							<VehicleSharingRef version="any" ref="car_club"/>
+						</Operator>
+						<OnlineServiceOperator version="any" id="floggit">
+							<Name>Online transport services</Name>
+							<TradingName>Web Floggers SA</TradingName>
+							<ContactDetails>
+								<Email>barrowboy@floggit.com</Email>
+							</ContactDetails>
+							<OrganisationType>onlineProvider</OrganisationType>
+							<Address>
+								<Street>Rue des Postes.</Street>
+								<Town>Betaville</Town>
+								<PostalRegion>Metroland</PostalRegion>
+							</Address>
+						</OnlineServiceOperator>
+					</organisations>
+					<modesOfOperation>
+						<VehicleSharing version="any" id="car_club">
+							<Name>Car Club</Name>
+							<Description>Cars available from fixed stations charge per period</Description>
+							<submodes>
+								<Submode version="any" id="car_club">
+									<TransportMode>selfDrive</TransportMode>
+									<SelfDriveSubmode>hireCar</SelfDriveSubmode>
+								</Submode>
+							</submodes>
+							<VehicleSharingType>vehicleSharing</VehicleSharingType>
+						</VehicleSharing>
+					</modesOfOperation>
+					<vehicleTypes>
+						<SimpleVehicleType version="any" id="small_car">
+							<Name>Small car</Name>
+							<ReversingDirection>false</ReversingDirection>
+							<SelfPropelled>true</SelfPropelled>
+							<PropulsionType>electric</PropulsionType>
+							<FuelType>battery</FuelType>
+							<TransportMode>selfDrive</TransportMode>
+							<PassengerCapacity version="any" id="car_club">
+								<SeatingCapacity>4</SeatingCapacity>
+							</PassengerCapacity>
+							<Length>3.5</Length>
+							<Height>1.6</Height>
+							<Weight>600</Weight>
+							<LicenceRequirements>full</LicenceRequirements>
+							<VehicleCategory>smallCar</VehicleCategory>
+							<MinimumAge>18</MinimumAge>
+						</SimpleVehicleType>
+					</vehicleTypes>
+					<vehicleModels>
+						<VehicleModel version="any" id="mini_whiz">
+							<Name>Model A</Name>
+							<SimpleVehicleTypeRef version="any" ref="small_car"/>
+							<CarModelProfileRef version="any" ref="model_a"/>
+						</VehicleModel>
+					</vehicleModels>
+					<vehicleModelProfiles>
+						<CarModelProfile version="any" id="model_a">
+							<ChildSeat>none</ChildSeat>
+							<Seats>4</Seats>
+							<Doors>2</Doors>
+							<Transmission>automatic</Transmission>
+							<SatNav>true</SatNav>
+							<AirConditioning>true</AirConditioning>
+							<Convertible>false</Convertible>
+							<UsbPowerSockets>false</UsbPowerSockets>
+							<RoofRack>false</RoofRack>
+							<SkiRack>false</SkiRack>
+						</CarModelProfile>
+					</vehicleModelProfiles>
+				</ResourceFrame>
+				<!--==== NETWORK ==== -->
+				<SiteFrame version="1.0" id="mc:car_club_example" responsibilitySetRef="mc:network_data">
+					<Name>Network data used by My Car 1</Name>
+					<prerequisites>
+						<ResourceFrameRef version="1.0" ref="mc:car_club_example"/>
+					</prerequisites>
+					<topographicPlaces>
+						<TopographicPlace version="any" id="Alphaville">
+							<Centroid>
+								<Location id="Alphaville">
+									<Longitude>1.35250</Longitude>
+									<Latitude>52.44692</Latitude>
+									<gml:pos srsName="UKOS">376748  167119</gml:pos>
+								</Location>
+							</Centroid>
+							<Descriptor>
+								<Name>Alphaville</Name>
+							</Descriptor>
+						</TopographicPlace>
+					</topographicPlaces>
+					<parkings>
+						<Parking version="any" id="car_station_alpha">
+							<Name lang="en">Car Station Alpha</Name>
+							<infoLinks>
+								<InfoLink typeOfInfoLink="info" targetPlatform="ios">http:mycar.com/ios/car_station_alpha</InfoLink>
+								<InfoLink typeOfInfoLink="info" targetPlatform="android">http:mycar.com/android/car_station_alpha</InfoLink>
+								<InfoLink typeOfInfoLink="info" targetPlatform="eb">http:mycar.com/web/car_station_alpha</InfoLink>
+							</infoLinks>
+							<CrossRoad>Main Street</CrossRoad>
+							<Landmark>Main Railway Station</Landmark>
+							<Covered>outdoors</Covered>
+							<Gated>openArea</Gated>
+							<Lighting>wellLit</Lighting>
+							<TopographicPlaceRef version="any" ref="Alphaville"/>
+							<OperatorRef version="any" ref="coc:MCR"/>
+							<ParkingType>rentalCarParking</ParkingType>
+							<ParkingVehicleTypes>car</ParkingVehicleTypes>
+							<vehicleTypes>
+								<SimpleVehicleTypeRef version="any" ref="small_car"/>
+							</vehicleTypes>
+							<ParkingLayout>roadside</ParkingLayout>
+							<TotalCapacity>02</TotalCapacity>
+							<parkingProperties>
+								<ParkingProperties version="any" id="car_station_alpha">
+									<ParkingUserTypes>rental</ParkingUserTypes>
+									<ParkingVehicleTypes>car</ParkingVehicleTypes>
+									<ParkingVisibility>demarcated</ParkingVisibility>
+								</ParkingProperties>
+							</parkingProperties>
+							<parkingAreas>
+								<VehicleSharingParkingArea version="any" id="car_station_alpha_A1">
+									<TotalCapacity>2</TotalCapacity>
+									<bays>
+										<MonitoredVehicleSharingParkingBay version="any" id="car_station_alpha_A1@01">
+											<ParkingVehicleType>car</ParkingVehicleType>
+											<SimpleVehicleTypeRef version="any" ref="small_car"/>
+											<RechargingAvailable>true</RechargingAvailable>
+										</MonitoredVehicleSharingParkingBay>
+										<MonitoredVehicleSharingParkingBay version="any" id="car_station_alpha_A1@02">
+											<ParkingVehicleType>car</ParkingVehicleType>
+											<SimpleVehicleTypeRef version="any" ref="small_car"/>
+											<RechargingAvailable>true</RechargingAvailable>
+										</MonitoredVehicleSharingParkingBay>
+									</bays>
+								</VehicleSharingParkingArea>
+							</parkingAreas>
+						</Parking>
+						<Parking version="any" id="car_station_beta">
+							<Name lang="en">Car Station Beta</Name>
+							<CrossRoad>Main Street</CrossRoad>
+							<Landmark>Town Hall</Landmark>
+							<Covered>outdoors</Covered>
+							<TopographicPlaceRef version="any" ref="Alphaville"/>
+							<OperatorRef version="any" ref="coc:MCR"/>
+							<ParkingType>rentalCarParking</ParkingType>
+							<ParkingVehicleTypes>car</ParkingVehicleTypes>
+							<vehicleTypes>
+								<SimpleVehicleTypeRef version="any" ref="small_car"/>
+							</vehicleTypes>
+							<ParkingLayout>roadside</ParkingLayout>
+							<TotalCapacity>02</TotalCapacity>
+							<parkingProperties>
+								<ParkingProperties version="any" id="car_station_beta">
+									<ParkingUserTypes>rental</ParkingUserTypes>
+									<ParkingVehicleTypes>car</ParkingVehicleTypes>
+									<ParkingVisibility>demarcated</ParkingVisibility>
+								</ParkingProperties>
+							</parkingProperties>
+							<parkingAreas>
+								<VehicleSharingParkingArea version="any" id="car_station_beta_B1">
+									<TotalCapacity>2</TotalCapacity>
+									<bays>
+										<MonitoredVehicleSharingParkingBay version="any" id="car_station_beta_B1@01">
+											<ParkingVehicleType>car</ParkingVehicleType>
+											<SimpleVehicleTypeRef version="any" ref="small_car"/>
+											<RechargingAvailable>true</RechargingAvailable>
+										</MonitoredVehicleSharingParkingBay>
+										<MonitoredVehicleSharingParkingBay version="any" id="car_station_beta_B1@02">
+											<ParkingVehicleType>car</ParkingVehicleType>
+											<SimpleVehicleTypeRef version="any" ref="small_car"/>
+											<RechargingAvailable>true</RechargingAvailable>
+										</MonitoredVehicleSharingParkingBay>
+									</bays>
+								</VehicleSharingParkingArea>
+							</parkingAreas>
+						</Parking>
+					</parkings>
+					<tariffZones>
+						<TariffZone version="any" id="AllMetropolis">
+							<Name lang="en">All Metropolis</Name>
+						</TariffZone>
+					</tariffZones>
+				</SiteFrame>
+				<!--==== SERVICE CALENDAR ==== -->
+				<ServiceCalendarFrame version="1.0" id="mc:car_club_example" responsibilitySetRef="mc:network_data">
+					<Name>Day Type devinitions</Name>
+					<ServiceCalendar version="any" id="car_club_example">
+						<dayTypes>
+							<DayType version="any" id="working_day">
+								<Name>Working Day</Name>
+								<properties>
+									<PropertyOfDay>
+										<DaysOfWeek>Weekdays</DaysOfWeek>
+										<HolidayTypes>WorkingDay</HolidayTypes>
+									</PropertyOfDay>
+								</properties>
+							</DayType>
+							<DayType version="any" id="non_working_day">
+								<Name>Working Day</Name>
+								<properties>
+									<PropertyOfDay>
+										<DaysOfWeek>Saturday Sunday</DaysOfWeek>
+										<HolidayTypes>AnyDay</HolidayTypes>
+									</PropertyOfDay>
+									<PropertyOfDay>
+										<DaysOfWeek>Weekdays</DaysOfWeek>
+										<HolidayTypes>AnyHoliday</HolidayTypes>
+									</PropertyOfDay>
+								</properties>
+							</DayType>
+						</dayTypes>
+					</ServiceCalendar>
+				</ServiceCalendarFrame>
+				<!--==== Mobility Service ==== -->
+				<MobilityServiceFrame version="1.0" id="mc:car_club_example" responsibilitySetRef="mc:network_data">
+					<prerequisites>
+						<ResourceFrameRef version="1.0" ref="mc:car_club_example"/>
+						<ServiceCalendarFrameRef version="1.0" ref="mc:car_club_example"/>
+					</prerequisites>
+					<fleets>
+						<Fleet version="any" id="mycar_fleet">
+							<Name>The My Car fleet</Name>
+							<members>
+								<Vehicle version="any" id="car_01">
+									<OperatorRef version="any" ref="coc:MCR"/>
+									<SimpleVehicleTypeRef version="any" ref="small_car"/>
+									<VehicleModelRef version="any" ref="mini_whiz"/>
+									<CarModelProfileRef version="any" ref="model_a"/>
+									<actualVehicleEquipments>
+										<VehicleReleaseEquipment version="any" id="P01@release">
+											<OutOfService>false</OutOfService>
+											<RemoteControl>true</RemoteControl>
+											<LocalControl>true</LocalControl>
+											<LockingMechanism>immobilisingLock</LockingMechanism>
+										</VehicleReleaseEquipment>
+									</actualVehicleEquipments>
+								</Vehicle>
+								<Vehicle version="any" id="car_02">
+									<OperatorRef version="any" ref="coc:MCR"/>
+									<SimpleVehicleTypeRef version="any" ref="small_car"/>
+									<VehicleModelRef version="any" ref="mini_whiz"/>
+									<CarModelProfileRef version="any" ref="model_a"/>
+									<actualVehicleEquipments>
+										<VehicleReleaseEquipment version="any" id="P02@release">
+											<OutOfService>false</OutOfService>
+											<RemoteControl>false</RemoteControl>
+											<LocalControl>true</LocalControl>
+											<LockingMechanism>immobilisingLock</LockingMechanism>
+										</VehicleReleaseEquipment>
+									</actualVehicleEquipments>
+								</Vehicle>
+							</members>
+						</Fleet>
+					</fleets>
+					<!-- === Availabels ervices  === -->
+					<mobilityServices>
+						<VehicleSharingService version="any" id="my_car_club">
+							<BrandingRef version="any" ref="myBrand"/>
+							<Name>My Car Club</Name>
+							<infoLinks>
+								<InfoLink typeOfInfoLink="info">http:mycar.com/info</InfoLink>
+								<InfoLink typeOfInfoLink="mobileAppDownload" targetPlatform="ios">http:mycar.com/ios</InfoLink>
+								<InfoLink typeOfInfoLink="mobileAppDownload" targetPlatform="android">http:mycar.com/android</InfoLink>
+								<InfoLink typeOfInfoLink="mobileAppDownload" targetPlatform="ios">http:mycar.com/ios</InfoLink>
+								<InfoLink typeOfInfoLink="mobileAppDownload" targetPlatform="android">http:mycar.com/android</InfoLink>
+							</infoLinks>
+							<OperatorRef version="any" ref="coc:MCR"/>
+							<BookingRequired>false</BookingRequired>
+							<RegistrationRequired>false</RegistrationRequired>
+							<proposedByServices>
+								<OnlineServiceRef version="any" ref="mycar_online"/>
+							</proposedByServices>
+							<VehicleSharingRef version="any" ref="car_club"/>
+							<MinimumSharingPeriod>PT30M</MinimumSharingPeriod>
+							<MaximumSharingPeriod>PT24H</MaximumSharingPeriod>
+							<fleets>
+								<FleetRef version="any" ref="mycar_fleet"/>
+							</fleets>
+						</VehicleSharingService>
+					</mobilityServices>
+					<onlineServices>
+						<OnlineService version="any" id="mycar_online">
+							<Name>Online registration for My Car</Name>
+							<OnlineServiceOperatorRef version="any" ref="floggit"/>
+							<proposingServices>
+								<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+							</proposingServices>
+						</OnlineService>
+					</onlineServices>
+					<vehicleMeetingPlaceAssignments>
+						<VehicleSharingPlaceAssignment version="any" id="metrobik@car_station_alpha_A1" order="1">
+							<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+							<VehicleSharingParkingAreaRef version="any" ref="car_station_alpha_A1"/>
+						</VehicleSharingPlaceAssignment>
+						<VehicleSharingPlaceAssignment version="any" id="car_station_beta" order="1">
+							<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+							<VehicleSharingParkingAreaRef version="any" ref="car_station_beta_B1"/>
+						</VehicleSharingPlaceAssignment>
+					</vehicleMeetingPlaceAssignments>
+				</MobilityServiceFrame>
+				<!--==== FARES ==== -->
+				<FareFrame version="1.0" id="mc:car_club_example-single_session" dataSourceRef="mc:my_car" responsibilitySetRef="mc:tariffs">
+					<Name>My Car single session </Name>
+					<prerequisites>
+						<MobilityServiceFrameRef version="1.0" ref="mc:car_club_example"/>
+						<SiteFrameRef version="1.0" ref="mc:car_club_example"/>
+					</prerequisites>
+					<!--==== Fare Structure ==== -->
+					<tariffs>
+						<Tariff version="any" id="my_car@membership">
+							<Name>My Car Club Membership - Tariff</Name>
+							<documentLinks>
+								<InfoLink typeOfInfoLink="info">https://mycar.com/membership.pdf</InfoLink>
+							</documentLinks>
+							<OperatorRef version="any" ref="coc:MCR"/>
+							<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+							<timeIntervals>
+								<TimeInterval version="any" id="my_car@1-year">
+									<Name>One Year</Name>
+									<Duration>P1Y</Duration>
+								</TimeInterval>
+							</timeIntervals>
+							<fareStructureElements>
+								<FareStructureElement version="any" id="my_car@membership@access">
+									<Name>Access rights</Name>
+									<TypeOfFareStructureElementRef versionRef="EXTERNAL" ref="fxc:can_access"/>
+									<GenericParameterAssignment version="any" order="1" id="my_car@membership@access">
+										<TypeOfAccessRightAssignmentRef versionRef="EXTERNAL" ref="fxc:condition_of_use"/>
+										<LimitationGroupingType>AND</LimitationGroupingType>
+										<limitations>
+											<EntitlementGiven version="any" id="mycar_online@membership@entitlements_given">
+												<PreassignedFareProductRef version="any" ref="my_car@single_session"/>
+												<EntitlementConstraint>
+													<UserConstraint>samePerson</UserConstraint>
+												</EntitlementConstraint>
+												<EntitlementType>purchase</EntitlementType>
+											</EntitlementGiven>
+										</limitations>
+									</GenericParameterAssignment>
+								</FareStructureElement>
+								<FareStructureElement version="any" id="my_car@membership@durations">
+									<Name>Any where in Zone</Name>
+									<TypeOfFareStructureElementRef ref="fxc:access_when"/>
+									<timeIntervals>
+										<TimeIntervalRef version="any" ref="my_car@1-year"/>
+									</timeIntervals>
+								</FareStructureElement>
+								<FareStructureElement version="any" id="my_car@membership@eligibility">
+									<Name>Eligible user types</Name>
+									<TypeOfFareStructureElementRef versionRef="EXTERNAL" ref="fxc:eligibility"/>
+									<GenericParameterAssignment order="1" id="my_car@membership@eligibility" version="any">
+										<TypeOfAccessRightAssignmentRef versionRef="EXTERNAL" ref="fxc:eligible"/>
+										<limitations>
+											<!---  ===ELIGIBILITY USAGE PARAMETERS =========    -->
+											<UserProfile version="any" id="adult_driver">
+												<Name>Qualified driver</Name>
+												<UserType>adult</UserType>
+												<MinimumAge>18</MinimumAge>
+												<typesOfProofRequiredRef>
+													<TypeOfProofRef versionRef="external" ref="driving_licence"/>
+												</typesOfProofRequiredRef>
+											</UserProfile>
+										</limitations>
+									</GenericParameterAssignment>
+								</FareStructureElement>
+								<FareStructureElement version="any" id="my_car@membership@conditions_of_travel">
+									<Name>Conditions on travel</Name>
+									<TypeOfFareStructureElementRef versionRef="EXTERNAL" ref="fxc:travel_conditions"/>
+									<GenericParameterAssignment version="any" order="1" id="my_car@membership@conditions_of_travel">
+										<Name>Conditions of travel</Name>
+										<TypeOfAccessRightAssignmentRef versionRef="EXTERNAL" ref="fxc:condition_of_use"/>
+										<LimitationGroupingType>AND</LimitationGroupingType>
+										<limitations>
+											<Transferability version="any" id="my_car@membership@transferability">
+												<Name>Not Transferable  </Name>
+												<CanTransfer>false</CanTransfer>
+											</Transferability>
+										</limitations>
+									</GenericParameterAssignment>
+								</FareStructureElement>
+								<FareStructureElement version="any" id="my_car@membership@conditions_of_sale">
+									<Name>Conditions of sale</Name>
+									<TypeOfFareStructureElementRef versionRef="EXTERNAL" ref="fxc:sale_conditions"/>
+									<GenericParameterAssignment version="any" order="1" id="my_car@membership@conditions_of_sale">
+										<Name>Conditions of sale</Name>
+										<TypeOfAccessRightAssignmentRef versionRef="EXTERNAL" ref="fxc:condition_of_sale"/>
+										<LimitationGroupingType>AND</LimitationGroupingType>
+										<limitations>
+											<Refunding version="any" id="my_car@membership@charging_policy@refunding">
+												<Allowed>none</Allowed>
+											</Refunding>
+										</limitations>
+									</GenericParameterAssignment>
+								</FareStructureElement>
+							</fareStructureElements>
+						</Tariff>
+						<Tariff version="any" id="my_car@single_session">
+							<Name>My Car 1 - Tariff</Name>
+							<documentLinks>
+								<InfoLink typeOfInfoLink="info">https://mycar.com/tariff.pdf</InfoLink>
+								<InfoLink typeOfInfoLink="map">https://mycar.com/tariffMap.pdf</InfoLink>
+							</documentLinks>
+							<OperatorRef version="any" ref="coc:MCR"/>
+							<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+							<timeIntervals>
+								<TimeInterval version="any" id="my_car@2-hours">
+									<Name>First 2hours</Name>
+									<Duration>PT2H</Duration>
+								</TimeInterval>
+								<TimeInterval version="any" id="my_car@12-hours">
+									<Name>Half day</Name>
+									<Duration>PT12H</Duration>
+								</TimeInterval>
+								<TimeInterval version="any" id="my_car@1-day">
+									<Name>1 dayr</Name>
+									<Duration>P1D</Duration>
+								</TimeInterval>
+							</timeIntervals>
+							<fareStructureElements>
+								<FareStructureElement version="any" id="my_car@single_session@access">
+									<Name>Anywhere in Zone</Name>
+									<TypeOfFareStructureElementRef ref="fxc:access"/>
+									<GenericParameterAssignment version="any" order="01" id="my_car@single_session@access">
+										<TypeOfAccessRightAssignmentRef versionRef="EXTERNAL" ref="fxc:can_access"/>
+										<ValidityParameterGroupingType>AND</ValidityParameterGroupingType>
+										<validityParameters>
+											<TariffZoneRef version="any" ref="AllMetropolis"/>
+											<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+										</validityParameters>
+									</GenericParameterAssignment>
+								</FareStructureElement>
+								<FareStructureElement version="any" id="my_car@single_session@durations">
+									<Name>Any where in Zone</Name>
+									<TypeOfFareStructureElementRef ref="fxc:access_when"/>
+									<timeIntervals>
+										<TimeIntervalRef version="any" ref="my_car@2-hours"/>
+										<TimeIntervalRef version="any" ref="my_car@12-hours"/>
+										<TimeIntervalRef version="any" ref="my_car@1-day"/>
+									</timeIntervals>
+								</FareStructureElement>
+								<FareStructureElement version="any" id="my_car@single_session@eligibility">
+									<Name>Eligible user types</Name>
+									<TypeOfFareStructureElementRef versionRef="EXTERNAL" ref="fxc:eligibility"/>
+									<GenericParameterAssignment order="1" id="my_car@single_session@eligibility" version="any">
+										<TypeOfAccessRightAssignmentRef versionRef="EXTERNAL" ref="fxc:eligible"/>
+										<limitations>
+											<!---  ===ELIGIBILITY USAGE PARAMETERS =========    -->
+											<UserProfileRef version="any" ref="adult_driver"/>
+										</limitations>
+									</GenericParameterAssignment>
+								</FareStructureElement>
+								<FareStructureElement version="any" id="my_car@single_session@conditions_of_travel">
+									<Name>Conditions on travel</Name>
+									<TypeOfFareStructureElementRef versionRef="EXTERNAL" ref="fxc:travel_conditions"/>
+									<GenericParameterAssignment version="any" order="1" id="my_car@single_session@conditions_of_travel">
+										<Name>Conditions of travel</Name>
+										<TypeOfAccessRightAssignmentRef versionRef="EXTERNAL" ref="fxc:condition_of_use"/>
+										<LimitationGroupingType>AND</LimitationGroupingType>
+										<limitations>
+											<UsageValidityPeriod version="any" id="my_car@single_session@usageValidity">
+												<ValidityPeriodType>singleTrip</ValidityPeriodType>
+												<UsageTrigger>activation</UsageTrigger>
+												<UsageEnd>productExpiry</UsageEnd>
+												<ActivationMeans>accessCode</ActivationMeans>
+											</UsageValidityPeriod>
+											<FrequencyOfUse version="any" id="my_car@single_session@frequency">
+												<Name>One trip  </Name>
+												<FrequencyOfUseType>single</FrequencyOfUseType>
+												<MaximalFrequency>1</MaximalFrequency>
+											</FrequencyOfUse>
+											<Transferability version="any" id="my_car@single_session@transferability">
+												<Name>Is Transferable - Transferee bust be eligible</Name>
+												<CanTransfer>false</CanTransfer>
+												<SharedUsage>singleUser</SharedUsage>
+											</Transferability>
+										</limitations>
+									</GenericParameterAssignment>
+								</FareStructureElement>
+								<FareStructureElement version="any" id="my_car@single_session@conditions_of_sale">
+									<Name>Conditions of sale</Name>
+									<TypeOfFareStructureElementRef versionRef="EXTERNAL" ref="fxc:sale_conditions"/>
+									<GenericParameterAssignment version="any" order="1" id="my_car@single_session@conditions_of_sale">
+										<Name>Conditions of sale</Name>
+										<TypeOfAccessRightAssignmentRef versionRef="EXTERNAL" ref="fxc:condition_of_sale"/>
+										<LimitationGroupingType>AND</LimitationGroupingType>
+										<limitations>
+											<ChargingPolicy version="any" id="my_car@single_session@charging_policy@Deposit">
+												<Name>Deposit</Name>
+												<DepositPolicy>depositBlocked</DepositPolicy>
+											</ChargingPolicy>
+											<RentalPenaltyPolicy version="any" id="my_car@single_session@hire_penalty@late_return">
+												<Name>Charge for late return</Name>
+												<RentalPenaltyPolicyType>lateVehicleReturn</RentalPenaltyPolicyType>
+											</RentalPenaltyPolicy>
+											<Refunding version="any" id="my_car@single_session@refunding">
+												<Allowed>partial</Allowed>
+											</Refunding>
+										</limitations>
+									</GenericParameterAssignment>
+								</FareStructureElement>
+							</fareStructureElements>
+						</Tariff>
+					</tariffs>
+					<!--==== Fare Usage Parameters ==== -->
+					<!--==== Fare Product ==== -->
+					<fareProducts>
+						<SaleDiscountRight version="any" id="mycar_online@membership">
+							<BrandingRef version="any" ref="myBrand"/>
+							<Name>1 years membership of My Car online</Name>
+							<OnlineServiceOperatorRef version="any" ref="floggit"/>
+							<validableElements>
+								<ValidableElement version="any" id="my_car@membership@travel">
+									<Name>Single  ride</Name>
+									<fareStructureElements>
+										<FareStructureElementRef version="any" ref="my_car@membership@access"/>
+										<FareStructureElementRef version="any" ref="my_car@membership@durations"/>
+										<FareStructureElementRef version="any" ref="my_car@membership@eligibility"/>
+										<FareStructureElementRef version="any" ref="my_car@membership@conditions_of_travel"/>
+										<FareStructureElementRef version="any" ref="my_car@membership@conditions_of_sale"/>
+									</fareStructureElements>
+								</ValidableElement>
+							</validableElements>
+						</SaleDiscountRight>
+						<PreassignedFareProduct version="any" id="my_car@single_session">
+							<Name>One off care hire session</Name>
+							<infoLinks>
+								<InfoLink targetPlatform="ios" typeOfInfoLink="mobileAppInstallCheck">https://mycar.com/hirecheck_ios.htm</InfoLink>
+								<InfoLink targetPlatform="android" typeOfInfoLink="mobileAppInstallCheck">https://mycar.com/hirecheck_android.htm </InfoLink>
+								<InfoLink targetPlatform="ios" typeOfInfoLink="mobileAppDownload">https://mycar.com/hire_ios.htm</InfoLink>
+								<InfoLink targetPlatform="android" typeOfInfoLink="mobileAppDownload">https://mycar.com/hire_android.htm </InfoLink>
+							</infoLinks>
+							<ChargingMomentType>beforeTravelThenAdjustAtEndOfTravel</ChargingMomentType>
+							<OperatorRef version="any" ref="coc:MCR"/>
+							<ConditionSummary>
+								<FareStructureType>networkFlatFare</FareStructureType>
+								<TariffBasis>flat</TariffBasis>
+								<IsRefundable>false</IsRefundable>
+								<RequiresDeposit>true</RequiresDeposit>
+								<NoCashPayment>true</NoCashPayment>
+								<RequiresReservation>true</RequiresReservation>
+							</ConditionSummary>
+							<!--==== VALIDABLE ELEMENTs ==== -->
+							<validableElements>
+								<ValidableElement version="any" id="my_car@single_session@travel">
+									<Name>Single  ride</Name>
+									<fareStructureElements>
+										<FareStructureElementRef version="any" ref="my_car@single_session@access"/>
+										<FareStructureElementRef version="any" ref="my_car@single_session@durations"/>
+										<FareStructureElementRef version="any" ref="my_car@single_session@eligibility"/>
+										<FareStructureElementRef version="any" ref="my_car@single_session@conditions_of_travel"/>
+										<FareStructureElementRef version="any" ref="my_car@single_session@conditions_of_sale"/>
+									</fareStructureElements>
+								</ValidableElement>
+							</validableElements>
+							<!--==== ACCESS RIGHTs ===== -->
+							<accessRightsInProduct>
+								<AccessRightInProduct version="any" id="my_car@single_session" order="1">
+									<ValidableElementRef version="any" ref="my_car@single_session@travel"/>
+								</AccessRightInProduct>
+							</accessRightsInProduct>
+							<ProductType>singleTrip</ProductType>
+						</PreassignedFareProduct>
+						<!--==== Other Products ==== -->
+					</fareProducts>
+					<!--==== Distribution Parameters ==== -->
+					<distributionChannels>
+						<DistributionChannel version="any" id="mobile_application">
+							<Name>Mobile application</Name>
+							<DistributionChannelType>mobileDevice</DistributionChannelType>
+							<OnlineServiceOperatorRef version="any" ref="floggit"/>
+							<PaymentMethods>debitCard creditCard  </PaymentMethods>
+							<DistributionRights>sell</DistributionRights>
+						</DistributionChannel>
+						<DistributionChannel version="any" id="online">
+							<Name>internet web acces</Name>
+							<DistributionChannelType>online</DistributionChannelType>
+							<OnlineServiceOperatorRef version="any" ref="floggit"/>
+							<PaymentMethods>debitCard creditCard  directDebit </PaymentMethods>
+							<DistributionRights>sell inform</DistributionRights>
+						</DistributionChannel>
+					</distributionChannels>
+					<fulfilmentMethods>
+						<FulfilmentMethod version="any" id="mobile_device">
+							<Name>Collect from machine</Name>
+							<FulfilmentMethodType>mobileApp</FulfilmentMethodType>
+							<typesOfTravelDocument>
+								<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+							</typesOfTravelDocument>
+						</FulfilmentMethod>
+					</fulfilmentMethods>
+					<typesOfTravelDocuments>
+						<TypeOfTravelDocument version="any" id="mobile_application_data">
+							<Name>Mobile app with access code</Name>
+							<MediaType>mobileApp</MediaType>
+							<MachineReadable>nfc</MachineReadable>
+						</TypeOfTravelDocument>
+					</typesOfTravelDocuments>
+					<!--==== Sales Packages==== -->
+					<salesOfferPackages>
+						<SalesOfferPackage version="any" id="mycar_online@membership-SOP@mobile_app">
+							<BrandingRef version="any" ref="myBrand"/>
+							<Name>My Car club membership</Name>
+							<salesOfferPackageElements>
+								<SalesOfferPackageElement version="any" id="mycar_online@membership-SOP@mobile_app" order="1">
+									<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+									<SaleDiscountRightRef version="any" ref="mycar_online@membership"/>
+								</SalesOfferPackageElement>
+							</salesOfferPackageElements>
+						</SalesOfferPackage>
+						<SalesOfferPackage version="any" id="my_car@single_session-SOP@mobileApp">
+							<BrandingRef version="any" ref="myBrand"/>
+							<Name>My Car one off Mobile app purchase</Name>
+							<ConditionSummary>
+								<RequiresAccount>true</RequiresAccount>
+							</ConditionSummary>
+							<validityParameterAssignments>
+								<GenericParameterAssignment version="any" id="my_car@single_session-SOP@mobileApp" order="1">
+									<Name>Must be Registered member of floggit</Name>
+									<limitations>
+										<EntitlementRequired version="any" id="my_car@single_session-SOP@mobileApp@registered">
+											<SaleDiscountRightRef version="any" ref="mycar_online@membership"/>
+											<EntitlementConstraint>
+												<UserConstraint>samePerson</UserConstraint>
+											</EntitlementConstraint>
+										</EntitlementRequired>
+									</limitations>
+									<validityParameters>
+										<OnlineServiceRef version="any" ref="mycar_online"/>
+									</validityParameters>
+								</GenericParameterAssignment>
+							</validityParameterAssignments>
+							<distributionAssignments>
+								<DistributionAssignment version="any" id="my_car@single_session-SOP@mobileApp" order="1">
+									<Name>By Mobile app</Name>
+									<DistributionChannelRef version="any" ref="mobile_application"/>
+									<DistributionChannelType>mobileDevice</DistributionChannelType>
+									<TicketingServiceFacilityList>purchase refund</TicketingServiceFacilityList>
+									<FulfilmentMethodRef version="any" ref="mobile_device"/>
+								</DistributionAssignment>
+							</distributionAssignments>
+							<salesOfferPackageElements>
+								<SalesOfferPackageElement version="any" id="my_car@single_session-SOP@mobileApp" order="1">
+									<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+									<PreassignedFareProductRef version="any" ref="my_car@single_session"/>
+								</SalesOfferPackageElement>
+							</salesOfferPackageElements>
+						</SalesOfferPackage>
+					</salesOfferPackages>
+				</FareFrame>
+				<FareFrame version="1.0" id="mc:car_club_example_prices" dataSourceRef="mc:my_car" responsibilitySetRef="mc:tariffs">
+					<FrameDefaults>
+						<DefaultCurrency>EUR</DefaultCurrency>
+					</FrameDefaults>
+					<prerequisites>
+						<FareFrameRef version="1.0" ref="mc:car_club_example-single_session"/>
+					</prerequisites>
+					<!--==== Pricing Parameters ====-->
+					<PricingParameterSet version="any" id="mc:car_club_example_Prices">
+						<pricingRules>
+							<DiscountingRule version="any" id="vat">
+								<Name>Vat </Name>
+								<MethodName>tax</MethodName>
+								<DiscountAsPercentage>-15</DiscountAsPercentage>
+							</DiscountingRule>
+						</pricingRules>
+					</PricingParameterSet>
+					<!--==== Fare Prices ==== -->
+					<fareTables>
+						<FareTable version="any" id="my_car_club">
+							<Name>My Car  prices</Name>
+							<OperatorRef version="any" ref="coc:MCR"/>
+							<limitations>
+								<UserProfileRef version="any" ref="adult_driver"/>
+							</limitations>
+							<specifics>
+								<TariffZoneRef version="any" ref="AllMetropolis"/>
+								<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+							</specifics>
+							<includes>
+								<FareTable version="any" id="my_car@single_session">
+									<Name>My Car one off use prices</Name>
+									<pricesFor>
+										<SalesOfferPackageRef version="any" ref="my_car@single_session-SOP@mobileApp"/>
+									</pricesFor>
+									<usedIn>
+										<TariffRef version="any" ref="my_car@single_session"/>
+									</usedIn>
+									<includes>
+										<FareTable version="any" id="my_car@single_session@rental">
+											<prices>
+												<SalesOfferPackagePrice version="any" id="mycar_online@membership-SOP@mobile_app">
+													<Name>Membership 1 year</Name>
+													<Amount>30.00</Amount>
+													<SalesOfferPackageRef version="any" ref="mycar_online@membership-SOP@mobile_app"/>
+												</SalesOfferPackagePrice>
+												<UsageParameterPrice version="any" id="my_car@single_session@charging_policy@Deposit">
+													<Name>Deposit - blocked</Name>
+													<Amount>300.00</Amount>
+													<ChargingPolicyRef version="any" ref="my_car@single_session@charging_policy@Deposit"/>
+												</UsageParameterPrice>
+												<UsageParameterPrice version="any" id="my_car@single_session@charging_policy@Deposit_Refund">
+													<Name>Deposit - unblocked</Name>
+													<Amount>-300.00</Amount>
+													<ChargingPolicyRef version="any" ref="my_car@single_session@charging_policy@Deposit"/>
+												</UsageParameterPrice>
+												<TimeIntervalPrice version="any" id="my_car@2-hours">
+													<Amount>45.00</Amount>
+													<TimeIntervalRef version="any" ref="my_car@2-hours"/>
+												</TimeIntervalPrice>
+												<TimeIntervalPrice version="any" id="my_car@12-hours">
+													<Amount>60.00</Amount>
+													<TimeIntervalRef version="any" ref="my_car@12-hours"/>
+												</TimeIntervalPrice>
+												<TimeIntervalPrice version="any" id="my_car@1-day">
+													<Amount>90.00</Amount>
+													<TimeIntervalRef version="any" ref="my_car@1-day"/>
+												</TimeIntervalPrice>
+											</prices>
+										</FareTable>
+										<FareTable version="any" id="my_car@hire_penalty">
+											<Name>My Car penalty fees</Name>
+											<limitations>
+												<UserProfileRef version="any" ref="adult_driver"/>
+											</limitations>
+											<prices>
+												<UsageParameterPrice version="any" id="my_car@single_session@hire_penalty@late_return">
+													<Name>Late return</Name>
+													<Amount>100.00</Amount>
+													<RentalPenaltyPolicyRef version="any" ref="my_car@single_session@hire_penalty@late_return"/>
+												</UsageParameterPrice>
+											</prices>
+										</FareTable>
+									</includes>
+								</FareTable>
+							</includes>
+						</FareTable>
+					</fareTables>
+				</FareFrame>
+			</frames>
+		</CompositeFrame>
+		<!--==== SAMPLE TRANSACTIONS - NORMALLY IN A SEPARATE FILE ==== -->
+		<CompositeFrame id="mc:car_club_example_transaction_examples" version="1.0" responsibilitySetRef="mc:transaction_data" dataSourceRef="mc:my_car">
+			<!--  ===============
+This Shows  sample Purchases 
+
+   Sales Transactions would normally be exchanged separately from the reference data on whoich they are based
+-->
+			<Name>Sample Transactions for My Car trips </Name>
+			<prerequisites>
+				<CompositeFrameRef version="1.0" ref="mc:car_club_example"/>
+			</prerequisites>
+			<frames>
+				<MobilityJourneyFrame version="1.2" id="mct:sample_transactions">
+					<vehicleAccessCredentials>
+						<VehicleAccessCredentialsAssignment version="any" id="mct:Cust444@trans005@purchase_single_session" order="1">
+							<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+							<MobileDeviceRef versionRef="External" ref="mct:317867122222"/>
+							<ServiceAccessCodeRef version="any" ref="mct:Good@Cust444@005@purchase_single_session"/>
+						</VehicleAccessCredentialsAssignment>
+					</vehicleAccessCredentials>
+					<parkingLogEntries>
+						<!--  Example log of changes from real time updates.  -->
+						<!--  Parking alpha   before checkout  -->
+						<RentalAvailability id="car_station_alpha@2021-10-08T11:15:00" version="any">
+							<Name>Before Checkout </Name>
+							<Date>2021-10-08T11:06:55</Date>
+							<ParkingRef version="any" ref="car_station_alpha"/>
+							<IsOperational>true</IsOperational>
+							<IsRenting>true</IsRenting>
+							<IsAcceptingReturns>true</IsAcceptingReturns>
+							<AvailableVehicles>5</AvailableVehicles>
+							<DisabledVehicles>2</DisabledVehicles>
+							<AvailableDocks>3</AvailableDocks>
+							<DisabledDocks>2</DisabledDocks>
+						</RentalAvailability>
+						<ParkingBayCondition id="car_station_alpha_A1@01@2021-10-08T11:15:00" version="any">
+							<Date>2021-10-08T11:15:00</Date>
+							<MonitoredVehicleSharingParkingBayRef version="any" ref="car_station_alpha_A1@01"/>
+							<Status>inUse</Status>
+						</ParkingBayCondition>
+						<ParkingBayCondition id="car_station_alpha_A1@02@2021-10-08T11:15:00" version="any">
+							<Date>2021-10-08T11:15:00</Date>
+							<MonitoredVehicleSharingParkingBayRef version="any" ref="car_station_alpha_A1@02"/>
+							<Status>inUse</Status>
+						</ParkingBayCondition>
+						<!--  Parking alpha after  checkout  -->
+						<RentalAvailability id="car_station_alpha@2021-10-08T11:07:20" version="any">
+							<Name>After Checkout </Name>
+							<Date>2021-10-08T11:07:20</Date>
+							<ParkingRef version="any" ref="car_station_alpha"/>
+							<IsOperational>true</IsOperational>
+							<IsRenting>true</IsRenting>
+							<IsAcceptingReturns>true</IsAcceptingReturns>
+							<AvailableVehicles>1</AvailableVehicles>
+							<AvailableDocks>1</AvailableDocks>
+						</RentalAvailability>
+						<ParkingBayCondition id="car_station_alpha_A1@01@2021-10-08T11:07:20" version="any">
+							<Date>2021-10-08T11:07:20</Date>
+							<MonitoredVehicleSharingParkingBayRef version="any" ref="car_station_alpha_A1@01"/>
+							<Status>available</Status>
+						</ParkingBayCondition>
+						<!-- Parking alpha  after return -->
+						<RentalAvailability id="car_station_alpha_A1@20@21-10-08T23:10:00" version="any">
+							<Name>After Return</Name>
+							<Date>2021-10-08T23:10:00</Date>
+							<ParkingRef version="any" ref="car_station_alpha"/>
+							<IsOperational>true</IsOperational>
+							<IsRenting>true</IsRenting>
+							<IsAcceptingReturns>true</IsAcceptingReturns>
+							<AvailableVehicles>2</AvailableVehicles>
+							<AvailableDocks>0</AvailableDocks>
+						</RentalAvailability>
+						<ParkingBayCondition id="car_station_alpha_A1@01@2021-10-08T23:10:00" version="any">
+							<Name>After Return</Name>
+							<Date>2021-10-08T23:10:00</Date>
+							<MonitoredVehicleSharingParkingBayRef version="any" ref="car_station_alpha_A1@01"/>
+							<Status>inUse</Status>
+						</ParkingBayCondition>
+					</parkingLogEntries>
+				</MobilityJourneyFrame>
+				<SalesTransactionFrame version="1.2" id="mct:sample_transactions">
+					<Name>My Car Sample Transactions</Name>
+					<codespaces>
+						<CodespaceRef ref="mc_data"/>
+						<Codespace id="mc_transactions">
+							<Xmlns>mct</Xmlns>
+							<XmlnsUrl>http://www.mycar.com/transactions</XmlnsUrl>
+							<Description>Operator transaction data</Description>
+						</Codespace>
+					</codespaces>
+					<!-- ===== Transaction data -->
+					<customers>
+						<Customer version="any" id="mct:Cust444">
+							<Surname>Johnson</Surname>
+							<FirstName>Boris</FirstName>
+							<Title>Mr</Title>
+							<Gender>male</Gender>
+							<Email>boris@brexit.eu</Email>
+							<EmailVerified>2021-02-28T15:00:00</EmailVerified>
+							<Phone>
+								<TelNationalNumber>07867122222</TelNationalNumber>
+								<TelCountryCode>41</TelCountryCode>
+							</Phone>
+							<PhoneVerified>2021-02-28T16:00:00</PhoneVerified>
+							<customerAccounts>
+								<CustomerAccount version="any" id="mct:Cust444@AC7651">
+									<Name>Bojo</Name>
+									<StartDate>2021-02-28T13:00:00</StartDate>
+									<CustomerAccountStatusType>active</CustomerAccountStatusType>
+									<customerPurchasePackages>
+										<CustomerPurchasePackageRef version="any" ref="mct:Good@Cust444@005"/>
+									</customerPurchasePackages>
+									<CustomerPaymentMeansRef version="any" ref="mct:Cust444@AC7651@p1"/>
+									<paymentMeans>
+										<CustomerPaymentMeans version="any" id="mct:Cust444@AC7651@p1">
+											<Name>B.Johnson Visa Card</Name>
+											<EmvCardRef versionRef="external" ref="visa:47594444555666"/>
+										</CustomerPaymentMeans>
+										<CustomerPaymentMeans version="any" id="mct:Cust444@AC7651@p2">
+											<Name>B.Johnson mobile device</Name>
+											<MobileDeviceRef versionRef="external" ref="mct:317867122222"/>
+										</CustomerPaymentMeans>
+									</paymentMeans>
+									<mediumAccessDevices>
+										<MobileDeviceRef versionRef="External" ref="mct:317867122222"/>
+									</mediumAccessDevices>
+								</CustomerAccount>
+							</customerAccounts>
+							<fareContracts>
+								<FareContract version="any" id="mct:Cust444@contract001">
+									<CustomerRef versionRef="EXTERNAL" ref="mct:Cust444"/>
+									<fareContractEntries>
+										<SalesTransaction version="any" id="mct:Cust444@contract001@t001@join_as_member">
+											<Name>Join As Member</Name>
+											<Date>2021-02-28T13:00:00</Date>
+											<TypeOfFareContractEntryRef versionRef="EXTERNAL" ref="fxc:product_purchase"/>
+											<Amount>30.00</Amount>
+											<travelSpecifications>
+												<OfferedTravelSpecification version="any" id="mct:Cust444@contract001@t001@join_as_member">
+													<Name>1 year membership</Name>
+													<Date>2021-02-28T13:00:00</Date>
+													<SalesTransactionRef version="any" ref="mct:Cust444@contract001@t001@join_as_member"/>
+													<SalesOfferPackagePriceRef version="any" ref="mycar_online@membership-SOP@mobile_app"/>
+													<Amount>34.50</Amount>
+													<ruleStepResults>
+														<RuleStepResult id="mct:Cust444@contract001@t001@join_as_member@tax" order="1">
+															<SalesOfferPackagePriceRef version="any" ref="mycar_online@membership-SOP@mobile_app"/>
+															<Amount>30.00</Amount>
+															<AdjustmentAmount>4.50</AdjustmentAmount>
+															<DiscountingRuleRef version="any" ref="vat"/>
+															<Narrative>Add 15% VAT</Narrative>
+														</RuleStepResult>
+													</ruleStepResults>
+													<StartOfValidity>2021-02-28T13:00:00</StartOfValidity>
+													<EndOfValidity>2022-02-28T13:00:00</EndOfValidity>
+													<TravelSpecificationSummaryView>
+														<Start>2021-02-28T13:00:00</Start>
+														<OperatorRef version="any" ref="coc:MCR"/>
+														<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+													</TravelSpecificationSummaryView>
+													<specificParameterAssignments>
+														<SpecificParameterAssignment version="any" order="1" id="mct:Cust444@contract001@t001@purchase_member">
+															<Name>Join as member</Name>
+															<SalesOfferPackageRef version="any" ref="mycar_online@membership-SOP@mobile_app"/>
+															<TimeIntervalRef version="any" ref="my_car@1-day"/>
+														</SpecificParameterAssignment>
+													</specificParameterAssignments>
+												</OfferedTravelSpecification>
+											</travelSpecifications>
+											<customerPurchasePackages>
+												<CustomerPurchasePackageRef version="any" ref="mct:Good@Cust444@001"/>
+											</customerPurchasePackages>
+											<travelDocuments>
+												<TravelDocument version="any" id="mbt:ticket@m-0345">
+													<ValidBetween>
+														<FromDate>2021-02-28T13:00:00</FromDate>
+														<ToDate>2022-02-28T12:59:59</ToDate>
+													</ValidBetween>
+													<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+												</TravelDocument>
+											</travelDocuments>
+										</SalesTransaction>
+										<SalesTransaction version="any" id="mct:Cust444@trans005@purchase_single_session">
+											<Name>Book and pay for  1-day use of a car</Name>
+											<Date>2021-10-01T10:10:00</Date>
+											<TypeOfFareContractEntryRef versionRef="EXTERNAL" ref="fxc:product_purchase"/>
+											<Amount>103.50</Amount>
+											<ruleStepResults>
+												<RuleStepResult id="mct:Cust444@trans005@purchase_single_session@tax" order="1">
+													<TimeIntervalPriceRef version="any" ref="my_car@1-day"/>
+													<Amount>90.00</Amount>
+													<AdjustmentAmount>13.50</AdjustmentAmount>
+													<DiscountingRuleRef version="any" ref="vat"/>
+													<Narrative>Add 15% VAT</Narrative>
+												</RuleStepResult>
+											</ruleStepResults>
+											<PaymentMethod>creditCard</PaymentMethod>
+											<travelSpecifications>
+												<OfferedTravelSpecification version="any" id="mct:Cust444@trans005@purchase_single_session">
+													<Date>2021-10-08T11:15:00</Date> <!-- date of travel -->
+													<SalesTransactionRef version="any" ref="mct:Cust444@trans005@purchase_single_session"/>
+													<TimeIntervalPriceRef version="any" ref="my_car@1-day"/>
+													<Amount>90.00</Amount>
+													<StartOfValidity>2021-10-08T11:15:00</StartOfValidity>
+													<TravelSpecificationSummaryView>
+														<Start>2021-10-08T11:15:00</Start>
+														<End>2021-10-09T11:14:59</End>
+														<Duration>P1D</Duration>
+														<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+													</TravelSpecificationSummaryView>
+													<specificParameterAssignments>
+														<SpecificParameterAssignment version="any" order="1" id="mct:Cust444@trans005@purchase_single_session">
+															<Name>Single session</Name>
+															<ValidableElementRef version="any" ref="my_car@single_session@travel"/>
+															<PreassignedFareProductRef version="any" ref="my_car@single_session"/>
+															<FareStructureElementRef version="any" ref="my_car@single_session@access"/>
+															<SalesOfferPackageRef version="any" ref="my_car@single_session-SOP@mobileApp"/>
+															<validityParameters>
+																<OperatorRef version="any" ref="coc:MCR"/>
+																<OnlineServiceOperatorRef version="any" ref="floggit"/>
+																<DistributionChannelRef version="any" ref="mobile_application"/>
+																<FulfilmentMethodRef version="any" ref="mobile_device"/>
+																<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+																<VehicleSharingRef version="any" ref="car_club"/>
+																<VehicleRef version="any" ref="car_01"/>
+																<CarModelProfileRef version="any" ref="model_a"/>
+																<VehicleSharingParkingAreaRef version="any" ref="car_station_alpha_A1"/>
+																<MonitoredVehicleSharingParkingBayRef version="any" ref="car_station_alpha_A1@01"/>
+																<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+															</validityParameters>
+															<TimeIntervalRef version="any" ref="my_car@1-day"/>
+														</SpecificParameterAssignment>
+													</specificParameterAssignments>
+												</OfferedTravelSpecification>
+											</travelSpecifications>
+											<customerPurchasePackages>
+												<CustomerPurchasePackageRef version="any" ref="mct:Good@Cust444@005"/>
+											</customerPurchasePackages>
+											<travelDocuments>
+												<ServiceAccessCodeRef version="any" ref="mct:Good@Cust444@005@purchase_single_session"/>
+											</travelDocuments>
+										</SalesTransaction>
+									</fareContractEntries>
+								</FareContract>
+							</fareContracts>
+						</Customer>
+					</customers>
+					<!-- CUSTOMER PURCHASE PACKAGES === -->
+					<customerPurchasePackages>
+						<CustomerPurchasePackage version="any" id="mct:Good@Cust444@001" created="2021-02-28T13:00:00">
+							<ValidBetween>
+								<FromDate>2021-02-28T13:00:00</FromDate>
+								<ToDate>2022-02-28T13:00:00</ToDate>
+							</ValidBetween>
+							<Name>Membership</Name>
+							<CustomerRef version="any" ref="mct:Cust444"/>
+							<CustomerAccountRef version="any" ref="mct:Cust444@AC7651"/>
+							<customerPurchasePackageElements>
+								<CustomerPurchasePackageElement version="any" id="mct:Good@Cust444@001" order="1" created="2021-02-28T13:00:00">
+									<SalesOfferPackageElementRef version="any" ref="mycar_online@membership-SOP@mobile_app"/>
+								</CustomerPurchasePackageElement>
+							</customerPurchasePackageElements>
+							<SalesTransactionRef version="any" ref="mct:Cust444@contract001@t001@join_as_member"/>
+							<prices>
+								<CustomerPurchasePackagePrice version="any" id="mct:Good@Cust444@001" created="2021-02-28T13:00:00">
+									<Amount>34.50</Amount>
+									<ruleStepResults>
+										<RuleStepResult id="mct:Good@Cust444@001@tax" order="1">
+											<SalesOfferPackagePriceRef version="any" ref="mycar_online@membership-SOP@mobile_app"/>
+											<Amount>30.00</Amount>
+											<AdjustmentAmount>4.50</AdjustmentAmount>
+											<DiscountingRuleRef version="any" ref="vat"/>
+											<Narrative>Add 15% VAT</Narrative>
+										</RuleStepResult>
+									</ruleStepResults>
+									<CustomerPurchasePackageRef version="any" ref="mct:Good@Cust444@001"/>
+								</CustomerPurchasePackagePrice>
+							</prices>
+							<MobileDeviceRef versionRef="external" ref="mct:317867122222"/>
+							<MediumApplicationInstanceRef versionRef="external" ref="mct:317867122222@mboik"/>
+						</CustomerPurchasePackage>
+						<CustomerPurchasePackage version="any" id="mct:Good@Cust444@005" created="2021-10-01T10:10:00"  changed="2021-10-08T23:10:00">
+							<ValidBetween>
+								<FromDate>2021-10-08T11:15:00</FromDate>
+								<ToDate>2021-10-08T23:59:59</ToDate>
+							</ValidBetween>
+							<Name>Day Hire on  2021-10-08  at 11:15:00 </Name>
+							<CustomerRef version="any" ref="mct:Cust444"/>
+							<CustomerAccountRef version="any" ref="mct:Cust444@AC7651"/>
+							<customerPurchasePackageElements>
+								<CustomerPurchasePackageElement version="any" id="mct:Good@Cust444@005" order="1" created="2021-10-01T10:10:00">
+									<SalesOfferPackageElementRef version="any" ref="my_car@single_session-SOP@mobileApp"/>
+									<elementAccesses>
+										<CustomerPurchasePackageElementAccess version="any" id="mct:Good@Cust444@005@02" created="2021-10-01T10:10:00">
+											<MarkedAs>unused</MarkedAs>
+											<AccessNumber>1</AccessNumber>
+										</CustomerPurchasePackageElementAccess>
+										<CustomerPurchasePackageElementAccess version="any" id="mct:Good@Cust444@005@02" created="2021-10-08T11:15:00">
+											<MarkedAs>activated</MarkedAs>
+											<AccessNumber>1</AccessNumber>
+										</CustomerPurchasePackageElementAccess>
+										<CustomerPurchasePackageElementAccess version="any" id="mct:Good@Cust444@005@02" created="2021-10-08T23:10:00">
+											<MarkedAs>expired</MarkedAs>
+											<AccessNumber>1</AccessNumber>
+										</CustomerPurchasePackageElementAccess>
+									</elementAccesses>
+									<validityParameterAssignments>
+										<CustomerPurchaseParameterAssignment version="any" id="mct:Good@Cust444@005" order="1">
+											<validityParameters>
+												<OperatorRef version="any" ref="coc:MCR"/>
+												<DistributionChannelRef version="any" ref="mobile_application"/>
+												<FulfilmentMethodRef version="any" ref="mobile_device"/>
+												<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+												<VehicleSharingRef ref="car_club"/>
+												<VehicleSharingServiceRef version="any" ref="my_car_club"/>
+											</validityParameters>
+											<TimeIntervalRef version="any" ref="my_car@1-day"/>
+										</CustomerPurchaseParameterAssignment>
+									</validityParameterAssignments>
+								</CustomerPurchasePackageElement>
+							</customerPurchasePackageElements>
+							<SalesTransactionRef version="any" ref="mct:Cust444@trans005@purchase_single_session"/>
+							<prices>
+								<CustomerPurchasePackagePrice version="any" id="mct:Good@Cust444@005" created="2021-10-01T10:10:00">
+									<Amount>103.50</Amount>
+									<ruleStepResults>
+										<RuleStepResult id="mct:Good@Cust444@005@tax" order="1">
+											<TimeIntervalPriceRef version="any" ref="my_car@1-day"/>
+											<Amount>90.00</Amount>
+											<AdjustmentAmount>13.50</AdjustmentAmount>
+											<DiscountingRuleRef version="any" ref="vat"/>
+											<Narrative>Add 15% VAT</Narrative>
+										</RuleStepResult>
+									</ruleStepResults>
+									<CustomerPurchasePackageRef version="any" ref="mct:Good@Cust444@005"/>
+								</CustomerPurchasePackagePrice>
+							</prices>
+							<travelDocuments>
+								<ServiceAccessCode version="any" id="mct:Good@Cust444@005@purchase_single_session" created="2021-10-01T10:10:00">
+									<ValidBetween>
+										<FromDate>2021-10-08T11:15:00</FromDate>
+										<ToDate>2021-10-09T11:14:59</ToDate>
+									</ValidBetween>
+									<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+									<CustomerPurchasePackageRef version="any" ref="mct:Good@Cust444@005"/>
+									<AccessCode>9876</AccessCode>
+									<VehicleAccessCredentialsAssignmentRef version="any" ref="mct:Cust444@trans005@purchase_day_pase"/>
+								</ServiceAccessCode>
+							</travelDocuments>
+							<MobileDeviceRef versionRef="external" ref="mct:317867122222"/>
+							<MediumApplicationInstanceRef versionRef="external" ref="mct:31786712244@mboik"/>
+						</CustomerPurchasePackage>
+					</customerPurchasePackages>
+				</SalesTransactionFrame>
+			</frames>
+		</CompositeFrame>
+	</dataObjects>
+</PublicationDelivery>

--- a/examples/functions/newModes/NewModes-CarPoolingExample.xml
+++ b/examples/functions/newModes/NewModes-CarPoolingExample.xml
@@ -550,7 +550,7 @@ In addition CUSTOMER PURCHASE PACKAGES showing the parameters that might be held
 					<vehicleMeetingPlaceAssignments>
 						<VehiclePoolingPlaceAssignment version="any" id="delta_park_and_ride" order="1">
 							<CarPoolingServiceRef version="any" ref="ryde"/>
-							<VehiclePoolingMeetingPlaceRef  version="any"  ref="delta_park_and_ride"/> 
+							<VehiclePoolingMeetingPlaceRef version="any" ref="delta_park_and_ride"/> 
 						</VehiclePoolingPlaceAssignment>
 						<VehiclePoolingPlaceAssignment version="any" id="delta_park_and_ride@A1" order="2">
 							<CarPoolingServiceRef version="any" ref="ryde"/>
@@ -1361,7 +1361,7 @@ This Shows  sample Purchases
 															<Amount>-10</Amount>
 															<AdjustmentAmount>2.00</AdjustmentAmount>
 															<PricingRuleRef ref="ryde_fee"/>
-															<Narrative>10 charge less £2 Ryde fee</Narrative>
+															<Narrative>10 charge less Â£2 Ryde fee</Narrative>
 														</RuleStepResult>
 													</ruleStepResults>
 													<StartOfValidity>2020-08-10T07:00:00 </StartOfValidity>

--- a/examples/functions/newModes/NewModes-CarPoolingExample.xml
+++ b/examples/functions/newModes/NewModes-CarPoolingExample.xml
@@ -519,7 +519,7 @@ In addition CUSTOMER PURCHASE PACKAGES showing the parameters that might be held
 					<vehicleMeetingPlaces>
 						<VehiclePoolingMeetingPlace version="any" id="delta_park_and_ride">
 							<Name>Delta Park and ride</Name>
-							<TopographicPlaceRef version="any" ref="gamma_sur_mer"> </TopographicPlaceRef>
+							<TopographicPlaceRef version="any" ref="gamma_sur_mer"> </TopographicPlaceRef>  
 						</VehiclePoolingMeetingPlace>
 						<VehiclePoolingMeetingPlace version="any" id="bull_and_bush_inn">
 							<Name>TheBull and bush, Gamma</Name>
@@ -548,13 +548,14 @@ In addition CUSTOMER PURCHASE PACKAGES showing the parameters that might be held
 						</VehiclePoolingMeetingPlace>
 					</vehicleMeetingPlaces>
 					<vehicleMeetingPlaceAssignments>
-						<VehiclePoolingPlaceAssignment version="any" id="delta_park_and_ride@A1" order="1">
-							<CarPoolingServiceRef version="any" ref="ryde"/>
-							<VehiclePoolingParkingAreaRef version="any" ref="delta_park_and_ride@A1"/>
-						</VehiclePoolingPlaceAssignment>
 						<VehiclePoolingPlaceAssignment version="any" id="delta_park_and_ride" order="1">
 							<CarPoolingServiceRef version="any" ref="ryde"/>
+							<VehiclePoolingMeetingPlaceRef  version="any"  ref="delta_park_and_ride"/> 
+						</VehiclePoolingPlaceAssignment>
+						<VehiclePoolingPlaceAssignment version="any" id="delta_park_and_ride@A1" order="2">
+							<CarPoolingServiceRef version="any" ref="ryde"/>
 							<VehiclePoolingMeetingPlaceRef version="any" ref="delta_park_and_ride"/>
+							<VehiclePoolingParkingBayRef version="any" ref="delta_park_and_ride@A1@01"/>
 						</VehiclePoolingPlaceAssignment>
 					</vehicleMeetingPlaceAssignments>
 				</MobilityServiceFrame>
@@ -1143,6 +1144,7 @@ This Shows  sample Purchases
 														<FromDate>2020-02-28T13:00:00</FromDate>
 													</ValidBetween>
 													<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+													<CustomerPurchasePackageRef version="any" ref="rydt:CPP@Cust555@001"/>
 												</TravelDocument>
 											</travelDocuments>
 										</SalesTransaction>
@@ -1195,7 +1197,7 @@ This Shows  sample Purchases
 																<ServiceFacilitySetRef version="any" ref="no_smoking"/>
 																<SingleJourneyRef version="any" ref="rydt:Cust777@trans001@ride1234"/>
 																<VehicleRef version="any" ref="db54278"/>
-																<!-- These are also given by Journey  but may be more specifc than opffer eg if agree to specif location-->
+																<!-- These are also given by Journey  but may be more specific than offer eg if agree to specific location-->
 																<VehicleMeetingPointRef version="any" ref="gamma_area"/>
 																<VehiclePoolingMeetingPlaceRef version="any" ref="delta_park_and_ride"/>
 																<VehiclePoolingParkingAreaRef version="any" ref="delta_park_and_ride@A1"/>
@@ -1494,7 +1496,7 @@ This Shows  sample Purchases
 							<CustomerAccountRef version="any" ref="rydt:Cust555@AC7651"/>
 							<customerPurchasePackageElements>
 								<CustomerPurchasePackageElement version="any" id="rydt:CPP@Cust555@001" order="1">
-									<SalesOfferPackageElementRef version="any" ref="ryde@single_trip-SOP@mobileApp"/>
+									<SalesOfferPackageElementRef version="any" ref="ryde@membership-SOP@mobileApp"/>
 								</CustomerPurchasePackageElement>
 							</customerPurchasePackageElements>
 							<SalesTransactionRef version="any" ref="rydt:Cust555@trans001@join_as_member"/>
@@ -1524,10 +1526,29 @@ This Shows  sample Purchases
 										<CustomerPurchasePackageElementAccess version="any" id="rydt:CPP@Cust555@005@002" changed="2020-08-10T07:00:00">
 											<!-- State when journey started  -->
 											<MarkedAs>activated</MarkedAs>
+											<validityParameterAssignments>
+												<CustomerPurchaseParameterAssignment version="any" order="1" id="rydt:Cust555@trans005@002">
+													<Name>Pick up at designated point</Name>
+													<validityParameters>
+														<VehicleMeetingPointRef version="any" ref="gamma_area"/>
+														<VehiclePoolingMeetingPlaceRef version="any" ref="delta_park_and_ride"/>
+														<VehiclePoolingParkingAreaRef version="any" ref="delta_park_and_ride@A1"/>
+													</validityParameters>
+												</CustomerPurchaseParameterAssignment>
+											</validityParameterAssignments>
 										</CustomerPurchasePackageElementAccess>
 										<CustomerPurchasePackageElementAccess version="any" id="rydt:CPP@Cust555@005@003" changed="2020-08-10T07:55:00">
 											<!-- State when complete -->
 											<MarkedAs>used</MarkedAs>
+											<validityParameterAssignments>
+												<CustomerPurchaseParameterAssignment version="any" order="1" id="rydt:Cust555@trans005@003">
+													<Name>Set down at designated point</Name>
+													<validityParameters>
+														<VehicleMeetingPointRef version="any" ref="alphaville_centre"/>
+														<VehiclePoolingMeetingPlaceRef version="any" ref="town_hall"/>
+													</validityParameters>
+												</CustomerPurchaseParameterAssignment>
+											</validityParameterAssignments>
 										</CustomerPurchasePackageElementAccess>
 									</elementAccesses>
 									<validityParameterAssignments>
@@ -1575,7 +1596,7 @@ This Shows  sample Purchases
 							<CustomerAccountRef version="any" ref="rydt:Cust777@AC8145"/>
 							<customerPurchasePackageElements>
 								<CustomerPurchasePackageElement version="any" id="rydt:CPP@Cust777@001" order="1">
-									<SalesOfferPackageElementRef version="any" ref="ryde@single_trip-SOP@mobileApp"/>
+									<SalesOfferPackageElementRef version="any" ref="ryde@membership-SOP@mobileApp"/>
 								</CustomerPurchasePackageElement>
 							</customerPurchasePackageElements>
 							<SalesTransactionRef version="any" ref="rydt:Cust777@trans001@join_as_member"/>

--- a/examples/functions/newModes/NewModes-ChauffeuredServiceExample.xml
+++ b/examples/functions/newModes/NewModes-ChauffeuredServiceExample.xml
@@ -437,6 +437,16 @@
 							<parkingAreas>
 								<TaxiParkingArea version="any" id="alphaville_airport_taxi_parking@A1">
 									<TotalCapacity>20</TotalCapacity>
+									<bays>
+										<ParkingBay version="any" id="alphaville_airport_taxi_parking@A1@chauff_1">
+											<Name>Chauffeured service pickup Bay</Name>
+											<Label>Chauffeur 1</Label>
+										</ParkingBay>
+										<ParkingBay version="any" id="alphaville_airport_taxi_parking@A1@chauff_2">
+											<Name>Chauffeured service pickup Bay</Name>
+											<Label>Chauffeur 1</Label>
+										</ParkingBay>
+									</bays>
 								</TaxiParkingArea>
 							</parkingAreas>
 						</Parking>
@@ -585,10 +595,12 @@
 						<VehiclePoolingPlaceAssignment version="any" id="alphaville_airport_taxi_parking@pick_up" order="1">
 							<ChauffeuredVehicleServiceRef version="any" ref="hj_cars"/>
 							<VehiclePoolingMeetingPlaceRef version="any" ref="alphaville_airport_pick_up"/>
+							<ParkingBayRef version="any" ref="alphaville_airport_taxi_parking@A1@chauff_1"/>
 						</VehiclePoolingPlaceAssignment>
 						<VehiclePoolingPlaceAssignment version="any" id="alphaville_airport_taxi_parking@set_down" order="1">
 							<ChauffeuredVehicleServiceRef version="any" ref="hj_cars"/>
 							<VehiclePoolingMeetingPlaceRef version="any" ref="alphaville_airport_set_down"/>
+							<ParkingBayRef version="any" ref="alphaville_airport_taxi_parking@A1@chauff_2"/>
 						</VehiclePoolingPlaceAssignment>
 						<VehiclePoolingPlaceAssignment version="any" id="alphaville_gare_taxi_parking@pick_up" order="1">
 							<ChauffeuredVehicleServiceRef version="any" ref="hj_cars"/>
@@ -599,7 +611,6 @@
 							<VehiclePoolingMeetingPlaceRef version="any" ref="alphaville_gare_set_down"/>
 						</VehiclePoolingPlaceAssignment>
 					</vehicleMeetingPlaceAssignments>
-			
 				</MobilityServiceFrame>
 				<!--==== FARES : Prepriced trips ==== -->
 				<FareFrame version="1.0" id="hjm:chauffeured_taxi_example-prepriced_trips" dataSourceRef="hjm:home_james" responsibilitySetRef="hjm:tariffs">
@@ -709,29 +720,23 @@
 									</GenericParameterAssignment>
 								</FareStructureElement>
 							</fareStructureElements>
-													<distanceMatrixElements>
-								 
- 
-					 
-				 
-						<DistanceMatrixElement version="any" id="gamma_area+alphaville_airport">
-							<InverseAllowed>true</InverseAllowed>
-								<StartMeetingPointRef version="any" ref="gamma_area"/>
-							<EndMeetingPointRef version="any" ref="alphaville_airport"/>
-						</DistanceMatrixElement>
-						<DistanceMatrixElement version="any" id="alphaville_airport+alphaville_centre">
-							<InverseAllowed>true</InverseAllowed> 
-														<StartMeetingPointRef version="any" ref="alphaville_airport"/>
-							<EndMeetingPointRef version="any" ref="alphaville_centre"/>
-							
-						</DistanceMatrixElement>
-						<DistanceMatrixElement version="any" id="gamma_area+alphaville_gare">
-							<InverseAllowed>true</InverseAllowed>
-											<StartMeetingPointRef version="any" ref="gamma_area"/>
-							<EndMeetingPointRef version="any" ref="alphaville_gare"/>
-						</DistanceMatrixElement>
-						</distanceMatrixElements>
-						
+							<distanceMatrixElements>
+								<DistanceMatrixElement version="any" id="gamma_area+alphaville_airport">
+									<InverseAllowed>true</InverseAllowed>
+									<StartMeetingPointRef version="any" ref="gamma_area"/>
+									<EndMeetingPointRef version="any" ref="alphaville_airport"/>
+								</DistanceMatrixElement>
+								<DistanceMatrixElement version="any" id="alphaville_airport+alphaville_centre">
+									<InverseAllowed>true</InverseAllowed>
+									<StartMeetingPointRef version="any" ref="alphaville_airport"/>
+									<EndMeetingPointRef version="any" ref="alphaville_centre"/>
+								</DistanceMatrixElement>
+								<DistanceMatrixElement version="any" id="gamma_area+alphaville_gare">
+									<InverseAllowed>true</InverseAllowed>
+									<StartMeetingPointRef version="any" ref="gamma_area"/>
+									<EndMeetingPointRef version="any" ref="alphaville_gare"/>
+								</DistanceMatrixElement>
+							</distanceMatrixElements>
 						</Tariff>
 					</tariffs>
 					<!--==== Fare Usage Parameters ==== -->
@@ -964,7 +969,7 @@
 										<LimitationGroupingType>AND</LimitationGroupingType>
 										<limitations>
 											<Cancelling version="any" id="home_james@charter@refunding">
-												<Name>Canc ancel up top 3 hours before</Name>
+												<Name>Can cancel up top 3 hours before</Name>
 												<BookingArrangements>
 													<MinimumBookingPeriod>PT3H</MinimumBookingPeriod>
 												</BookingArrangements>
@@ -1104,7 +1109,7 @@ This Shows  sample Purchases
 				</ResourceFrame>
 				<!--==== NETWORK ==== -->
 				<MobilityJourneyFrame version="1.2" id="hjmt:sample_transactions">
- 		<singleJourneyPaths>
+					<singleJourneyPaths>
 						<SingleJourneyPath version="any" id="hmjt:anon@trans005@ride5163">
 							<Name>Path from Airportand   to Chez Ritter.</Name>
 							<Distance>25.00</Distance>
@@ -1153,7 +1158,7 @@ This Shows  sample Purchases
 								</VehicleMeetingPointAssignment>
 							</meetingPointAssignments>
 						</SingleJourney>
-					</singleJourneys> 
+					</singleJourneys>
 				</MobilityJourneyFrame>
 				<SalesTransactionFrame version="1.2" id="hjmt:sample_transactions">
 					<Name>Home James  Sample Transactions</Name>

--- a/examples/functions/newModes/NewModes-CycleSharingExample.xml
+++ b/examples/functions/newModes/NewModes-CycleSharingExample.xml
@@ -39,7 +39,7 @@
 					<LayerRef ref="fxc:fareNetwork_fareProducts_farePrices"/>
 					<objectReferences>
 						<OperatorRef version="any" ref="noc:MBIKE"/>
-						<VehicleSharingRef ref="cycle_sharing"/>
+						<VehicleSharingRef version="any" ref="cycle_share"/>
 					</objectReferences>
 				</NetworkFilterByValue>
 			</NetworkFrameTopic>
@@ -189,7 +189,7 @@
 							<PropulsionType>human</PropulsionType>
 							<FuelType>none</FuelType>
 							<TransportMode>selfDrive</TransportMode>
-							<PassengerCapacity version="any" id="cycle_share">
+							<PassengerCapacity version="any" id="pedal_cycle">
 								<SeatingCapacity>1</SeatingCapacity>
 							</PassengerCapacity>
 							<Length>2</Length>
@@ -205,8 +205,9 @@
 							<SelfPropelled>true</SelfPropelled>
 							<PropulsionType>electricAssist</PropulsionType>
 							<FuelType>battery</FuelType>
+							<MaximumRange>15</MaximumRange>
 							<TransportMode>selfDrive</TransportMode>
-							<PassengerCapacity version="any" id="cycle_share">
+							<PassengerCapacity version="any" id="electric_cycle">
 								<SeatingCapacity>1</SeatingCapacity>
 							</PassengerCapacity>
 							<Length>2.2</Length>
@@ -218,7 +219,7 @@
 						</SimpleVehicleType>
 					</vehicleTypes>
 					<vehicleModels>
-						<VehicleModel version="any" id="pennyFarthing">
+						<VehicleModel version="any" id="penny_farthing">
 							<Name>Old Model Bike</Name>
 							<SimpleVehicleTypeRef version="any" ref="pedal_cycle"/>
 							<CycleModelProfileRef version="any" ref="boneKitA"/>
@@ -504,7 +505,7 @@
 						</Parking>
 					</parkings>
 					<tariffZones>
-						<TariffZone version="any" id="AllMetropolis">
+						<TariffZone version="any" id="all_metropolis">
 							<Name lang="en">All Metropolis</Name>
 						</TariffZone>
 					</tariffZones>
@@ -533,13 +534,13 @@
 						<ServiceCalendarFrameRef version="1.0" ref="mb:cycle_sharing_example"/>
 					</prerequisites>
 					<fleets>
-						<Fleet version="any" id="MetrobikeFleet">
+						<Fleet version="any" id="metrobike_fleet">
 							<Name>The metrobike fleet</Name>
 							<members>
 								<Vehicle version="any" id="P01">
 									<OperatorRef version="any" ref="noc:MBIKE"/>
 									<SimpleVehicleTypeRef version="any" ref="pedal_cycle"/>
-									<VehicleModelRef version="any" ref="pennyFarthing"/>
+									<VehicleModelRef version="any" ref="penny_farthing"/>
 									<actualVehicleEquipments>
 										<VehicleReleaseEquipment version="any" id="P01@release">
 											<OutOfService>false</OutOfService>
@@ -552,7 +553,7 @@
 								<Vehicle version="any" id="P02">
 									<OperatorRef version="any" ref="noc:MBIKE"/>
 									<SimpleVehicleTypeRef version="any" ref="pedal_cycle"/>
-									<VehicleModelRef version="any" ref="pennyFarthing"/>
+									<VehicleModelRef version="any" ref="penny_farthing"/>
 									<actualVehicleEquipments>
 										<VehicleReleaseEquipment version="any" id="P02@release">
 											<OutOfService>false</OutOfService>
@@ -565,7 +566,7 @@
 								<Vehicle version="any" id="P03">
 									<OperatorRef version="any" ref="noc:MBIKE"/>
 									<SimpleVehicleTypeRef version="any" ref="pedal_cycle"/>
-									<VehicleModelRef version="any" ref="pennyFarthing"/>
+									<VehicleModelRef version="any" ref="penny_farthing"/>
 									<actualVehicleEquipments>
 										<VehicleReleaseEquipment version="any" id="P03@release">
 											<OutOfService>true</OutOfService>
@@ -578,7 +579,7 @@
 								<Vehicle version="any" id="P04">
 									<OperatorRef version="any" ref="noc:MBIKE"/>
 									<SimpleVehicleTypeRef version="any" ref="pedal_cycle"/>
-									<VehicleModelRef version="any" ref="pennyFarthing"/>
+									<VehicleModelRef version="any" ref="penny_farthing"/>
 								</Vehicle>
 								<Vehicle version="any" id="B01">
 									<OperatorRef version="any" ref="noc:MBIKE"/>
@@ -639,18 +640,18 @@
 							<BookingRequired>false</BookingRequired>
 							<RegistrationRequired>false</RegistrationRequired>
 							<proposedByServices>
-								<OnlineServiceRef version="any" ref="MetrobikeOnline"/>
+								<OnlineServiceRef version="any" ref="metrobike_online"/>
 							</proposedByServices>
 							<VehicleSharingRef version="any" ref="cycle_share"/>
 							<MinimumSharingPeriod>PT30M</MinimumSharingPeriod>
 							<MaximumSharingPeriod>PT24H</MaximumSharingPeriod>
 							<fleets>
-								<FleetRef version="any" ref="MetrobikeFleet"/>
+								<FleetRef version="any" ref="metrobike_fleet"/>
 							</fleets>
 						</VehicleSharingService>
 					</mobilityServices>
 					<onlineServices>
-						<OnlineService version="any" id="MetrobikeOnline">
+						<OnlineService version="any" id="metrobike_online">
 							<Name>Online registration for metrobike</Name>
 							<OnlineServiceOperatorRef version="any" ref="floggit"/>
 							<proposingServices>
@@ -763,7 +764,7 @@
 										<TypeOfAccessRightAssignmentRef versionRef="EXTERNAL" ref="fxc:can_access"/>
 										<ValidityParameterGroupingType>AND</ValidityParameterGroupingType>
 										<validityParameters>
-											<TariffZoneRef version="any" ref="AllMetropolis"/>
+											<TariffZoneRef version="any" ref="all_metropolis"/>
 											<VehicleSharingServiceRef version="any" ref="metrobike"/>
 										</validityParameters>
 									</GenericParameterAssignment>
@@ -844,7 +845,7 @@
 												<MaximalFrequency>1</MaximalFrequency>
 											</FrequencyOfUse>
 											<Transferability version="any" id="metrobike@single_session@transferability">
-												<Name>Is Transferable - Transferee bust be eligible</Name>
+												<Name>Is Transferable to one user at a time - NB Transferee must also be eligible</Name>
 												<CanTransfer>true</CanTransfer>
 												<SharedUsage>singleUser</SharedUsage>
 											</Transferability>
@@ -884,11 +885,11 @@
 					<!--==== Fare Usage Parameters ==== -->
 					<!--==== Fare Product ==== -->
 					<fareProducts>
-						<ThirdPartyProduct version="any" id="metrobike_online@membership">
+						<SaleDiscountRight version="any" id="metrobike_online@membership">
 							<BrandingRef version="any" ref="myBrand"/>
 							<Name>Registered member of Metrobike online</Name>
 							<OnlineServiceOperatorRef version="any" ref="floggit"/>
-						</ThirdPartyProduct>
+						</SaleDiscountRight>
 						<PreassignedFareProduct version="any" id="metrobike@single_session">
 							<Name>One off trip</Name>
 							<infoLinks>
@@ -985,6 +986,16 @@
 					</typesOfTravelDocuments>
 					<!--==== Sales Packages==== -->
 					<salesOfferPackages>
+						<SalesOfferPackage version="any" id="metrobike_online@membership-SOP@mobile_app">
+							<BrandingRef version="any" ref="myBrand"/>
+							<Name>Metrobike membership</Name>
+							<salesOfferPackageElements>
+								<SalesOfferPackageElement version="any" id="metrobike_online@membership-SOP@mobile_app" order="1">
+									<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+									<SaleDiscountRightRef version="any" ref="metrobike_online@membership"/>
+								</SalesOfferPackageElement>
+							</salesOfferPackageElements>
+						</SalesOfferPackage>
 						<SalesOfferPackage version="any" id="metrobike@single_session-SOP@p-ticket">
 							<BrandingRef version="any" ref="myBrand"/>
 							<Name>Metrobike one-session purchase from  ticket machine</Name>
@@ -1013,17 +1024,17 @@
 							</ConditionSummary>
 							<validityParameterAssignments>
 								<GenericParameterAssignment version="any" id="metrobike@single_session-SOP@mobileApp" order="1">
-									<Name>Registered member of floggit </Name>
+									<Name>Must be Registered member of floggit</Name>
 									<limitations>
 										<EntitlementRequired version="any" id="metrobike@single_session-SOP@mobileApp@registered">
-											<ThirdPartyProductRef version="any" ref="metrobike_online@membership"/>
+											<SaleDiscountRightRef version="any" ref="metrobike_online@membership"/>
 											<EntitlementConstraint>
 												<UserConstraint>samePerson</UserConstraint>
 											</EntitlementConstraint>
 										</EntitlementRequired>
 									</limitations>
 									<validityParameters>
-										<OnlineServiceRef version="any" ref="MetrobikeOnline"/>
+										<OnlineServiceRef version="any" ref="metrobike_online"/>
 									</validityParameters>
 								</GenericParameterAssignment>
 							</validityParameterAssignments>
@@ -1075,7 +1086,7 @@
 										<TypeOfAccessRightAssignmentRef versionRef="EXTERNAL" ref="fxc:can_access"/>
 										<ValidityParameterGroupingType>AND</ValidityParameterGroupingType>
 										<validityParameters>
-											<TariffZoneRef version="any" ref="AllMetropolis"/>
+											<TariffZoneRef version="any" ref="all_metropolis"/>
 											<VehicleSharingServiceRef version="any" ref="metrobike"/>
 										</validityParameters>
 									</GenericParameterAssignment>
@@ -1179,14 +1190,14 @@
 									<Name>Registered member of floggit </Name>
 									<limitations>
 										<EntitlementRequired version="any" id="metrobike_registered">
-											<ThirdPartyProductRef version="any" ref="metrobike_online@membership"/>
+											<SaleDiscountRightRef version="any" ref="metrobike_online@membership"/>
 											<EntitlementConstraint>
 												<UserConstraint>samePerson</UserConstraint>
 											</EntitlementConstraint>
 										</EntitlementRequired>
 									</limitations>
 									<validityParameters>
-										<OnlineServiceRef version="any" ref="MetrobikeOnline"/>
+										<OnlineServiceRef version="any" ref="metrobike_online"/>
 									</validityParameters>
 								</GenericParameterAssignment>
 							</validityParameterAssignments>
@@ -1235,7 +1246,7 @@
 								<UserProfileRef version="any" ref="notATot"/>
 							</limitations>
 							<specifics>
-								<TariffZoneRef version="any" ref="AllMetropolis"/>
+								<TariffZoneRef version="any" ref="all_metropolis"/>
 								<VehicleSharingServiceRef version="any" ref="metrobike"/>
 							</specifics>
 							<includes>
@@ -1253,7 +1264,12 @@
 											<prices>
 												<UsageParameterPrice version="any" id="metrobike@single_session@charging_policy@Deposit">
 													<Name>Deposit - blocked</Name>
-													<Amount>300</Amount>
+													<Amount>300.00</Amount>
+													<ChargingPolicyRef version="any" ref="metrobike@single_session@charging_policy@Deposit"/>
+												</UsageParameterPrice>
+												<UsageParameterPrice version="any" id="metrobike@single_session@charging_policy@Deposit_Refund">
+													<Name>Deposit - unblocked</Name>
+													<Amount>-300.00</Amount>
 													<ChargingPolicyRef version="any" ref="metrobike@single_session@charging_policy@Deposit"/>
 												</UsageParameterPrice>
 												<TimeIntervalPrice version="any" id="metrobike@M0+M45">
@@ -1349,12 +1365,12 @@ This Shows  sample Purchases
 						<VehicleAccessCredentialsAssignment version="any" id="mbt:Anon001@trans069@purchase_single_session@one_time" order="1">
 							<VehicleSharingServiceRef version="any" ref="metrobike"/>
 							<VehicleRef version="any" ref="C01"/>
-							<ServiceAccessCodeRef version="any" ref="mbt:Anon001@trans069@purchase_single_session"/>
+							<ServiceAccessCodeRef version="any" ref="mbt:Anon001@027@purchase_single_session"/>
 						</VehicleAccessCredentialsAssignment>
 						<VehicleAccessCredentialsAssignment version="any" id="mbt:Cust444@trans005@purchase_day_pass" order="1">
 							<VehicleSharingServiceRef version="any" ref="metrobike"/>
 							<MobileDeviceRef versionRef="External" ref="mbt:317867122222"/>
-							<ServiceAccessCodeRef version="any" ref="mbt:Cust444@trans005@purchase_day_pass"/>
+							<ServiceAccessCodeRef version="any" ref="mbt:Good@Cust444@005@purchase_day_pass"/>
 						</VehicleAccessCredentialsAssignment>
 					</vehicleAccessCredentials>
 					<parkingLogEntries>
@@ -1507,7 +1523,7 @@ This Shows  sample Purchases
 					</codespaces>
 					<!-- ===== Transaction data -->
 					<customers>
-						<Customer version="any" id="mbt:Cust444">
+						<Customer version="any" id="mbt:Cust444" created="2020-02-28T13:00:00">
 							<Surname>Johnson</Surname>
 							<FirstName>Boris</FirstName>
 							<Title>Mr</Title>
@@ -1519,12 +1535,9 @@ This Shows  sample Purchases
 								<TelCountryCode>31</TelCountryCode>
 							</Phone>
 							<PhoneVerified>2020-02-28T16:00:00</PhoneVerified>
-							<customerEligibilities>
-								<UserProfileEligibility version="any" id="mbt:Cust444@trans001@pooler">
-								</UserProfileEligibility>
-							</customerEligibilities>
+							 
 							<customerAccounts>
-								<CustomerAccount version="any" id="mbt:Cust444@AC7651">
+								<CustomerAccount version="any" id="mbt:Cust444@AC7651" created="2020-02-28T13:00:00">
 									<Name>hotrider</Name>
 									<StartDate>2020-02-28T13:00:00</StartDate>
 									<CustomerAccountStatusType>active</CustomerAccountStatusType>
@@ -1548,43 +1561,36 @@ This Shows  sample Purchases
 								</CustomerAccount>
 							</customerAccounts>
 							<fareContracts>
-								<FareContract version="any" id="mbt:Cust444@trans001">
-									<CustomerRef ref="mbt:Anon"/>
+								<FareContract version="any" id="mbt:Cust444@contract001">
+									<CustomerRef versionRef="EXTERNAL" ref="mbt:Cust444"/>
 									<fareContractEntries>
-										<SalesTransaction version="any" id="mbt:Cust444@trans001@join_as_member">
-											<Name>Join AS Member</Name>
+										<SalesTransaction version="any" id="mbt:Cust444@contract001@t001@join_as_member">
+											<Name>Join As Member</Name>
 											<Date>2020-02-28T13:00:00</Date>
 											<TypeOfFareContractEntryRef versionRef="EXTERNAL" ref="fxc:product_purchase"/>
 											<Amount>0</Amount>
 											<travelSpecifications>
-												<OfferedTravelSpecification version="any" id="mbt:Cust444@trans001@join_as_member">
-													<Date>2020-10-08T11:07:00</Date>
-													<SalesTransactionRef version="any" ref="mbt:Cust444@trans001@join_as_member"/>
+												<OfferedTravelSpecification version="any" id="mbt:Cust444@contract001@t001@join_as_member">
+													<Date>2020-02-28T13:00:00</Date>
+													<SalesTransactionRef version="any" ref="mbt:Cust444@contract001@t001@join_as_member"/>
 													<Amount>0</Amount>
-													<StartOfValidity>2020-10-08T11:07:00</StartOfValidity>
+													<StartOfValidity>2020-02-28T13:00:00</StartOfValidity>
 													<TravelSpecificationSummaryView>
 														<Start>2020-02-28T13:00:00</Start>
 														<OperatorRef version="any" ref="noc:MBIKE"/>
 														<VehicleSharingServiceRef version="any" ref="metrobike"/>
 													</TravelSpecificationSummaryView>
 													<specificParameterAssignments>
-														<SpecificParameterAssignment version="any" order="1" id="mbt:Cust444@trans001@purchase_member">
+														<SpecificParameterAssignment version="any" order="1" id="mbt:Cust444@contract001@t001@purchase_member">
 															<Name>Join as member</Name>
-															<ThirdPartyProductRef version="any" ref="metrobike_online@membership"/>
+															<SaleDiscountRightRef version="any" ref="metrobike_online@membership"/>
 														</SpecificParameterAssignment>
 													</specificParameterAssignments>
 												</OfferedTravelSpecification>
 											</travelSpecifications>
-											<travelDocuments>
-												<ServiceAccessCode version="any" id="mbt:Anon001@trans069@purchase_single_session">
-													<ValidBetween>
-														<FromDate>2018-07-08T11:07:00</FromDate>
-													</ValidBetween>
-													<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
-													<AccessCode>1234</AccessCode>
-													<VehicleAccessCredentialsAssignmentRef version="any" ref="mbt:Anon001@trans069@purchase_single_session@one_time"/>
-												</ServiceAccessCode>
-											</travelDocuments>
+											<customerPurchasePackages>
+												<CustomerPurchasePackageRef version="any" ref="mbt:Good@Cust444@001"/>
+											</customerPurchasePackages>
 										</SalesTransaction>
 										<SalesTransaction version="any" id="mbt:Cust444@trans005@purchase_day_pass">
 											<Name>Buy Dap PAss</Name>
@@ -1617,7 +1623,7 @@ This Shows  sample Purchases
 																<DistributionChannelRef version="any" ref="mobile_application"/>
 																<FulfilmentMethodRef version="any" ref="mobile_device"/>
 																<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
-																<VehicleSharingRef ref="cycle_sharing"/>
+																<VehicleSharingRef version="any" ref="cycle_share"/>
 																<VehicleSharingServiceRef version="any" ref="metrobike"/>
 															</validityParameters>
 															<TimeIntervalRef version="any" ref="metrobike@1D"/>
@@ -1625,17 +1631,11 @@ This Shows  sample Purchases
 													</specificParameterAssignments>
 												</OfferedTravelSpecification>
 											</travelSpecifications>
+											<customerPurchasePackages>
+												<CustomerPurchasePackageRef version="any" ref="mbt:Good@Cust444@005"/>
+											</customerPurchasePackages>
 											<travelDocuments>
-												<ServiceAccessCode version="any" id="mbt:Cust444@trans005@purchase_day_pass">
-													<ValidBetween>
-														<FromDate>2020-10-08T11:07:00</FromDate>
-														<ToDate>2020-10-09T11:02:00</ToDate>
-													</ValidBetween>
-													<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
-													<CustomerPurchasePackageRef version="any" ref="mbt:Good@Cust444@005"/>
-													<AccessCode>9876</AccessCode>
-													<VehicleAccessCredentialsAssignmentRef version="any" ref="mbt:Cust444@trans005@purchase_day_pase"/>
-												</ServiceAccessCode>
+												<ServiceAccessCodeRef version="any" ref="mbt:Good@Cust444@005@purchase_day_pass"/>
 											</travelDocuments>
 										</SalesTransaction>
 									</fareContractEntries>
@@ -1646,26 +1646,26 @@ This Shows  sample Purchases
 					<!--  ==== Annonymous transactions -->
 					<fareContracts>
 						<FareContract version="any" id="mbt:Anon001@trans069">
-							<CustomerRef ref="mbt:Anon"/>
+							<CustomerRef versionRef="EXTERNAL" ref="mbt:Anon001"/>
 							<fareContractEntries>
 								<SalesTransaction version="any" id="mbt:Anon001@trans069@purchase_single_session@checkout">
 									<Name>Buy Single   ticket Adult</Name>
-									<Date>2020-10-08T11:07:00</Date>
+									<Date>2020-12-08T12:01:00</Date>
 									<TypeOfFareContractEntryRef versionRef="EXTERNAL" ref="fxc:product_purchase"/>
 									<Amount>2.10</Amount>
 									<PaymentMethod>cash</PaymentMethod>
 									<travelSpecifications>
 										<OfferedTravelSpecification version="any" id="mbt:Anon001@trans069@purchase_single_session@checkout">
-											<Date>2020-10-08T11:07:00</Date>
+											<Date>2020-12-08T12:01:00</Date>
 											<SalesTransactionRef version="any" ref="mbt:Anon001@trans069@purchase_single_session@checkout"/>
 											<TimeIntervalPriceRef version="any" ref="metrobike@M0+M45"/>
 											<Amount>2.10</Amount>
-											<StartOfValidity>2020-10-08T11:07:00</StartOfValidity>
+											<StartOfValidity>2020-12-08T12:01:00</StartOfValidity>
 											<TravelSpecificationSummaryView>
 												<Origin>
 													<ParkingRef version="any" ref="bike_station_alpha"/>
 												</Origin>
-												<Start>2020-10-08T11:07:00</Start>
+												<Start>2020-12-08T12:01:00</Start>
 												<Duration>PT45M</Duration>
 												<OperatorRef version="any" ref="noc:MBIKE"/>
 												<UserProfileRef version="any" ref="notATot"/>
@@ -1683,7 +1683,7 @@ This Shows  sample Purchases
 													</limitations>
 													<validityParameters>
 														<OperatorRef version="any" ref="noc:MBIKE"/>
-														<TariffZoneRef version="any" ref="AllMetropolis"/>
+														<TariffZoneRef version="any" ref="all_metropolis"/>
 														<MonitoredVehicleSharingParkingBayRef version="any" ref="bike_station_alpha_A1@02"/>
 														<DistributionChannelRef version="any" ref="ticket_machine"/>
 														<FulfilmentMethodRef version="any" ref="collect_from_machine"/>
@@ -1702,28 +1702,30 @@ This Shows  sample Purchases
 											</specificParameterAssignments>
 										</OfferedTravelSpecification>
 									</travelSpecifications>
+									<customerPurchasePackages>
+										<CustomerPurchasePackageRef version="any" ref="mbt:Anon001@027"/>
+									</customerPurchasePackages>
 									<travelDocuments>
 										<TravelDocument version="any" id="mbt:ticket@765452234">
 											<ValidBetween>
-												<FromDate>2018-07-08T11:07:00</FromDate>
-												<ToDate>2018-08-08T00:02:00</ToDate>
+												<FromDate>2020-12-08T12:01:00</FromDate>
+												<ToDate>2020-12-08T14:01:00</ToDate>
 											</ValidBetween>
 											<TypeOfTravelDocumentRef version="any" ref="printed_ticket"/>
 										</TravelDocument>
+										<ServiceAccessCodeRef version="any" ref="mbt:Anon001@027@purchase_single_session"/>
 									</travelDocuments>
 								</SalesTransaction>
 								<SalesTransaction version="any" id="mbt:Anon001@trans069@purchase_single_session@return">
 									<Name>Return and pay additional charge</Name>
-									<Date>2020-10-08T13:10:00</Date>
+									<Date>2020-12-08T14:47:00</Date>
 									<TypeOfFareContractEntryRef versionRef="EXTERNAL" ref="fxc:product_purchase"/>
-									<Amount>11.00</Amount>
-									<Units>123</Units>
 									<PaymentMethod>cash</PaymentMethod>
 									<travelSpecifications>
 										<OfferedTravelSpecification version="any" id="mbt:Anon001@trans069@purchase_single_session@return">
 											<Date>2020-10-08T13:10:00</Date>
 											<SalesTransactionRef version="any" ref="mbt:Anon001@trans069@purchase_single_session@return"/>
-											<Amount>11.00</Amount>
+											<Amount>7.00</Amount>
 											<ruleStepResults>
 												<RuleStepResult id="mbt:Anon001@trans069@purchase_single_session@return" order="1">
 													<TimeIntervalPriceRef version="any" ref="metrobike@M45+M90"/>
@@ -1754,14 +1756,14 @@ This Shows  sample Purchases
 											</TravelSpecificationSummaryView>
 											<specificParameterAssignments>
 												<SpecificParameterAssignment version="any" order="1" id="mbt:Anon001@trans069@purchase_single_session@return">
-													<Name>One off cycle hire</Name>
+													<Name>One off cycle hire - return</Name>
 													<ValidableElementRef version="any" ref="metrobike@single_session@travel"/>
 													<PreassignedFareProductRef version="any" ref="metrobike@single_session"/>
 													<FareStructureElementRef version="any" ref="metrobike@single_session@access"/>
 													<SalesOfferPackageRef version="any" ref="metrobike@single_session-SOP@p-ticket"/>
 													<validityParameters>
 														<OperatorRef version="any" ref="noc:MBIKE"/>
-														<TariffZoneRef version="any" ref="AllMetropolis"/>
+														<TariffZoneRef version="any" ref="all_metropolis"/>
 														<DistributionChannelRef version="any" ref="online"/>
 														<VehicleSharingRef version="any" ref="cycle_share"/>
 														<SimpleVehicleTypeRef version="any" ref="electric_cycle"/>
@@ -1777,32 +1779,54 @@ This Shows  sample Purchases
 											</specificParameterAssignments>
 										</OfferedTravelSpecification>
 									</travelSpecifications>
+									<customerPurchasePackages>
+										<CustomerPurchasePackageRef version="any" ref="mbt:Anon001@027"/>
+									</customerPurchasePackages>
 								</SalesTransaction>
 							</fareContractEntries>
 						</FareContract>
 					</fareContracts>
 					<!-- CUSTOMER PURCHASE PACKAGES === -->
 					<customerPurchasePackages>
-						<CustomerPurchasePackage version="any" id="mbt:Good@Cust444@001">
+						<CustomerPurchasePackage version="any" id="mbt:Good@Cust444@001" created="2020-02-28T13:00:00">
+							<ValidBetween>
+								<FromDate>2020-02-28T13:00:00</FromDate>
+								<ToDate>2023-02-28T13:00:00</ToDate>
+							</ValidBetween>
 							<Name>Membership</Name>
 							<CustomerRef version="any" ref="mbt:Cust444"/>
 							<CustomerAccountRef version="any" ref="mbt:Cust444@AC7651"/>
 							<customerPurchasePackageElements>
-								<CustomerPurchasePackageElement version="any" id="mbt:Good@Cust444@001" order="1">
-									<SalesOfferPackageElementRef version="any" ref="metrobike@day_pass-SOP@mobileApp"/>
+								<CustomerPurchasePackageElement version="any" id="mbt:Good@Cust444@001" order="1" created="2020-02-28T13:00:00">
+									<SalesOfferPackageElementRef version="any" ref="metrobike_online@membership-SOP@mobile_app"/>
 								</CustomerPurchasePackageElement>
 							</customerPurchasePackageElements>
-							<SalesTransactionRef version="any" ref="mbt:Cust444@trans001@join_as_member"/>
+							<SalesTransactionRef version="any" ref="mbt:Cust444@contract001@t001@join_as_member"/>
 							<MobileDeviceRef versionRef="external" ref="mbt:317867122222"/>
 							<MediumApplicationInstanceRef versionRef="external" ref="mbt:317867122222@mboik"/>
 						</CustomerPurchasePackage>
-						<CustomerPurchasePackage version="any" id="mbt:Good@Cust444@005">
+						<CustomerPurchasePackage version="any" id="mbt:Good@Cust444@005" created="2020-10-08T11:07:00" changed="2020-10-08T18:35:00">
+							<ValidBetween>
+								<FromDate>2020-10-08T11:07:00</FromDate>
+								<ToDate>2020-10-08T23:59:59</ToDate>
+							</ValidBetween>
 							<Name>Day Pass</Name>
 							<CustomerRef version="any" ref="mbt:Cust444"/>
 							<CustomerAccountRef version="any" ref="mbt:Cust444@AC7651"/>
 							<customerPurchasePackageElements>
-								<CustomerPurchasePackageElement version="any" id="mbt:Good@Cust444@005" order="1">
+								<CustomerPurchasePackageElement version="any" id="mbt:Good@Cust444@005" order="1" created="2020-10-08T11:07:00">
 									<SalesOfferPackageElementRef version="any" ref="metrobike@day_pass-SOP@mobileApp"/>
+									<elementAccesses>
+										<CustomerPurchasePackageElementAccess version="any" id="mbt:Good@Cust444@005@02" created="2020-10-08T11:07:00">
+											<AccessNumber>1</AccessNumber>
+										</CustomerPurchasePackageElementAccess>
+										<CustomerPurchasePackageElementAccess version="any" id="mbt:Good@Cust444@005@02" created="2020-10-08T15:03:00">
+											<AccessNumber>2</AccessNumber>
+										</CustomerPurchasePackageElementAccess>
+										<CustomerPurchasePackageElementAccess version="any" id="mbt:Good@Cust444@005@02" created="2020-10-08T18:35:00">
+											<AccessNumber>2</AccessNumber>
+										</CustomerPurchasePackageElementAccess>
+									</elementAccesses>
 									<validityParameterAssignments>
 										<CustomerPurchaseParameterAssignment version="any" id="mbt:Good@Cust444@005" order="1">
 											<validityParameters>
@@ -1810,7 +1834,7 @@ This Shows  sample Purchases
 												<DistributionChannelRef version="any" ref="mobile_application"/>
 												<FulfilmentMethodRef version="any" ref="mobile_device"/>
 												<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
-												<VehicleSharingRef ref="cycle_sharing"/>
+												<VehicleSharingRef version="any" ref="cycle_share"/>
 												<VehicleSharingServiceRef version="any" ref="metrobike"/>
 											</validityParameters>
 										</CustomerPurchaseParameterAssignment>
@@ -1819,11 +1843,101 @@ This Shows  sample Purchases
 							</customerPurchasePackageElements>
 							<SalesTransactionRef version="any" ref="mbt:Cust444@trans005@purchase_day_pass"/>
 							<prices>
-								<CustomerPurchasePackagePrice version="any" id="mbt:Good@Cust444@005">
+								<CustomerPurchasePackagePrice version="any" id="mbt:Good@Cust444@005" created="2020-10-08T11:07:00">
 									<Amount>12.00</Amount>
 									<CustomerPurchasePackageRef version="any" ref="mbt:Good@Cust444@005"/>
 								</CustomerPurchasePackagePrice>
 							</prices>
+							<travelDocuments>
+								<ServiceAccessCode version="any" id="mbt:Good@Cust444@005@purchase_day_pass">
+									<ValidBetween>
+										<FromDate>2020-10-08T11:07:00</FromDate>
+										<ToDate>2020-10-09T11:02:00</ToDate>
+									</ValidBetween>
+									<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+									<CustomerPurchasePackageRef version="any" ref="mbt:Good@Cust444@005"/>
+									<AccessCode>9876</AccessCode>
+									<VehicleAccessCredentialsAssignmentRef version="any" ref="mbt:Cust444@trans005@purchase_day_pase"/>
+								</ServiceAccessCode>
+							</travelDocuments>
+							<MobileDeviceRef versionRef="external" ref="mbt:317867122222"/>
+							<MediumApplicationInstanceRef versionRef="external" ref="mbt:317867122222@mboik"/>
+						</CustomerPurchasePackage>
+						<CustomerPurchasePackage version="any" id="mbt:Anon001@027" created="2020-12-08T12:01:00" changed="2020-12-08T14:47:00">
+							<ValidBetween>
+								<FromDate>2020-12-08T12:01:00</FromDate>
+								<ToDate>2020-12-08T14:01:00</ToDate>
+							</ValidBetween>
+							<Name>Single session cycle  use</Name>
+							<CustomerRef versionRef="EXTERNAL" ref="mbt:Anon001"/>
+							<customerPurchasePackageElements>
+								<CustomerPurchasePackageElement version="any" id="mbt:Anon001@027" order="1" created="2020-12-08T12:01:00">
+									<SalesOfferPackageElementRef version="any" ref="metrobike@day_pass-SOP@mobileApp"/>
+									<elementAccesses>
+										<CustomerPurchasePackageElementAccess version="any" id="mbt:Anon001@027@001" created="2020-12-08T12:01:00">
+											<MarkedAs>activated</MarkedAs>
+											<validityParameterAssignments>
+												<CustomerPurchaseParameterAssignment version="any" id="mbt:Anon001@027@001" created="2020-12-08T12:01:00" order="1">
+													<Name>Checkout from station alpha_a1_001</Name>
+													<validityParameters>
+														<MonitoredVehicleSharingParkingBayRef version="any" ref="bike_station_alpha_A1@01"/>
+													</validityParameters>
+												</CustomerPurchaseParameterAssignment>
+											</validityParameterAssignments>
+										</CustomerPurchasePackageElementAccess>
+										<CustomerPurchasePackageElementAccess version="any" id="mbt:Anon001@027@002" created="2020-12-08T14:47:00">
+											<MarkedAs>used</MarkedAs>
+											<validityParameterAssignments>
+												<CustomerPurchaseParameterAssignment version="any" id="mbt:Anon001@027@002" created="2020-12-08T14:47:00" order="1">
+													<Name>Check back in to station  beta_b1_004</Name>
+													<validityParameters>
+														<MonitoredVehicleSharingParkingBayRef version="any" ref="bike_station_beta_B1@04"/>
+													</validityParameters>
+												</CustomerPurchaseParameterAssignment>
+											</validityParameterAssignments>
+										</CustomerPurchasePackageElementAccess>
+									</elementAccesses>
+									<validityParameterAssignments>
+										<CustomerPurchaseParameterAssignment version="any" id="mbt:Anon001@027" order="1">
+											<validityParameters>
+												<OperatorRef version="any" ref="noc:MBIKE"/>
+												<DistributionChannelRef version="any" ref="mobile_application"/>
+												<FulfilmentMethodRef version="any" ref="mobile_device"/>
+												<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+												<VehicleSharingRef version="any" ref="cycle_share"/>
+												<VehicleSharingServiceRef version="any" ref="metrobike"/>
+											</validityParameters>
+										</CustomerPurchaseParameterAssignment>
+									</validityParameterAssignments>
+								</CustomerPurchasePackageElement>
+							</customerPurchasePackageElements>
+							<SalesTransactionRef version="any" ref="mbt:Anon001@trans069@purchase_single_session@checkout"/>
+							<salesTransactions>
+								<SalesTransactionRef version="any" ref="mbt:Anon001@trans069@purchase_single_session@return"/>
+							</salesTransactions>
+							<prices>
+								<CustomerPurchasePackagePrice version="any" id="mbt:Anon001@027" created="2020-12-08T12:01:00">
+									<Name>Intial prepayment</Name>
+									<Amount>2.10</Amount>
+									<CustomerPurchasePackageRef version="any" ref="mbt:Anon001@027"/>
+								</CustomerPurchasePackagePrice>
+								<CustomerPurchasePackagePrice version="any" id="mbt:Anon001@027" created="2020-12-08T14:47:00">
+									<Name>Additional charge  3 + 4</Name>
+									<Amount>7.00</Amount>
+									<CustomerPurchasePackageRef version="any" ref="mbt:Anon001@027"/>
+								</CustomerPurchasePackagePrice>
+							</prices>
+							<travelDocuments>
+								<ServiceAccessCode version="any" id="mbt:Anon001@027@purchase_single_session">
+									<ValidBetween>
+										<FromDate>2020-12-08T12:01:00</FromDate>
+										<ToDate>2020-12-08T12:15:00</ToDate>
+									</ValidBetween>
+									<TypeOfTravelDocumentRef version="any" ref="mobile_application_data"/>
+									<AccessCode>1234</AccessCode>
+									<VehicleAccessCredentialsAssignmentRef version="any" ref="mbt:Anon001@trans069@purchase_single_session@one_time"/>
+								</ServiceAccessCode>
+							</travelDocuments>
 							<MobileDeviceRef versionRef="external" ref="mbt:317867122222"/>
 							<MediumApplicationInstanceRef versionRef="external" ref="mbt:317867122222@mboik"/>
 						</CustomerPurchasePackage>

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_equipmentEnergy_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_equipmentEnergy_version.xsd
@@ -125,7 +125,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Type of storage.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="MasimumPower" type="WattageType" minOccurs="0">
+			<xsd:element name="MaximumPower" type="WattageType" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Maximum charging power of the grid
 supply [W]. The sum of the current

--- a/xsd/netex_part_1/part1_networkDescription/netex_route_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_route_version.xsd
@@ -28,6 +28,9 @@
 				<Date>
 					<Modified>2019-03-25</Modified>Fix #37 by Skinkie: Correct Typo:  rename OppositeDIrectionRef to OppositeDirectionRef NB this will break existing XML
 				</Date>
+				<Date>
+					<Modified>2021-07-10</Modified>NewMOdes: Correct data type for NumberOfPassengers on new RouteAssessment element
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the ROUTE types.</p>
@@ -44,7 +47,7 @@
 					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
 				</Relation>
 				<Rights>Unclassified
-					 <Copyright>CEN, Crown Copyright 2009-2019</Copyright>
+					 <Copyright>CEN, Crown Copyright 2009-2021</Copyright>
 				</Rights>
 				<Source>
 					<ul>
@@ -543,7 +546,7 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="ModeOfOperationRef" minOccurs="0"/>
-			<xsd:element name="MinimumNumberOfPassengers" type="xsd:nonNegativeInteger" minOccurs="0">
+			<xsd:element name="MinimumNumberOfPassengers" type="NumberOfPassengers" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Minimum number of passengers to be able to use.</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleServicePlaceAssignment_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleServicePlaceAssignment_version.xsd
@@ -20,7 +20,7 @@
 					<Created>2020-10-05</Created>Add for New Modes
 				</Date>
 				<Date>
-					<Modified>2020-10-05</Modified>
+					<Modified>2021-07-13</Modified>NewModes correction - Allow assignment of Bay 
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -38,7 +38,7 @@
 					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
 				</Relation>
 				<Rights>Unclassified
-					 <Copyright>CEN, Crown Copyright 2029-2020</Copyright>
+					 <Copyright>CEN, Crown Copyright 2029-2021</Copyright>
 				</Rights>
 				<Source>
 					<ul>
@@ -275,6 +275,7 @@ Rail transport, Roads and Road transport
 				<xsd:element ref="VehiclePoolingMeetingPlaceRef"/>
 				<xsd:element ref="VehiclePoolingParkingAreaRef"/>
 			</xsd:choice>
+			<xsd:element ref="ParkingBayRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== VEHICLE POOLING PLACE ASSIGNMENT ========================================== -->
@@ -332,6 +333,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element ref="CommonVehicleServiceRef"/>
 			<xsd:element ref="VehicleSharingParkingAreaRef"/>
+			<xsd:element ref="ParkingBayRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->


### PR DESCRIPTION
Add a car club example to new mode examples

This prompted a corerction to VehiclexxxxPlaceAssignments

In Netex UML, VehiclexxxxPlaceAssignmenst can also reference a ParkingBay so that assignment can be to a specific bay within a parking area.  Thsi was missing 