### PR TITLE
Should allow for explicit referencing of TariffZone subtype FareZone

### DIFF
--- a/xsd/netex_framework/netex_genericFramework/netex_zone_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_support.xsd
@@ -127,7 +127,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="oneToManyRelationshipStructure">
 				<xsd:sequence>
-					<xsd:element ref="TariffZoneRef" maxOccurs="unbounded"/>
+					<xsd:element ref="TariffZoneRef_" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>


### PR DESCRIPTION
A TariffZone reference can be to a TariffZone or FareZone, i.e. 

`<TariffZoneRef ref="ENT:TariffZone:1" version="1"/>
and
<TariffZoneRef ref="ENT:FareZone:1" version="1"/>`

are both valid NeTEx XML.

However, in contrast to other similar structures, the reference itself cannot be of subtype. 

I.e. 
`<FareZoneRef ref="ENT:FareZone:1" version="1"/>`

is currently not allowed (unless the reference is explicitly of FareZoneRef type, which is appropriate for some elements e.g. Parent**Fare**ZoneRef).

As FareZone is a subtype of TariffZone, lists of TariffZone references should allow for interchangeably using the subtype reference, by implementing it as its substitutionGroup (TariffZoneRef_) rather than the parent type explicitly.  

_Change is backwards compatible and is in line with the current model, only affecting the XSD_