### PR TITLE
EPIAP quay boarding positions enhancement

### DIFF
--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
@@ -662,7 +662,7 @@ contained within its parent QUAY.</xsd:documentation>
 			</xsd:element>
 			<xsd:element name="EdgeToTrackCenterDistance" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Distance from centerline of the track towards the platform edge.</xsd:documentation>
+					<xsd:documentation>Distance between the track centre and the platform edge parallel to the running plane (bq), as defined in chapter 13 of EN 15273-3:2013.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
@@ -510,6 +510,7 @@ contained within its parent QUAY.</xsd:documentation>
 		<xsd:sequence>
 			<xsd:group ref="QuayIdentifierGroup"/>
 			<xsd:group ref="QuayDescriptorGroup"/>
+			<xsd:group ref="PlatformAccessibilitySpecificGroup"/>
 			<xsd:element name="ParentQuayRef" type="QuayRefStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>if QUAY is a subzone of another QUAY, identifies parent.</xsd:documentation>
@@ -648,6 +649,24 @@ contained within its parent QUAY.</xsd:documentation>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:group name="PlatformAccessibilitySpecificGroup">
+		<xsd:annotation>
+			<xsd:documentation>Additional details for accessibility of QUAYs and BOARDING POSITIONs</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="PlatformHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Height of the platform relative to the ground (bus) or the rail track.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="EdgeToTrackCenterDistance" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Distance from centerline of the track towards the platform edge.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
 	<!-- ======================================================================= -->
 	<xsd:complexType name="accessSpaces_RelStructure">
 		<xsd:annotation>
@@ -850,6 +869,7 @@ contained within its parent QUAY.</xsd:documentation>
 					<xsd:documentation>Entrances to BOARDING POSITION.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:group ref="PlatformAccessibilitySpecificGroup"/>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->


### PR DESCRIPTION
Replaces #296 / #295
Adds **EdgeToTrackCenterDistance**
Distance from centerline of the track towards the platform edge. In combination with the VehicleType half width, the gap between the platform and the vehicle floor can be calculated for vehicles without a slidingStep.

Adds **PlatformHeight**
Height of the platform relative to the ground (bus) or the rail track.

This is a way to do it using a group used by quays and  boarding position (only)