### PR TITLE
Allow multiple gml:Polygons associated to a Zone

### DIFF
--- a/xsd/gml/geometryAggregates-extract-v3_2_1.xsd
+++ b/xsd/gml/geometryAggregates-extract-v3_2_1.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.opengis.net/gml/3.2" elementFormDefault="qualified" version="3.2.1.2">
+	<annotation>
+		<appinfo source="urn:x-ogc:specification:gml:schema-xsd:geometryAggregates:3.2.1">geometryAggregates.xsd</appinfo>
+		<documentation>See ISO/DIS 19136 12.3.
+Geometric aggregates (i.e. instances of a subtype of gml:AbstractGeometricAggregateType) are arbitrary aggregations of geometry elements. They are not assumed to have any additional internal structure and are used to "collect" pieces of geometry of a specified type. Application schemas may use aggregates for features that use multiple geometric objects in their representations.
+
+GML is an OGC Standard.
+Copyright (c) 2007,2010 Open Geospatial Consortium.
+To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+		</documentation>
+	</annotation>
+	<include schemaLocation="geometryPrimitives-extract-v3_2_1.xsd"/>
+	<complexType name="AbstractGeometricAggregateType" abstract="true">
+		<complexContent>
+			<extension base="gml:AbstractGeometryType">
+				<attributeGroup ref="gml:AggregationAttributeGroup"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="AbstractGeometricAggregate" type="gml:AbstractGeometricAggregateType" abstract="true" substitutionGroup="gml:AbstractGeometry">
+		<annotation>
+			<documentation>gml:AbstractGeometricAggregate is the abstract head of the substitution group for all geometric aggregates.</documentation>
+		</annotation>
+	</element>
+	<complexType name="MultiSurfaceType">
+		<complexContent>
+			<extension base="gml:AbstractGeometricAggregateType">
+				<sequence>
+					<element ref="gml:surfaceMember" minOccurs="0" maxOccurs="unbounded"/>
+					<element ref="gml:surfaceMembers" minOccurs="0"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="MultiSurface" type="gml:MultiSurfaceType" substitutionGroup="gml:AbstractGeometricAggregate">
+		<annotation>
+			<documentation>A gml:MultiSurface is defined by one or more gml:AbstractSurfaces.
+The members of the geometric aggregate may be specified either using the "standard" property (gml:surfaceMember) or the array property (gml:surfaceMembers). It is also valid to use both the "standard" and the array properties in the same collection.</documentation>
+		</annotation>
+	</element>
+	<element name="surfaceMembers" type="gml:SurfaceArrayPropertyType">
+		<annotation>
+			<documentation>This property element contains a list of surfaces. The order of the elements is significant and shall be preserved when processing the array.</documentation>
+		</annotation>
+	</element>
+	<complexType name="MultiSurfacePropertyType">
+		<annotation>
+			<documentation>A property that has a collection of surfaces as its value domain may either be an appropriate geometry element encapsulated in an element of this type or an XLink reference to a remote geometry element (where remote includes geometry elements located elsewhere in the same document). Either the reference or the contained element shall be given, but neither both nor none.</documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:MultiSurface"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+</schema>

--- a/xsd/gml/geometryPrimitives-extract-v3_2_1.xsd
+++ b/xsd/gml/geometryPrimitives-extract-v3_2_1.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" elementFormDefault="qualified" version="3.2.1.2">
+	<annotation>
+		<appinfo source="urn:x-ogc:specification:gml:schema-xsd:geometryPrimitives:3.2.1">geometryPrimitives.xsd</appinfo>
+		<documentation>See ISO/DIS 19136 Clause 11.
+Beside the "simple" geometric primitives specified in the previous Clause, this Clause specifies additional primitives to describe real world situations which require a more expressive geometry model.
+
+GML is an OGC Standard.
+Copyright (c) 2007,2010 Open Geospatial Consortium.
+To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+		</documentation>
+	</annotation>
+	<include schemaLocation="gmlBasic2d-extract-v3_2_1-.xsd"/>
+	<element name="surfaceMember" type="gml:SurfacePropertyType">
+		<annotation>
+			<documentation>This property element either references a surface via the XLink-attributes or contains the surface element. A surface element is any element, which is substitutable for gml:AbstractSurface.</documentation>
+		</annotation>
+	</element>
+</schema>

--- a/xsd/gml/gml_extract_all_objects_v_3_2_1.xsd
+++ b/xsd/gml/gml_extract_all_objects_v_3_2_1.xsd
@@ -4,9 +4,11 @@
 	<!-- ===Dependencies ======================================= -->
 	<!-- ====================================================================== -->
 	<!-- ====================================================================== -->
-	<!--SOME GML ELEMENTS HAVE BEEN DROPPED TO MINIMSE DEPENDECIES-->
+	<!--SOME GML ELEMENTS HAVE BEEN DROPPED TO MINIMISE DEPENDECIES-->
 	<include schemaLocation="basicTypes.xsd"/>
 	<include schemaLocation="geometryBasic0d1d-extract-v3_2_1.xsd"/>
 	<include schemaLocation="gmlBase-extract-v3_2_1.xsd"/>
 	<include schemaLocation="gmlBasic2d-extract-v3_2_1-.xsd"/>
+	<include schemaLocation="geometryPrimitives-extract-v3_2_1.xsd"/>
+	<include schemaLocation="geometryAggregates-extract-v3_2_1.xsd"/>
 </schema>

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
@@ -126,7 +126,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Centre Coordinates of ZONE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="gml:Polygon" minOccurs="0"/>
+			<xsd:element ref="gml:Polygon" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element name="projections" type="projections_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Projections of ZONE onto another layer.</xsd:documentation>

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
@@ -126,7 +126,13 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Centre Coordinates of ZONE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="gml:Polygon" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:choice minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Use gml:MultiSurface if the Zone contains multiple non-continuous areas, e.g. a coastline with islands.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:element ref="gml:Polygon"/>
+				<xsd:element ref="gml:MultiSurface"/>
+			</xsd:choice>
 			<xsd:element name="projections" type="projections_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Projections of ZONE onto another layer.</xsd:documentation>


### PR DESCRIPTION
For certain types of _Zone_ (e.g. TransportAdministrativeZone) there are situations where the area represented by the Zone is not **one** surface, but consists of multiple parts. The most common case is a region consisting of several islands.
These cases cannot be described by the current implementation of Zone, because it contains only one _gml:Polygon_. The problem can be solved by allowing multiple polygons to be associated to the Zone.