### PR TITLE
Single Files Validation issues

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_equipment_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipment_support.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_equipment_support">
 	<xsd:include schemaLocation="../netex_genericFramework/netex_place_support.xsd"/>
 	<xsd:annotation>
@@ -55,6 +54,32 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEX: EQUIPMENT identifier types for NeTEx.</xsd:documentation>
 	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:element name="PlaceEquipmentRef" type="PlaceEquipmentRefStructure" abstract="true" substitutionGroup="InstalledEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PLACE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PlaceEquipmentRefStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an PLACE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="InstalledEquipmentRefStructure">
+				<xsd:attribute name="ref" type="PlaceEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PLACE EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="PlaceEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PLACE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="InstalledEquipmentIdType"/>
+	</xsd:simpleType>	
 	<!-- ======================================================================= -->
 	<xsd:simpleType name="EquipmentIdType">
 		<xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipment_version.xsd
@@ -243,31 +243,6 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="InstalledEquipment_VersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PlaceEquipmentRef" type="PlaceEquipmentRefStructure" abstract="true" substitutionGroup="InstalledEquipmentRef">
-		<xsd:annotation>
-			<xsd:documentation>Reference to a PLACE EQUIPMENT.</xsd:documentation>
-		</xsd:annotation>
-	</xsd:element>
-	<xsd:complexType name="PlaceEquipmentRefStructure" abstract="true">
-		<xsd:annotation>
-			<xsd:documentation>Type for a reference to an PLACE EQUIPMENT.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:restriction base="InstalledEquipmentRefStructure">
-				<xsd:attribute name="ref" type="PlaceEquipmentIdType" use="required">
-					<xsd:annotation>
-						<xsd:documentation>Identifier of a PLACE EQUIPMENT.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:restriction>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:simpleType name="PlaceEquipmentIdType">
-		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a PLACE EQUIPMENT.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="InstalledEquipmentIdType"/>
-	</xsd:simpleType>
 	<xsd:element name="OtherPlaceEquipment" type="PlaceEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Equipment that may be in a fixed within a SITE.</xsd:documentation>


### PR DESCRIPTION
A few SXD files were not valid when used individually (netex_ifopt_equipmentAccess_support.xsd and netex_ifopt_equipmentSigns_support.xsd for example) 
This was solved by simply move PlaceEquipmentRef, PlaceEquipmentRefStructure and PlaceEquipmentIdType from netex_equipment_version.xsd to netex_equipment_support.xsd (which is  quite logical).

This is linked to the CR61 in the 2022-2023 NeTEx Revision