### PR TITLE
Fix annotation errors and align with definitions in NeTEx pt 3

### DIFF
--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
@@ -197,7 +197,7 @@
       </xsd:choice>
       <xsd:element name="ExchangableFromIntervalRef" type="TimeIntervalRefStructure" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Reference to arbitrary TimeInterval determining period from which reselling can be made relative to trigger point.</xsd:documentation>
+          <xsd:documentation>Reference to arbitrary TimeInterval determining period from which reselling can be done relative to trigger point.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
       <xsd:choice minOccurs="0">
@@ -219,7 +219,7 @@
       </xsd:choice>
       <xsd:element name="ExchangableUntilIntervalRef" type="TimeIntervalRefStructure" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Reference to arbitrary TimeInterval determining period up until which reselling can be made relative to trigger point.</xsd:documentation>
+          <xsd:documentation>Reference to arbitrary TimeInterval determining period up until which reselling can be done relative to trigger point.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
       <xsd:element name="EffectiveFrom" type="EffectiveFromEnumeration" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
@@ -156,7 +156,7 @@
       </xsd:element>
       <xsd:element name="OnlyAtCertainDistributionPoints" type="xsd:boolean" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Whether refund/Exchaneg can only be done in ceratin places.</xsd:documentation>
+          <xsd:documentation>Whether reselling can only be done in ceratin places.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
       <xsd:group ref="ResellingPeriodGroup"/>
@@ -175,51 +175,51 @@
     <xsd:sequence>
       <xsd:element name="ResellWhen" type="ResellWhenEnumeration" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Event marking when the is exchangable status of the ticket changes.</xsd:documentation>
+          <xsd:documentation>Event marking when the is resell status of the ticket changes.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
       <xsd:choice minOccurs="0">
         <xsd:element name="ExchangableFromAnyTime" type="EmptyType">
           <xsd:annotation>
-            <xsd:documentation>Special value - Can be exchanged or refunded from any point after purchase.</xsd:documentation>
+            <xsd:documentation>Special value - Can be resold from any point after purchase.</xsd:documentation>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="ExchangableFromDuration" type="xsd:duration">
           <xsd:annotation>
-            <xsd:documentation>Duration to start of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) after which ticket may be exchanged refunded or resold.</xsd:documentation>
+            <xsd:documentation>Duration to start of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) after which ticket may be resold.</xsd:documentation>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="ExchangableFromPercentUse" type="xsd:decimal">
           <xsd:annotation>
-            <xsd:documentation>Can be exchanged once a certain percentage of duration or use has been achieved. +v1.1</xsd:documentation>
+            <xsd:documentation>Can be resold once a certain percentage of duration or use has been achieved. +v1.1</xsd:documentation>
           </xsd:annotation>
         </xsd:element>
       </xsd:choice>
       <xsd:element name="ExchangableFromIntervalRef" type="TimeIntervalRefStructure" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Reference to arbitrary TimeInterval determining period from which exchange can be made relative to trigger point.</xsd:documentation>
+          <xsd:documentation>Reference to arbitrary TimeInterval determining period from which reselling can be made relative to trigger point.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
       <xsd:choice minOccurs="0">
         <xsd:element name="ExchangableUntilAnyTime" type="EmptyType">
           <xsd:annotation>
-            <xsd:documentation>Can be exchanged, refunded or resold up until any point in time after purchase.</xsd:documentation>
+            <xsd:documentation>Can be resold up until any point in time after purchase.</xsd:documentation>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="ExchangableUntilDuration" type="xsd:duration">
           <xsd:annotation>
-            <xsd:documentation>Duration to end of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) after which ticket may be exchanged refunded or resold.</xsd:documentation>
+            <xsd:documentation>Duration to end of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) after which ticket may be resold.</xsd:documentation>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="ExchangableUntilPercentUse" type="xsd:decimal">
           <xsd:annotation>
-            <xsd:documentation>Can be exchanged until a certain percentage of duration or use has been achieved. +v1.1</xsd:documentation>
+            <xsd:documentation>Can be resold until a certain percentage of duration or use has been achieved. +v1.1</xsd:documentation>
           </xsd:annotation>
         </xsd:element>
       </xsd:choice>
       <xsd:element name="ExchangableUntilIntervalRef" type="TimeIntervalRefStructure" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Reference to arbitrary TimeInterval determining period up until which exchange can be made relative to trigger point.</xsd:documentation>
