### PR TITLE
Add 'provisional' to ServiceAlterationEnumeration

### DIFF
--- a/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd
@@ -195,6 +195,7 @@ Rail transport, Roads and Road transport
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="extraJourney"/>
 			<xsd:enumeration value="cancellation"/>
+			<xsd:enumeration value="provisional"/>
 			<xsd:enumeration value="planned"/>
 			<xsd:enumeration value="replaced"/>
 		</xsd:restriction>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd
@@ -193,11 +193,31 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Allowed values for Service Alteration.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
-			<xsd:enumeration value="extraJourney"/>
-			<xsd:enumeration value="cancellation"/>
-			<xsd:enumeration value="provisional"/>
-			<xsd:enumeration value="planned"/>
-			<xsd:enumeration value="replaced"/>
+			<xsd:enumeration value="extraJourney">
+				<xsd:annotation>
+					<xsd:documentation>Journey is a short-term addition to the original planned schedule.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cancellation">
+				<xsd:annotation>
+					<xsd:documentation>Journey is a cancellation of a journey in the planned schedule.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="provisional">
+				<xsd:annotation>
+					<xsd:documentation>Journey is an intermediary planning, serving as a temporary provision for the time being.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="planned">
+				<xsd:annotation>
+					<xsd:documentation>Journey is as planned.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="replaced">
+				<xsd:annotation>
+					<xsd:documentation>Journey is a replacement.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<!-- ======================================================================= -->


### PR DESCRIPTION
For long term journey planning, relevant as a ServiceAlteration(Type) either before being 'planned' (finalized) or as an intermediary state before 'cancellation' or 'replaced'.