### PR TITLE
Fix: wheechair to wheelchair (#279)

### DIFF
--- a/examples/functions/timetable/Netex_01.1_Bus_SimpleTimetable_JourneysOnly.xml
+++ b/examples/functions/timetable/Netex_01.1_Bus_SimpleTimetable_JourneysOnly.xml
@@ -354,7 +354,7 @@ The Calendar is shown coded as
 					<serviceFacilitySets>
 						<ServiceFacilitySet version="any" id="acs:sfs_24o_01">
 							<ProvidedByRef ref="xyz:4567">EXTERNAL</ProvidedByRef>
-							<AssistanceFacilityList>boardingAssistance conductor wheechairAssistance</AssistanceFacilityList>
+							<AssistanceFacilityList>boardingAssistance conductor wheelchairAssistance</AssistanceFacilityList>
 							<FareClasses>standardClass</FareClasses>
 							<MobilityFacilityList> stepFreeAccess suitableForWheelchairs</MobilityFacilityList>
 							<NuisanceFacilityList>noSmoking</NuisanceFacilityList>

--- a/examples/functions/timetable/Netex_01.2_Bus_SimpleTimetable_WithTimings.xml
+++ b/examples/functions/timetable/Netex_01.2_Bus_SimpleTimetable_WithTimings.xml
@@ -972,7 +972,7 @@ The Calendar is shown coded as
 					<serviceFacilitySets>
 						<ServiceFacilitySet version="any" id="hde:sfs_24o_01">
 							<ProvidedByRef ref="xyz:4567">EXTERNAL</ProvidedByRef>
-							<AssistanceFacilityList>boardingAssistance conductor wheechairAssistance</AssistanceFacilityList>
+							<AssistanceFacilityList>boardingAssistance conductor wheelchairAssistance</AssistanceFacilityList>
 							<FareClasses>standardClass</FareClasses>
 							<MobilityFacilityList> stepFreeAccess suitableForWheelchairs</MobilityFacilityList>
 							<NuisanceFacilityList>noSmoking</NuisanceFacilityList>

--- a/examples/functions/timetable/Netex_08.2_Bus_SimpleTimetable_Cancellation.xml
+++ b/examples/functions/timetable/Netex_08.2_Bus_SimpleTimetable_Cancellation.xml
@@ -377,7 +377,7 @@ The Calendar is shown coded as
 					<serviceFacilitySets>
 						<ServiceFacilitySet version="any" id="hde:sfs_24o_01">
 							<ProvidedByRef ref="xyz:4567">EXTERNAL</ProvidedByRef>
-							<AssistanceFacilityList>boardingAssistance conductor wheechairAssistance</AssistanceFacilityList>
+							<AssistanceFacilityList>boardingAssistance conductor wheelchairAssistance</AssistanceFacilityList>
 							<FareClasses>   standardClass</FareClasses>
 							<MobilityFacilityList> stepFreeAccess suitableForWheelchairs</MobilityFacilityList>
 							<NuisanceFacilityList>   noSmoking</NuisanceFacilityList>

--- a/examples/functions/timetable/Netex_09.2_Bus_SimpleTimetable_Slovenia.xml
+++ b/examples/functions/timetable/Netex_09.2_Bus_SimpleTimetable_Slovenia.xml
@@ -569,7 +569,7 @@ This example shows the encoding of a simple bus timetable for a linear route in 
 					<serviceFacilitySets>
 						<ServiceFacilitySet version="any" id="ao:sfs_24o_01">
 							<ProvidedByRef ref="xyz:4567">EXTERNAL</ProvidedByRef>
-							<AssistanceFacilityList>boardingAssistance conductor wheechairAssistance</AssistanceFacilityList>
+							<AssistanceFacilityList>boardingAssistance conductor wheelchairAssistance</AssistanceFacilityList>
 							<FareClasses>standardClass</FareClasses>
 							<MobilityFacilityList> stepFreeAccess suitableForWheelchairs</MobilityFacilityList>
 							<NuisanceFacilityList>noSmoking</NuisanceFacilityList>

--- a/examples/functions/timetable/Netex_10_Rail_SplittingJoiningTimetable.xml
+++ b/examples/functions/timetable/Netex_10_Rail_SplittingJoiningTimetable.xml
@@ -1173,7 +1173,7 @@ The TIMETABLE FRAME groups the servicee  elements
 					<serviceFacilitySets>
 						<ServiceFacilitySet version="any" id="bbd:svcfc_general">
 							<Description>General facilities</Description>
-							<AssistanceFacilityList>boardingAssistance conductor wheechairAssistance</AssistanceFacilityList>
+							<AssistanceFacilityList>boardingAssistance conductor wheelchairAssistance</AssistanceFacilityList>
 							<CateringFacilityList> buffet</CateringFacilityList>
 							<FareClasses> firstClass standardClass</FareClasses>
 							<MobilityFacilityList> stepFreeAccess suitableForWheelchairs</MobilityFacilityList>

--- a/examples/functions/timetable/Netex_11_Rail_CompoundTrain.xml
+++ b/examples/functions/timetable/Netex_11_Rail_CompoundTrain.xml
@@ -1173,7 +1173,7 @@ The TIMETABLE FRAME groups the servicee  elements
 					<serviceFacilitySets>
 						<ServiceFacilitySet version="any" id="bbd:svcfc_general">
 							<Description>General facilities</Description>
-							<AssistanceFacilityList>boardingAssistance conductor wheechairAssistance</AssistanceFacilityList>
+							<AssistanceFacilityList>boardingAssistance conductor wheelchairAssistance</AssistanceFacilityList>
 							<CateringFacilityList> buffet</CateringFacilityList>
 							<FareClasses> firstClass standardClass</FareClasses>
 							<MobilityFacilityList> stepFreeAccess suitableForWheelchairs</MobilityFacilityList>

--- a/examples/functions/timetable/Netex_21_Rail_NetworkTimetable_eurostar.xml
+++ b/examples/functions/timetable/Netex_21_Rail_NetworkTimetable_eurostar.xml
@@ -11337,7 +11337,7 @@ Q.4. Public holiday - Services do not run on a christams day -
 					<serviceFacilitySets>
 						<ServiceFacilitySet version="any" id="es:sfs_general">
 							<Description>General</Description>
-							<AssistanceFacilityList>boardingAssistance conductor wheechairAssistance</AssistanceFacilityList>
+							<AssistanceFacilityList>boardingAssistance conductor wheelchairAssistance</AssistanceFacilityList>
 							<NuisanceFacilityList>noSmoking</NuisanceFacilityList>
 							<PassengerCommsFacilityList>publicWifi</PassengerCommsFacilityList>
 							<TicketingServiceFacilityList> purchase</TicketingServiceFacilityList>

--- a/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
@@ -254,7 +254,7 @@ Rail transport, Roads and Road transport
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="personalAssistance"/>
 			<xsd:enumeration value="boardingAssistance"/>
-			<xsd:enumeration value="wheechairAssistance"/>
+			<xsd:enumeration value="wheelchairAssistance"/>
 			<xsd:enumeration value="unaccompaniedMinorAssistance"/>
 			<xsd:enumeration value="wheelchairUse"/>
 			<xsd:enumeration value="conductor"/>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -1195,7 +1195,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Door can be passed in a wheel chair.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="WheechairUnaided" type="xsd:boolean" minOccurs="0">
+			<xsd:element name="WheelchairUnaided" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Can be passed in a wheel chair unaided.</xsd:documentation>
 				</xsd:annotation>


### PR DESCRIPTION
Correcting all wrong spellings of wheelchair, including examples.