### PR TITLE
Extended-DatedVehicleJourney+Replace-PR368

### DIFF
--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -6965,7 +6965,7 @@ Correct COnstraints for PointOnRoute
 			<xsd:annotation>
 				<xsd:documentation>Every [VehicleJourney Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:VehicleJourney"/>
+			<xsd:selector xpath=".//netex:VehicleJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>
@@ -6995,12 +6995,12 @@ Correct COnstraints for PointOnRoute
 		</xsd:unique>
 		<!-- =====Journey Key ========================== -->
 		<xsd:keyref name="Journey_KeyRef" refer="netex:Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef | .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef"/>
+			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef | .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef | .//netex:DatedVehicleJourneyRef | .//netex:NormalDatedJourneyRef"/>
 			<xsd:field xpath="@ref"/>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney | .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedServiceJourney"/>
+			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney | .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney | .//netex:DatedServiceJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>

--- a/xsd/NeTEx_publication_timetable.xsd
+++ b/xsd/NeTEx_publication_timetable.xsd
@@ -5606,7 +5606,7 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:annotation>
 				<xsd:documentation>Every [VehicleJourney Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:VehicleJourney"/>
+			<xsd:selector xpath=".//netex:VehicleJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>
@@ -5636,12 +5636,12 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 		</xsd:unique>
 		<!-- =====Journey Key ========================== -->
 		<xsd:keyref name="Journey_KeyRef" refer="netex:Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef| .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef"/>
+			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef| .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef | .//netex:DatedVehicleJourneyRef | .//netex:NormalDatedJourneyRef"/>
 			<xsd:field xpath="@ref"/>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney| .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedServiceJourney"/>
+			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney| .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney | .//netex:DatedServiceJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_support.xsd
@@ -91,6 +91,25 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="DatedVehicleJourneyIdType"/>
 	</xsd:simpleType>
+	<xsd:element name="NormalDatedVehicleJourneyRef" type="VehicleJourneyRefStructure" substitutionGroup="JourneyRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="NormalDatedVehicleJourneyRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+		<xsd:restriction base="VehicleJourneyRefStructure">
+			<xsd:attribute name="ref" type="NormalDatedVehicleJourneyIdType" use="required">
+			<xsd:annotation>
+				<xsd:documentation>Identifier of NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
+			</xsd:annotation>
+			</xsd:attribute>
+		</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
 	<xsd:simpleType name="NormalDatedVehicleJourneyTypeEnumeration">
 		<xsd:annotation>
 			<xsd:documentation>Allowed values for type of NORMAL DATED JOURNEY.</xsd:documentation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -309,7 +309,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 							<xsd:group ref="DatedVehicleJourneyGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="NormalDatedVehicleJourneyIdType" use="optional">
+					<xsd:attribute name="id" type="NormalDatedVehicleJourneyIdType" use="required">
 						<xsd:annotation>
 							<xsd:documentation>Identifier of NORMAL DATED VEHICLE JORUNEY.</xsd:documentation>
 						</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -183,6 +183,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>DATED CALLs  for JOURNEY.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="ServiceAlterationType" type="ServiceAlterationEnumeration" default="planned" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Type of Service alteration. Default is planned.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="DatedVehicleJourneyReferencesGroup">
@@ -191,6 +196,11 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="JourneyRef" minOccurs="0"/>
+			<xsd:element name="replacedJourneys" type="replacedJourneys_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DATED VEHICLE JOURNEYs for which current VEHICLE JOURNEY is an alteration (i.e. change, replacement, supplement)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="OperatingDayRef"/>
 			<xsd:element name="ExternalDatedVehicleJourneyRef" type="ExternalObjectRefStructure" minOccurs="0">
 				<xsd:annotation>
@@ -202,9 +212,26 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Reference to a JOURNEY PATTERN.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="DriverRef" minOccurs="0"/>
+			<xsd:element ref="DriverRef" minOccurs="0">
+			<xsd:annotation>
+					<xsd:documentation>** DEPRECATED ** not to be used - It is expected that the driver's DUTY refer the DatedJourneyPattern, not the way arround !</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
+	<xsd:complexType name="replacedJourneys_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of (NORMAL) DATED VEHICLE JOURNEY references.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="DatedVehicleJourneyRef" maxOccurs="1"/>
+					<xsd:element ref="NormalDatedVehicleJourneyRef" maxOccurs="1"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
 	<!-- ====DATED SERVICE JOURNEY====================================-->
 	<xsd:element name="DatedServiceJourney" abstract="false" substitutionGroup="ServiceJourney_">
 		<xsd:annotation>
@@ -257,7 +284,11 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 				<xsd:element ref="OperatingDayRef"/>
 				<xsd:element ref="UicOperatingPeriod"/>
 			</xsd:choice>
-			<xsd:element ref="DriverRef" minOccurs="0"/>
+			<xsd:element ref="DriverRef" minOccurs="0">
+			<xsd:annotation>
+					<xsd:documentation>** DEPRECATED ** not to be used - It is expected that the driver's DUTY refer the DatedJourneyPattern, not the way arround !</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
@@ -285,9 +316,6 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 						<xsd:sequence>
 							<xsd:group ref="DatedVehicleJourneyGroup"/>
 						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="NormalDatedVehicleJourneyGroup"/>
-						</xsd:sequence>
 					</xsd:sequence>
 					<xsd:attribute name="id" type="NormalDatedVehicleJourneyIdType" use="optional">
 						<xsd:annotation>
@@ -303,25 +331,13 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			<xsd:documentation>Type for NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="DatedVehicleJourney_VersionStructure">
+				<xsd:extension base="VehicleJourney_VersionStructure">
 				<xsd:sequence>
-					<xsd:group ref="NormalDatedVehicleJourneyGroup"/>
+					<xsd:group ref="DatedVehicleJourneyGroup"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:group name="NormalDatedVehicleJourneyGroup">
-		<xsd:annotation>
-			<xsd:documentation>Elements for NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="ServiceAlterationType" type="ServiceAlterationEnumeration" default="planned" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Type of Service alteration. Default is planned.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:group>
 	<!-- ======================================================================= -->
 	<xsd:element name="DatedSpecialService" abstract="false" substitutionGroup="Journey_">
 		<xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -235,7 +235,7 @@ Rail transport, Roads and Road transport
 	<!-- ====DATED SERVICE JOURNEY====================================-->
 	<xsd:element name="DatedServiceJourney" abstract="false" substitutionGroup="ServiceJourney_">
 		<xsd:annotation>
-			<xsd:documentation>A particular journey of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff. 
+			<xsd:documentation>A particular SERVICE JOURNEY of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff. 
 
 The VIEW includes derived ancillary data from referenced entities.</xsd:documentation>
 		</xsd:annotation>
@@ -280,15 +280,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			<xsd:documentation>If the journey is an alteration to a timetable, indicates the original journey, and the nature of the difference.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:choice minOccurs="0">
-				<xsd:element ref="OperatingDayRef"/>
-				<xsd:element ref="UicOperatingPeriod"/>
-			</xsd:choice>
-			<xsd:element ref="DriverRef" minOccurs="0">
-			<xsd:annotation>
-					<xsd:documentation>** DEPRECATED ** not to be used - It is expected that the driver's DUTY refer the DatedJourneyPattern, not the way arround !</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:group ref="DatedVehicleJourneyReferencesGroup"/>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->


### PR DESCRIPTION
Initial PR368 from Kristian Syversen (Kirstian has moved and the PR was not editable ... so it was easier to create a new one). 

This is the exact copy of PR368, but targeting 'next' and not master branch 
It complements it with deprecated DriverRef (DatedJourney are expected to be referenced by driver's DUTY, not the way arround). 

This is conforming the decision from meeting #3 of the NeTEx revision 2022/2023.