### PR TITLE
Add PrivateCode to TrainElement

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
@@ -360,6 +360,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Description of TRAIN ELEMENT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element ref="PrivateCode" minOccurs="0"/>
 			<xsd:element name="TrainElementType" type="TrainElementTypeEnumeration" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Type of TRAIN ELEMENT.</xsd:documentation>


### PR DESCRIPTION
PrivateCode for TrainElement has been requested for Nordic train service data, and as Vehicle already has this field adding it to the equivalent TrainElement should be uncontroversial.

See similar discussion in #334 and #367 / #371 (_PublicCode_) 