### PR TITLE
Align temporalValidityParameters with spec

### DIFF
--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -315,7 +315,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="oneToManyRelationshipStructure">
-				<xsd:sequence>
+				<xsd:sequence maxOccurs="unbounded">
 					<xsd:group ref="TemporalValidityParametersGroup"/>
 				</xsd:sequence>
 			</xsd:extension>


### PR DESCRIPTION
Bugfix. 

NeTEx part 3 - 7.6.1.2.3.5 AccessRightParameterValidityParameterGroup

> Table 97 – AccessRightParameterValidityParameterGroup

The _temporalValidityParameters_ (TemporalValidityParametersGroup) element (list) is documented with cardinality 0:* but implemented as a sequence with its elements **only allowed once** (as all its included reference elements are 0:1), whereas the following _validityParameters_ element (list) is documented similarly 0:* yet implemented as a "unbound" sequence allowing multiple instances of its (groups of) references.




