### PR TITLE
EPIAP: edgetotrackcenterdistance

### DIFF
--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
@@ -397,6 +397,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>ENTRANCEs to SPACE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="PlatformHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Height of the platform relative to the ground (bus) or the rail track.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="StopPlaceComponentIdentifierGroup">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
@@ -402,6 +402,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Height of the platform relative to the ground (bus) or the rail track.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="EdgeToTrackCenterDistance" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Distance from centerline of the track towards the platform edge.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="StopPlaceComponentIdentifierGroup">


### PR DESCRIPTION
Distance from centerline of the track towards the platform edge. In combination with the VehicleType half width, the gap between the platform and the vehicle floor can be calculated for vehicles without a slidingStep.