### PR TITLE
Add VehicleMode to VehicleType (and some typos)

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -2,6 +2,7 @@
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_vehicleType_version">
 	<xsd:include schemaLocation="netex_vehicleType_support.xsd"/>
 	<xsd:include schemaLocation="netex_transportOrganisation_support.xsd"/>
+	<xsd:include schemaLocation="../netex_reusableComponents/netex_mode_support.xsd"/>
 	<xsd:include schemaLocation="netex_equipmentVehiclePassenger_version.xsd"/>
 	<!-- ======================================================================= -->
 	<xsd:annotation>
@@ -70,7 +71,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="VehicleType" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation>Type of VEHICLe.</xsd:documentation>
+			<xsd:documentation>Type of VEHICLE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -97,7 +98,7 @@ Rail transport, Roads and Road transport
 	</xsd:element>
 	<xsd:complexType name="VehicleType_VersionStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for a VEHICLE. TYPE.</xsd:documentation>
+			<xsd:documentation>Type for a VEHICLE TYPE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="DataManagedObjectStructure">
@@ -109,7 +110,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:group name="VehicleTypeGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for a VEHICLE. TYPE.</xsd:documentation>
+			<xsd:documentation>Elements for a VEHICLE TYPE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
@@ -128,6 +129,11 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0"/>
+			<xsd:element name="VehicleMode" type="VehicleModeEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>VEHICLE MODE to which VEHICLE TYPE belongs. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:group ref="VehicleTypePropertiesGroup"/>
 			<xsd:element name="IncludedIn" type="VehicleTypeRefStructure" minOccurs="0">
 				<xsd:annotation>
@@ -141,7 +147,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="facilities" type="serviceFacilitySets_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Facilities of VEHICLE.</xsd:documentation>
+					<xsd:documentation>Facilities of VEHICLE TYPE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="VehicleRequirementsGroup"/>
@@ -149,7 +155,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="VehicleTypePropertiesGroup">
 		<xsd:annotation>
-			<xsd:documentation>Prooprty Elements for a VEHICLE. TYPE.</xsd:documentation>
+			<xsd:documentation>Property Elements for a VEHICLE TYPE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="ReversingDirection" type="xsd:boolean" default="true" minOccurs="0">
@@ -174,7 +180,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="PassengerCapacity" type="PassengerCapacityStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Total Number of passengers that VEHICLE TYPE. can carry.</xsd:documentation>
+					<xsd:documentation>Total Number of passengers that VEHICLE TYPE can carry.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="capacities" type="passengerCapacities_RelStructure" minOccurs="0">
@@ -203,7 +209,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="Height" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>The length of a VEHICLE of the type. +v1.1</xsd:documentation>
+					<xsd:documentation>The height of a VEHICLE of the type. +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="Weight" type="WeightType" minOccurs="0">


### PR DESCRIPTION
According to Transmodel (paragraph 5.6.2): _"A VEHICLE TYPE must belong to one TRANSPORT MODE. For instance, the 'bus' TRANSPORT MODE will gather standard, articulated, minibus, double-deck buses."_
But there is no way to express this in a VehicleType, both in Transmodel (paragraph 5.6.10) and in NeTEx (paragraph 7.7.11.3.2 and xsd). In the Dutch Profile we need this relationship.
