### PR TITLE
Changes to netex_datedVehicleJourney_version v3

### DIFF
--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -202,7 +202,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="DriverRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ====DATED SERVICE JOURNEY====================================-->
+<!-- ====DATED SERVICE JOURNEY====================================-->
 	<xsd:element name="DatedServiceJourney" abstract="false" substitutionGroup="ServiceJourney_">
 		<xsd:annotation>
 			<xsd:documentation>A particular SERVICE JOURNEY on a particular OPERATING DAY including all modifications possibly decided by the control staff. 
@@ -233,6 +233,18 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
+	<xsd:complexType name="DatedServiceJourney_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Data type for Planned VEHICLE JOURNEY (Production Timetable Service).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ServiceJourney_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="DatedServiceJourneyGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
 	<xsd:group name="DatedServiceJourneyGroup">
 		<xsd:annotation>
 			<xsd:documentation>If the journey is an alteration to a timetable, indicates the original journey, and the nature of the difference.</xsd:documentation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -205,7 +205,7 @@ Rail transport, Roads and Road transport
 	<!-- ====DATED SERVICE JOURNEY====================================-->
 	<xsd:element name="DatedServiceJourney" abstract="false" substitutionGroup="ServiceJourney_">
 		<xsd:annotation>
-			<xsd:documentation>A particular journey of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff. 
+			<xsd:documentation>A particular SERVICE JOURNEY on a particular OPERATING DAY including all modifications possibly decided by the control staff. 
 
 The VIEW includes derived ancillary data from referenced entities.</xsd:documentation>
 		</xsd:annotation>
@@ -233,27 +233,20 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="DatedServiceJourney_VersionStructure" abstract="false">
-		<xsd:annotation>
-			<xsd:documentation>Data type for Planned VEHICLE JOURNEY (Production Timetable Service).</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="ServiceJourney_VersionStructure">
-				<xsd:sequence>
-					<xsd:group ref="DatedServiceJourneyGroup"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
 	<xsd:group name="DatedServiceJourneyGroup">
 		<xsd:annotation>
 			<xsd:documentation>If the journey is an alteration to a timetable, indicates the original journey, and the nature of the difference.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:choice minOccurs="0">
-				<xsd:element ref="OperatingDayRef"/>
-				<xsd:element ref="UicOperatingPeriod"/>
-			</xsd:choice>
+			<xsd:element ref="OperatingDayRef" minOccurs="1"/>
+			<xsd:element ref="JourneyRef" minOccurs="0"/>
+			<xsd:element name="replacedJourneys" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence maxOccurs="unbounded">
+						<xsd:element name="DatedServiceJourneyRef" type="DatedVehicleJourneyRefStructure" minOccurs="0"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
 			<xsd:element ref="DriverRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>


### PR DESCRIPTION
Changed annotation
Made OperatingDayRef mandatory and first in sequence
removed UicOperatingPeriod
Added JourneyRef
Added replacedJourneys and DatedServiceJourneyRef