### PR TITLE
Fixing non-unique IDs in example

### DIFF
--- a/examples/functions/fares/Netex_101.21_TfL_GeographicFares_UnitZone_MultipleProduct.xml
+++ b/examples/functions/fares/Netex_101.21_TfL_GeographicFares_UnitZone_MultipleProduct.xml
@@ -3520,9 +3520,9 @@ Oyster_PayAsYouGo_right -   PayAsYouGo_trip
 										<VehicleModes>metro</VehicleModes>
 									</validityParameters>
 								</GenericParameterAssignment>
-								<GenericParameterAssignment version="any" order="2" id="tfl:Prepaid_trip">
+								<GenericParameterAssignment version="any" order="2" id="tfl:Prepaid_trip@single">
 									<Name>Cant Break Metro journeys</Name>
-									<Description>  														Flat far simgle tripcase. </Description>
+									<Description>Flat fare single trip case.</Description>
 									<TypeOfAccessRightAssignmentRef version="any" ref="tfl:condition_of_use"/>
 									<limitations>
 										<InterchangingRef ref="tfl:no_interchange_cannot_break_journey" version="any"/>
@@ -13565,7 +13565,7 @@ All other journeys on this service	£3.00	n/a	£2.00</Description>
 														<GroupTicketRef version="any" ref="lrs:River_cruise"/>
 													</limitations>
 												</GenericParameterAssignment>
-												<GenericParameterAssignment version="any" order="2" id="lrs:London_Eye_River_tour@01@Freedom_passNot">
+												<GenericParameterAssignment version="any" order="2" id="lrs:London_Eye_River_tour@01@TravelCard_Freedom_passNot">
 													<Description>Travelcard and Freedom Pass discounts do not apply on this route.</Description>
 													<IsAllowed>false</IsAllowed>
 													<TypeOfAccessRightAssignmentRef version="any" ref="tfl:eligible"/>
@@ -14280,7 +14280,7 @@ Oyster card holders who want to travel on the Emirates Air Line as part of a 360
 										<VehicleModes>cableway</VehicleModes>
 									</validityParameters>
 								</GenericParameterAssignment>
-								<GenericParameterAssignment version="any" order="2" id="ea:360_cableway_trip">
+								<GenericParameterAssignment version="any" order="2" id="ea:360_cableway_trip@CannotBreakJourney">
 									<TypeOfAccessRightAssignmentRef version="any" ref="tfl:condition_of_use"/>
 									<ValidableElementRef version="any" ref="ea:cableway_trip"/>
 									<limitations>


### PR DESCRIPTION
Added inherited assignment types in Entur repo enforces slightly stricter consistency checks, which highlighted three duplicate (not globally unique) IDs in this example. This PR adds an appropriate suffix to these strings.