### PR TITLE
Update netex_facility_support.xsd

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
@@ -281,14 +281,19 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="availableIfBooked">
 				<xsd:annotation>
-					<xsd:documentation>Assistance is  available if booked.</xsd:documentation>
+					<xsd:documentation>Assistance is available if booked.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="availableAtCertainTimes">
 				<xsd:annotation>
-					<xsd:documentation>Assistance is   available at certain times.</xsd:documentation>
+					<xsd:documentation>Assistance is available at certain times.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
+			<xsd:enumeration value="availableDependentOnJourney">
+				<xsd:annotation>
+					<xsd:documentation>Assistance is dependent on the journey.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>			
 			<xsd:enumeration value="unknown">
 				<xsd:annotation>
 					<xsd:documentation>Not known if assistance is available.</xsd:documentation>


### PR DESCRIPTION
TSI-PRM IoA has a "Dependent on the train" value for PRM assistance. The current set of AssistanceAvailability does not really model that. It only models availableAtCertainTimes. So I thought this would be a good update. Also Adrian and I thought that the "train" is probably more Journey than Vehicle.