+          <xsd:documentation>Reference to arbitrary TimeInterval determining period up until which reselling can be made relative to trigger point.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
       <xsd:element name="EffectiveFrom" type="EffectiveFromEnumeration" minOccurs="0">
@@ -241,12 +241,12 @@
     <xsd:sequence>
       <xsd:element name="HasFee" type="xsd:boolean" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Whether these is a fee for a refund, exchange or reselling.</xsd:documentation>
+          <xsd:documentation>Whether these is a fee for a resale.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
       <xsd:element name="RefundBasis" type="PerBasisEnumeration" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Basis on which refund is made.</xsd:documentation>
+          <xsd:documentation>Basis on which resale is made.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
     </xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
@@ -181,12 +181,12 @@
       <xsd:choice minOccurs="0">
         <xsd:element name="ExchangableFromAnyTime" type="EmptyType">
           <xsd:annotation>
-            <xsd:documentation>Special value Can be exhanged from Purchase onwards.</xsd:documentation>
+            <xsd:documentation>Special value - Can be exchanged or refunded from any point after purchase.</xsd:documentation>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="ExchangableFromDuration" type="xsd:duration">
           <xsd:annotation>
-            <xsd:documentation>Duration to start of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) or that ticket.</xsd:documentation>
+            <xsd:documentation>Duration to start of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) after which ticket may be exchanged refunded or resold.</xsd:documentation>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="ExchangableFromPercentUse" type="xsd:decimal">
@@ -197,18 +197,18 @@
       </xsd:choice>
       <xsd:element name="ExchangableFromIntervalRef" type="TimeIntervalRefStructure" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Period to start of period before (negative) or after (positive) the trigger point- as arbitrary interval.</xsd:documentation>
+          <xsd:documentation>Reference to arbitrary TimeInterval determining period from which exchange can be made relative to trigger point.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
       <xsd:choice minOccurs="0">
         <xsd:element name="ExchangableUntilAnyTime" type="EmptyType">
           <xsd:annotation>
-            <xsd:documentation>Can be exchanged anyTime.</xsd:documentation>
+            <xsd:documentation>Can be exchanged, refunded or resold up until any point in time after purchase.</xsd:documentation>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="ExchangableUntilDuration" type="xsd:duration">
           <xsd:annotation>
-            <xsd:documentation>Duration to end of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) or that ticket.</xsd:documentation>
+            <xsd:documentation>Duration to end of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) after which ticket may be exchanged refunded or resold.</xsd:documentation>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="ExchangableUntilPercentUse" type="xsd:decimal">
@@ -219,7 +219,7 @@
       </xsd:choice>
       <xsd:element name="ExchangableUntilIntervalRef" type="TimeIntervalRefStructure" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Period to endof period before (negative) or after (positive) the trigger point- as arbitrary interval.</xsd:documentation>
+          <xsd:documentation>Reference to arbitrary TimeInterval determining period up until which exchange can be made relative to trigger point.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
       <xsd:element name="EffectiveFrom" type="EffectiveFromEnumeration" minOccurs="0">
@@ -229,8 +229,7 @@
       </xsd:element>
       <xsd:element name="NotificationPeriod" type="xsd:duration" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Notice period needed before transaction can be made. + v1.1
-          </xsd:documentation>
+          <xsd:documentation>Notice period needed before transaction can be made. + v1.1</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
     </xsd:sequence>
@@ -242,12 +241,12 @@
     <xsd:sequence>
       <xsd:element name="HasFee" type="xsd:boolean" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Whether othere is a fee for reselling.</xsd:documentation>
+          <xsd:documentation>Whether these is a fee for a refund, exchange or reselling.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
       <xsd:element name="RefundBasis" type="PerBasisEnumeration" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>Whether there is a fee for reselling.</xsd:documentation>
+          <xsd:documentation>Basis on which refund is made.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
     </xsd:sequence>
@@ -264,7 +263,7 @@
       </xsd:element>
       <xsd:element name="typesOfPaymentMethodRef" type="TypeOfPaymentMethodRefs_RelStructure" minOccurs="0">
         <xsd:annotation>
-          <xsd:documentation>POther AYMENT METHODs allowd to pay fee or to make refund.</xsd:documentation>
+          <xsd:documentation>Other PAYMENT METHODs allowd to pay fee or to make refund.</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
     </xsd:sequence>


### PR DESCRIPTION
Commit **only** contains cleanup of xsd:documentation

See NeTEx part 3 chapter 7.6.1.3.1.2 Reselling – Model Element and subchapters / underlying element definitions.