### PR TITLE
ConditionSummaryChargingGroup not referenced from ConditionSummaryStructure

### DIFF
--- a/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
@@ -111,6 +111,7 @@
       <xsd:group ref="ConditionSummaryTravelGroup"/>
       <xsd:group ref="ConditionSummaryCommercialGroup"/>
       <xsd:group ref="ConditionSummaryReservationGroup"/>
+      <xsd:group ref="ConditionSummaryChargingGroup"/>
       <xsd:group ref="ConditionSummaryRentalGroup"/>
     </xsd:sequence>
   </xsd:complexType>


### PR DESCRIPTION
Must be included to allow PenaltyIfWithoutTicket and AvailableOnSubscription in ConditionSummary

See NeTEx part 3 - 7.6.2.3.5 ConditionSummary – Model Element (Table 224 – ConditionSummary – Element) / 7.6.2.3.5.7 ConditionSummaryChargingGroup – Group

See also revision v1.1 log in NEeTEx part 3 annex F.3 List of Changes - EURA0040