### PR TITLE
SpatialFeature needs to be in DataManagedObject substitutionGroup

### DIFF
--- a/xsd/netex_framework/netex_genericFramework/netex_spatialFeature_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_spatialFeature_version.xsd
@@ -82,7 +82,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="SpatialFeature" type="GroupOfPoints_VersionStructure" abstract="false">
+	<xsd:element name="SpatialFeature" type="GroupOfPoints_VersionStructure" abstract="false" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Abstract SPATIAL FEATURE.</xsd:documentation>
 		</xsd:annotation>


### PR DESCRIPTION
SpatialFeature needs to be in DataManagedObject substitutionGroup, if not SimpleFeature and ComplexFeature will not be acccepted in GeneralFrames, etc.

Solves https://github.com/NeTEx-CEN/NeTEx/issues/258
