### PR TITLE
Update netex_version_support.xsd

### DIFF
--- a/xsd/netex_framework/netex_responsibility/netex_version_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_version_support.xsd
@@ -128,26 +128,31 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Allowed values for Statuses of VERSION.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="draft"/>
+			<xsd:enumeration value="draft">
 				<xsd:annotation>
 					<xsd:documentation>This version is a draft: it is currently under construction and should not be used for operational purposes.</xsd:documentation>
 				</xsd:annotation>
-			<xsd:enumeration value="proposed"/>
+			</xsd:enumeration>
+			<xsd:enumeration value="proposed">
 				<xsd:annotation>
 					<xsd:documentation>This version is comprehensive but not yet validated.</xsd:documentation>
 				</xsd:annotation>
-			<xsd:enumeration value="versioned"/>
+			</xsd:enumeration>
+			<xsd:enumeration value="versioned">
 				<xsd:annotation>
 					<xsd:documentation>This is a finalised version frozen from further modifications.</xsd:documentation>
 				</xsd:annotation>
-			<xsd:enumeration value="deprecated"/>
+			</xsd:enumeration>
+			<xsd:enumeration value="deprecated">
 				<xsd:annotation>
 					<xsd:documentation>This is an old version: it should not be used for operational purposes any more.</xsd:documentation>
 				</xsd:annotation>
-			<xsd:enumeration value="other"/>
+			</xsd:enumeration>
+			<xsd:enumeration value="other">
 				<xsd:annotation>
 					<xsd:documentation>Like draft, proposed, and deprecated, this version should not be used for operational purposes (for other reasons, however). </xsd:documentation>
 				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="VersionTypeEnumeration">

--- a/xsd/netex_framework/netex_responsibility/netex_version_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_version_support.xsd
@@ -129,10 +129,25 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="draft"/>
+				<xsd:annotation>
+					<xsd:documentation>This version is a draft: it is currently under construction and should not be used for operational purposes.</xsd:documentation>
+				</xsd:annotation>
 			<xsd:enumeration value="proposed"/>
+				<xsd:annotation>
+					<xsd:documentation>This version is comprehensive but not yet validated.</xsd:documentation>
+				</xsd:annotation>
 			<xsd:enumeration value="versioned"/>
+				<xsd:annotation>
+					<xsd:documentation>This is a finalised version frozen from further modifications.</xsd:documentation>
+				</xsd:annotation>
 			<xsd:enumeration value="deprecated"/>
+				<xsd:annotation>
+					<xsd:documentation>This is an old version: it should not be used for operational purposes any more.</xsd:documentation>
+				</xsd:annotation>
 			<xsd:enumeration value="other"/>
+				<xsd:annotation>
+					<xsd:documentation>Like draft, proposed, and deprecated, this version should not be used for operational purposes (for other reasons, however). </xsd:documentation>
+				</xsd:annotation>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="VersionTypeEnumeration">


### PR DESCRIPTION
Added annotations to the VersionStatusEnumeration enums. Documentation has been updated as well. PR #180.

Note: I don't see yet how to link this PR to the existing PR 180 (which is intendet to be fixed by the changes).