### PR TITLE
Add order attribute to Via

### DIFF
--- a/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
@@ -854,6 +854,11 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="VersionedChildStructure">
 				<xsd:group ref="ViaGroup"/>
+				<xsd:attribute name="order" type="xsd:integer" use="optional" default="1">
+					<xsd:annotation>
+						<xsd:documentation>Relative order of ASSIGNMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/xsd/netex_part_1/part1_networkDescription/netex_networkRestriction_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_networkRestriction_support.xsd
@@ -85,7 +85,7 @@ Rail transport, Roads and ROAD transport
 				</xsd:attribute>
 				<xsd:attribute name="order" type="xsd:integer" use="optional">
 					<xsd:annotation>
-						<xsd:documentation>Relative order of ASSIGNMENT.</xsd:documentation>
+						<xsd:documentation>Relative order of element.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:restriction>


### PR DESCRIPTION
Due to request in Norway/Nordics for explicitly assigning and verifying the order of each Via when a DestinationDisplay has multiple _vias_, i.e. to ensure these are displayed correctly in e.g. journey planners and customer information systems.

_Added to the Via_VersionedChildStructure to harmonize with most other NeTEx types having explicit attribute(s)_