### PR TITLE
Fixed incorrect annotation(s)

### DIFF
--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPatternTimings_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPatternTimings_version.xsd
@@ -81,13 +81,13 @@ Rail transport, Roads and Road transport
 				</xsd:element>
 				<xsd:element name="waitTimes" type="journeyPatternWaitTimes_RelStructure">
 					<xsd:annotation>
-						<xsd:documentation>Wait times for TIMING POINT. There may be different times for different time demands.</xsd:documentation>
+						<xsd:documentation>Wait times for (TIMING) POINT IN JOURNEY PATTERN. There may be different times for different time demands.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
 			<xsd:element name="headways" type="journeyPatternHeadways_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Wait times for TIMING POINT. There may be different times for different time demands.</xsd:documentation>
+				    <xsd:documentation>Set of HEADWAYs (frequency of services) that applies at a (TIMING) POINT IN JOURNEY PATTERN.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>


### PR DESCRIPTION
Aligned with NeTEx part 1, both _Table 611 – TimingPointInJourneyPattern – Element_ and _Table 622 – StopPointInPatternTimingGroup – Group_ as the TimingPointWaitGroup is reused.