### PR TITLE
Update netex_timingPattern_version.xsd

### DIFF
--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
@@ -562,7 +562,7 @@ Rail transport, Roads and Road transport
 								<xsd:annotation>
 									<xsd:documentation>Distance for TIMING LINK.</xsd:documentation>
 								</xsd:annotation>
-							</xsd:element>	
+							</xsd:element>
 							<xsd:element name="RunTime" type="xsd:duration" minOccurs="0">
 								<xsd:annotation>
 									<xsd:documentation>Run time for TIMING LINK - TIME BAND given by context.</xsd:documentation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
@@ -558,6 +558,11 @@ Rail transport, Roads and Road transport
 									<xsd:documentation>Identifier of POINT at which LINK ends.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
+							<xsd:element name="Distance" type="DistanceType" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Distance for TIMING LINK.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>	
 							<xsd:element name="RunTime" type="xsd:duration" minOccurs="0">
 								<xsd:annotation>
 									<xsd:documentation>Run time for TIMING LINK - TIME BAND given by context.</xsd:documentation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
@@ -558,11 +558,6 @@ Rail transport, Roads and Road transport
 									<xsd:documentation>Identifier of POINT at which LINK ends.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
-							<xsd:element name="Distance" type="DistanceType" minOccurs="0">
-								<xsd:annotation>
-									<xsd:documentation>Distance for TIMING LINK.</xsd:documentation>
-								</xsd:annotation>
-							</xsd:element>
 							<xsd:element name="RunTime" type="xsd:duration" minOccurs="0">
 								<xsd:annotation>
 									<xsd:documentation>Run time for TIMING LINK - TIME BAND given by context.</xsd:documentation>
@@ -593,6 +588,11 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>Identifier of POINT at which LINK ends.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
+					<xsd:element name="Distance" type="DistanceType" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Distance for TIMING LINK.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>					
 					<xsd:element name="RunTime" type="xsd:duration" minOccurs="0">
 						<xsd:annotation>
 							<xsd:documentation>Run time for TIMING LINK - TIME BAND given by context.</xsd:documentation>


### PR DESCRIPTION
The restiction in OnwardTimingLinkView was also containing an extension (Distance) !!
The distance has been moved to OnwardTimingLink_DerivedViewStructure  (not used elsewhere for now)