### PR TITLE
XSD Validation issue

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_equipment_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipment_support.xsd
@@ -235,8 +235,8 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Type for identifier of a PLACE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="InstalledEquipmentIdType"/>
-	</xsd:simpleType>	
-	<!-- ======================================================================= -->	
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
 	<xsd:simpleType name="EquipmentStatusEnumeration">
 		<xsd:annotation>
 			<xsd:documentation>Allowed values for status of EQUIPMENT.</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipment_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipment_support.xsd
@@ -211,6 +211,32 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
+	<xsd:element name="PlaceEquipmentRef" type="PlaceEquipmentRefStructure" abstract="true" substitutionGroup="InstalledEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PLACE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PlaceEquipmentRefStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an PLACE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="InstalledEquipmentRefStructure">
+				<xsd:attribute name="ref" type="PlaceEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PLACE EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="PlaceEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PLACE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="InstalledEquipmentIdType"/>
+	</xsd:simpleType>	
+	<!-- ======================================================================= -->	
 	<xsd:simpleType name="EquipmentStatusEnumeration">
 		<xsd:annotation>
 			<xsd:documentation>Allowed values for status of EQUIPMENT.</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipment_version.xsd
@@ -241,31 +241,6 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="InstalledEquipment_VersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PlaceEquipmentRef" type="PlaceEquipmentRefStructure" abstract="true" substitutionGroup="InstalledEquipmentRef">
-		<xsd:annotation>
-			<xsd:documentation>Reference to a PLACE EQUIPMENT.</xsd:documentation>
-		</xsd:annotation>
-	</xsd:element>
-	<xsd:complexType name="PlaceEquipmentRefStructure" abstract="true">
-		<xsd:annotation>
-			<xsd:documentation>Type for a reference to an PLACE EQUIPMENT.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:restriction base="InstalledEquipmentRefStructure">
-				<xsd:attribute name="ref" type="PlaceEquipmentIdType" use="required">
-					<xsd:annotation>
-						<xsd:documentation>Identifier of a PLACE EQUIPMENT.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:restriction>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:simpleType name="PlaceEquipmentIdType">
-		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a PLACE EQUIPMENT.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="InstalledEquipmentIdType"/>
-	</xsd:simpleType>
 	<xsd:element name="OtherPlaceEquipment" type="PlaceEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Equipment that may be in a fixed within a SITE.</xsd:documentation>


### PR DESCRIPTION
A few SXD files were not valid when used individually (netex_ifopt_equipmentAccess_support.xsd and netex_ifopt_equipmentSigns_support.xsd for example) This was solved by simply move PlaceEquipmentRef, PlaceEquipmentRefStructure and PlaceEquipmentIdType from netex_equipment_version.xsd to netex_equipment_support.xsd (which is quite logical)