### PR TITLE
examples adapted to new RelativeLevelOrder and RelativeLevelOrder optional and a small validity problem

### DIFF
--- a/examples/functions/stopPlace/FX-PI-01_UK_TBD_STOP-OFFER_910GWIMBLDN-accessibility_20140601.xml
+++ b/examples/functions/stopPlace/FX-PI-01_UK_TBD_STOP-OFFER_910GWIMBLDN-accessibility_20140601.xml
@@ -757,14 +757,17 @@ Changes
 								<Level version="001" created="2010-04-17T09:30:47Z" id="tbd:9100WIMBLDN@Lvl_G0">
 									<Name>Ground </Name>
 									<PublicCode>G</PublicCode>
+									<RelativeLevelOrder>0</RelativeLevelOrder>
 								</Level>
 								<Level version="001" created="2010-04-17T09:30:47Z" id="tbd:9100WIMBLDN@Lvl_PL">
 									<Name>Platform Level</Name>
 									<PublicCode>PL</PublicCode>
+									<RelativeLevelOrder>-1</RelativeLevelOrder>
 								</Level>
 								<Level version="001" created="2010-04-17T09:30:47Z" id="tbd:9100WIMBLDN@Lvl_ST">
 									<Name>Street Level</Name>
 									<PublicCode>ST</PublicCode>
+									<RelativeLevelOrder>+1</RelativeLevelOrder>
 								</Level>
 							</levels>
 							<!-- ============ENTRANCES ===================- -->

--- a/examples/standards/epiap/Chur_Equipment_Pathlink_V1.0.xml
+++ b/examples/standards/epiap/Chur_Equipment_Pathlink_V1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- edited with XMLSpy v2015 rel. 3 (x64) (http://www.altova.com) by Jutta Schmedding (Mentz Datenverarbeitung GmbH) -->
-<PublicationDelivery xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" xsi:schemaLocation="http://www.netex.org.uk/netex  file:///D:/code/netex/xsd/NeTEx_publication.xsd" version="1.10" xmlns="http://www.netex.org.uk/netex">
+<PublicationDelivery xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" xsi:schemaLocation="http://www.netex.org.uk/netex  ../../../xsd/NeTEx_publication.xsd" version="1.10" xmlns="http://www.netex.org.uk/netex">
 	<PublicationTimestamp>2022-04-13T18:38:52.6831392+02:00</PublicationTimestamp>
 	<ParticipantRef>MENTZ</ParticipantRef>
 	<Description>NeTEx Export, Version: 19.16.0.0</Description>
@@ -766,14 +766,23 @@
 								<Level id="ch:1:Level:8509000-0" version="any">
 									<Name lang="de">Erdgeschoss</Name>
 									<ShortName lang="de">G</ShortName>
+									<PublicCode>G</PublicCode>
+									<PublicUse>true</PublicUse>
+									<RelativeLevelOrder>0</RelativeLevelOrder>											
 								</Level>
 								<Level id="ch:1:Level:8509000--1" version="any">
 									<Name lang="de">1. Untergeschoss</Name>
 									<ShortName lang="de">B1</ShortName>
+									<PublicCode>B1</PublicCode>
+									<PublicUse>true</PublicUse>
+									<RelativeLevelOrder>-1</RelativeLevelOrder>											
 								</Level>
 								<Level id="ch:1:Level:8509000--2" version="any">
 									<Name lang="de">2. Untergeschoss</Name>
 									<ShortName lang="de">B2</ShortName>
+									<PublicCode>B2</PublicCode>
+									<PublicUse>true</PublicUse>
+									<RelativeLevelOrder>-2</RelativeLevelOrder>											
 								</Level>
 							</levels>
 							<entrances>
@@ -6075,10 +6084,16 @@
 								<Level id="ch:1:Level:8509681-1" version="any">
 									<Name lang="de">1. Obergeschoss</Name>
 									<ShortName lang="de">F1</ShortName>
+									<PublicCode>F1</PublicCode>
+									<PublicUse>true</PublicUse>
+									<RelativeLevelOrder>1</RelativeLevelOrder>											
 								</Level>
 								<Level id="ch:1:Level:8509681-0" version="any">
 									<Name lang="de">Erdgeschoss</Name>
 									<ShortName lang="de">G</ShortName>
+									<PublicCode>G</PublicCode>
+									<PublicUse>true</PublicUse>
+									<RelativeLevelOrder>0</RelativeLevelOrder>											
 								</Level>
 							</levels>
 							<entrances>
@@ -6766,6 +6781,9 @@
 								<Level id="ch:1:Level:8509790-0" version="any">
 									<Name lang="de">Erdgeschoss</Name>
 									<ShortName lang="de">G</ShortName>
+									<PublicCode>G</PublicCode>
+									<PublicUse>true</PublicUse>
+									<RelativeLevelOrder>0</RelativeLevelOrder>											
 								</Level>
 							</levels>
 							<Weighting>interchangeAllowed</Weighting>
@@ -7368,6 +7386,9 @@
 								<Level id="ch:1:Level:8572111-0" version="any">
 									<Name lang="de">Erdgeschoss</Name>
 									<ShortName lang="de">G</ShortName>
+									<PublicCode>G</PublicCode>
+									<PublicUse>true</PublicUse>
+									<RelativeLevelOrder>0</RelativeLevelOrder>											
 								</Level>
 							</levels>
 							<Weighting>interchangeAllowed</Weighting>
@@ -9334,10 +9355,16 @@
 								<Level id="ch:1:Level:8575112-1" version="any">
 									<Name lang="de">1. Obergeschoss</Name>
 									<ShortName lang="de">F1</ShortName>
+									<PublicCode>F1</PublicCode>
+									<PublicUse>true</PublicUse>
+									<RelativeLevelOrder>1</RelativeLevelOrder>											
 								</Level>
 								<Level id="ch:1:Level:8575112-0" version="any">
 									<Name lang="de">Erdgeschoss</Name>
 									<ShortName lang="de">G</ShortName>
+									<PublicCode>G</PublicCode>
+									<PublicUse>true</PublicUse>
+									<RelativeLevelOrder>0</RelativeLevelOrder>											
 								</Level>
 							</levels>
 							<entrances>
@@ -10056,6 +10083,9 @@
 								<Level id="ch:1:Level:8581044-0" version="any">
 									<Name lang="de">Erdgeschoss</Name>
 									<ShortName lang="de">G</ShortName>
+									<PublicCode>G</PublicCode>
+									<PublicUse>true</PublicUse>
+									<RelativeLevelOrder>0</RelativeLevelOrder>											
 								</Level>
 							</levels>
 							<Weighting>interchangeAllowed</Weighting>
@@ -10442,6 +10472,9 @@
 								<Level id="ch:1:Level:8582835-0" version="any">
 									<Name lang="de">Erdgeschoss</Name>
 									<ShortName lang="de">G</ShortName>
+									<PublicCode>G</PublicCode>
+									<PublicUse>true</PublicUse>
+									<RelativeLevelOrder>0</RelativeLevelOrder>											
 								</Level>
 							</levels>
 							<Weighting>interchangeAllowed</Weighting>

--- a/examples/standards/epiap/Chur_Equipment_Pathlink_V1.0.xml
+++ b/examples/standards/epiap/Chur_Equipment_Pathlink_V1.0.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- edited with XMLSpy v2015 rel. 3 (x64) (http://www.altova.com) by Jutta Schmedding (Mentz Datenverarbeitung GmbH) -->
-<PublicationDelivery xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" xsi:schemaLocation="http://www.netex.org.uk/netex  ../../../xsd/NeTEx_publication.xsd" version="1.10" xmlns="http://www.netex.org.uk/netex">
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" xmlns="http://www.netex.org.uk/netex" xsi:schemaLocation="http://www.netex.org.uk/netex  ../../../xsd/NeTEx_publication.xsd" version="1.10">
 	<PublicationTimestamp>2022-04-13T18:38:52.6831392+02:00</PublicationTimestamp>
 	<ParticipantRef>MENTZ</ParticipantRef>
 	<Description>NeTEx Export, Version: 19.16.0.0</Description>
@@ -768,21 +767,21 @@
 									<ShortName lang="de">G</ShortName>
 									<PublicCode>G</PublicCode>
 									<PublicUse>true</PublicUse>
-									<RelativeLevelOrder>0</RelativeLevelOrder>											
+									<RelativeLevelOrder>0</RelativeLevelOrder>
 								</Level>
 								<Level id="ch:1:Level:8509000--1" version="any">
 									<Name lang="de">1. Untergeschoss</Name>
 									<ShortName lang="de">B1</ShortName>
 									<PublicCode>B1</PublicCode>
 									<PublicUse>true</PublicUse>
-									<RelativeLevelOrder>-1</RelativeLevelOrder>											
+									<RelativeLevelOrder>-1</RelativeLevelOrder>
 								</Level>
 								<Level id="ch:1:Level:8509000--2" version="any">
 									<Name lang="de">2. Untergeschoss</Name>
 									<ShortName lang="de">B2</ShortName>
 									<PublicCode>B2</PublicCode>
 									<PublicUse>true</PublicUse>
-									<RelativeLevelOrder>-2</RelativeLevelOrder>											
+									<RelativeLevelOrder>-2</RelativeLevelOrder>
 								</Level>
 							</levels>
 							<entrances>
@@ -6086,14 +6085,14 @@
 									<ShortName lang="de">F1</ShortName>
 									<PublicCode>F1</PublicCode>
 									<PublicUse>true</PublicUse>
-									<RelativeLevelOrder>1</RelativeLevelOrder>											
+									<RelativeLevelOrder>1</RelativeLevelOrder>
 								</Level>
 								<Level id="ch:1:Level:8509681-0" version="any">
 									<Name lang="de">Erdgeschoss</Name>
 									<ShortName lang="de">G</ShortName>
 									<PublicCode>G</PublicCode>
 									<PublicUse>true</PublicUse>
-									<RelativeLevelOrder>0</RelativeLevelOrder>											
+									<RelativeLevelOrder>0</RelativeLevelOrder>
 								</Level>
 							</levels>
 							<entrances>
@@ -6783,7 +6782,7 @@
 									<ShortName lang="de">G</ShortName>
 									<PublicCode>G</PublicCode>
 									<PublicUse>true</PublicUse>
-									<RelativeLevelOrder>0</RelativeLevelOrder>											
+									<RelativeLevelOrder>0</RelativeLevelOrder>
 								</Level>
 							</levels>
 							<Weighting>interchangeAllowed</Weighting>
@@ -7388,7 +7387,7 @@
 									<ShortName lang="de">G</ShortName>
 									<PublicCode>G</PublicCode>
 									<PublicUse>true</PublicUse>
-									<RelativeLevelOrder>0</RelativeLevelOrder>											
+									<RelativeLevelOrder>0</RelativeLevelOrder>
 								</Level>
 							</levels>
 							<Weighting>interchangeAllowed</Weighting>
@@ -9357,14 +9356,14 @@
 									<ShortName lang="de">F1</ShortName>
 									<PublicCode>F1</PublicCode>
 									<PublicUse>true</PublicUse>
-									<RelativeLevelOrder>1</RelativeLevelOrder>											
+									<RelativeLevelOrder>1</RelativeLevelOrder>
 								</Level>
 								<Level id="ch:1:Level:8575112-0" version="any">
 									<Name lang="de">Erdgeschoss</Name>
 									<ShortName lang="de">G</ShortName>
 									<PublicCode>G</PublicCode>
 									<PublicUse>true</PublicUse>
-									<RelativeLevelOrder>0</RelativeLevelOrder>											
+									<RelativeLevelOrder>0</RelativeLevelOrder>
 								</Level>
 							</levels>
 							<entrances>
@@ -10085,7 +10084,7 @@
 									<ShortName lang="de">G</ShortName>
 									<PublicCode>G</PublicCode>
 									<PublicUse>true</PublicUse>
-									<RelativeLevelOrder>0</RelativeLevelOrder>											
+									<RelativeLevelOrder>0</RelativeLevelOrder>
 								</Level>
 							</levels>
 							<Weighting>interchangeAllowed</Weighting>
@@ -10474,7 +10473,7 @@
 									<ShortName lang="de">G</ShortName>
 									<PublicCode>G</PublicCode>
 									<PublicUse>true</PublicUse>
-									<RelativeLevelOrder>0</RelativeLevelOrder>											
+									<RelativeLevelOrder>0</RelativeLevelOrder>
 								</Level>
 							</levels>
 							<Weighting>interchangeAllowed</Weighting>

--- a/examples/standards/norway/Full_PublicationDelivery_109_Oslo_morningbus_example.xml
+++ b/examples/standards/norway/Full_PublicationDelivery_109_Oslo_morningbus_example.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ===Simple Timetable  Example=== -->
 <!-- This example show the timetable for route 109 morning express in Oslo. -->
-<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:siri="http://www.siri.org.uk/siri" version="1.04:NO-NeTEx-networktimetable:1.0" xsi:schemaLocation="http://www.netex.org.uk/netex ../../NeTEx-XML/schema/xsd/NeTEx_publication.xsd">
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:siri="http://www.siri.org.uk/siri" version="1.04:NO-NeTEx-networktimetable:1.0" xsi:schemaLocation="http://www.netex.org.uk/netex ../../../xsd/NeTEx_publication.xsd">
 	<PublicationTimestamp>2016-05-23T12:00:00.0Z</PublicationTimestamp>
 	<ParticipantRef>NSR</ParticipantRef>
 	<dataObjects>
@@ -233,10 +233,10 @@
 							<LineRef ref="UNI:line:109"/>
 							<DirectionType>outbound</DirectionType>
 							<pointsInSequence>
-								<PointOnRoute version="any" id="UNI:PointOnRoute:109-start">
+								<PointOnRoute version="any" id="UNI:PointOnRoute:109-start" order="1">
 									<RoutePointRef version="any" ref="UNI:RoutePoint:helsfyr"/>
 								</PointOnRoute>
-								<PointOnRoute version="any" id="UNI:PointOnRoute:109-end">
+								<PointOnRoute version="any" id="UNI:PointOnRoute:109-end" order="2">
 									<RoutePointRef version="any" ref="UNI:RoutePoint:holtet"/>
 								</PointOnRoute>
 							</pointsInSequence>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
@@ -600,7 +600,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Whether level is for public use.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="RelativeLevelOrder" type="xsd:integer">
+			<xsd:element name="RelativeLevelOrder" type="xsd:integer" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Order of LEVELs. The level numbers are not absolute, but only give a relative order within the SITE. 0 should be the ground floor, even when it is often difficult to determine which one that is in a complex structure. Complex buildings can be modelled with multiple SITEs and referenced by SiteRef.</xsd:documentation>
 				</xsd:annotation>


### PR DESCRIPTION
And RelativeLevelOrder optional. We otherwise have examples that break. And it might be that people don't wish to use them.

Fixed:
* Examples for RelativeLevelOrder
* RelativeLevelOrder now optional
* order missing in an example