### PR TITLE
Rail dated journey fix without example updates

### DIFF
--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -6921,7 +6921,7 @@ Correct COnstraints for PointOnRoute
 			<xsd:annotation>
 				<xsd:documentation>Every [VehicleJourney Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:VehicleJourney"/>
+			<xsd:selector xpath=".//netex:VehicleJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>
@@ -6951,12 +6951,12 @@ Correct COnstraints for PointOnRoute
 		</xsd:unique>
 		<!-- =====Journey Key ========================== -->
 		<xsd:keyref name="Journey_KeyRef" refer="netex:Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef | .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef"/>
+			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef | .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef | .//netex:DatedVehicleJourneyRef | .//netex:NormalDatedJourneyRef"/>
 			<xsd:field xpath="@ref"/>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney | .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedServiceJourney"/>
+			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney | .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedServiceJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>

--- a/xsd/NeTEx_publication_timetable.xsd
+++ b/xsd/NeTEx_publication_timetable.xsd
@@ -5594,7 +5594,7 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:annotation>
 				<xsd:documentation>Every [VehicleJourney Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:VehicleJourney"/>
+			<xsd:selector xpath=".//netex:VehicleJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>
@@ -5624,12 +5624,12 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 		</xsd:unique>
 		<!-- =====Journey Key ========================== -->
 		<xsd:keyref name="Journey_KeyRef" refer="netex:Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef| .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef"/>
+			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef | .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef | .//netex:DatedVehicleJourneyRef | .//netex:NormalDatedJourneyRef"/>
 			<xsd:field xpath="@ref"/>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney| .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedServiceJourney"/>
+			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney | .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedServiceJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_support.xsd
@@ -101,13 +101,13 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Type for a reference to a NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
-		<xsd:restriction base="VehicleJourneyRefStructure">
-			<xsd:attribute name="ref" type="NormalDatedVehicleJourneyIdType" use="required">
-			<xsd:annotation>
-				<xsd:documentation>Identifier of NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
-			</xsd:annotation>
-			</xsd:attribute>
-		</xsd:restriction>
+			<xsd:restriction base="VehicleJourneyRefStructure">
+				<xsd:attribute name="ref" type="NormalDatedVehicleJourneyIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<xsd:simpleType name="NormalDatedVehicleJourneyTypeEnumeration">

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_support.xsd
@@ -91,6 +91,25 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="DatedVehicleJourneyIdType"/>
 	</xsd:simpleType>
+	<xsd:element name="NormalDatedVehicleJourneyRef" type="VehicleJourneyRefStructure" substitutionGroup="JourneyRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="NormalDatedVehicleJourneyRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+		<xsd:restriction base="VehicleJourneyRefStructure">
+			<xsd:attribute name="ref" type="NormalDatedVehicleJourneyIdType" use="required">
+			<xsd:annotation>
+				<xsd:documentation>Identifier of NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
+			</xsd:annotation>
+			</xsd:attribute>
+		</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
 	<xsd:simpleType name="NormalDatedVehicleJourneyTypeEnumeration">
 		<xsd:annotation>
 			<xsd:documentation>Allowed values for type of NORMAL DATED JOURNEY.</xsd:documentation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_dateVehicleJourney_version">
 	<xsd:include schemaLocation="netex_datedVehicleJourney_support.xsd"/>
 	<xsd:include schemaLocation="netex_serviceJourney_version.xsd"/>
@@ -17,9 +18,11 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date><Modified>2011-02-05</Modified>Name Space changes  
+				<Date>
+					<Modified>2011-02-05</Modified>Name Space changes  
 				</Date>
-				<Date><Modified>2020-07-29</Modified>Issue #97 Add NormalDatedJourney and DatedVehicleJourney journeys  in timetableframe
+				<Date>
+					<Modified>2020-07-29</Modified>Issue #97 Add NormalDatedJourney and DatedVehicleJourney journeys  in timetableframe
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -180,6 +183,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>DATED CALLs  for JOURNEY.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="ServiceAlterationType" type="ServiceAlterationEnumeration" default="planned" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Type of Service alteration. Default is planned.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="DatedVehicleJourneyReferencesGroup">
@@ -188,7 +196,21 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="JourneyRef" minOccurs="0"/>
-			<xsd:element ref="OperatingDayRef"/>
+			<xsd:element name="replacedJourneys" type="replacedJourneys_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DATED VEHICLE JOURNEYs for which current VEHICLE JOURNEY is an alteration (i.e. change, replacement, supplement)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="OperatingDayRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>EXPECTED TO BE MANDATORY - left with minOccurs="0" only to avoid breaking compatibility with old rail datasets</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="UicOperatingPeriod" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>** DEPRECATED ** not to be used - left available only to avoid breaking compatibility with old rail datasets</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="ExternalDatedVehicleJourneyRef" type="ExternalObjectRefStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>An alternative  code that uniquely identifies theDATED  VEHICLE  JOURNEY. Specifically for use in AVMS systems. For VDV compatibility.</xsd:documentation>
@@ -199,13 +221,30 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Reference to a JOURNEY PATTERN.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="DriverRef" minOccurs="0"/>
+			<xsd:element ref="DriverRef" minOccurs="0">
+			<xsd:annotation>
+					<xsd:documentation>** DEPRECATED ** not to be used - It is expected that the driver's DUTY refer the DatedJourneyPattern, not the way arround !</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
+	<xsd:complexType name="replacedJourneys_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of (NORMAL) DATED VEHICLE JOURNEY references.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="DatedVehicleJourneyRef" maxOccurs="1"/>
+					<xsd:element ref="NormalDatedVehicleJourneyRef" maxOccurs="1"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
 	<!-- ====DATED SERVICE JOURNEY====================================-->
 	<xsd:element name="DatedServiceJourney" abstract="false" substitutionGroup="ServiceJourney_">
 		<xsd:annotation>
-			<xsd:documentation>A particular journey of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff. 
+			<xsd:documentation>A particular SERVICE JOURNEY of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff. 
 
 The VIEW includes derived ancillary data from referenced entities.</xsd:documentation>
 		</xsd:annotation>
@@ -250,11 +289,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			<xsd:documentation>If the journey is an alteration to a timetable, indicates the original journey, and the nature of the difference.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:choice minOccurs="0">
-				<xsd:element ref="OperatingDayRef"/>
-				<xsd:element ref="UicOperatingPeriod"/>
-			</xsd:choice>
-			<xsd:element ref="DriverRef" minOccurs="0"/>
+			<xsd:group ref="DatedVehicleJourneyReferencesGroup"/>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
@@ -282,11 +317,8 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 						<xsd:sequence>
 							<xsd:group ref="DatedVehicleJourneyGroup"/>
 						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="NormalDatedVehicleJourneyGroup"/>
-						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="NormalDatedVehicleJourneyIdType" use="optional">
+					<xsd:attribute name="id" type="NormalDatedVehicleJourneyIdType" use="required">
 						<xsd:annotation>
 							<xsd:documentation>Identifier of NORMAL DATED VEHICLE JORUNEY.</xsd:documentation>
 						</xsd:annotation>
@@ -300,25 +332,13 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			<xsd:documentation>Type for NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="DatedVehicleJourney_VersionStructure">
+				<xsd:extension base="VehicleJourney_VersionStructure">
 				<xsd:sequence>
-					<xsd:group ref="NormalDatedVehicleJourneyGroup"/>
+					<xsd:group ref="DatedVehicleJourneyGroup"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:group name="NormalDatedVehicleJourneyGroup">
-		<xsd:annotation>
-			<xsd:documentation>Elements for NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="ServiceAlterationType" type="ServiceAlterationEnumeration" default="planned" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Type of Service alteration. Default is planned.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:group>
 	<!-- ======================================================================= -->
 	<xsd:element name="DatedSpecialService" abstract="false" substitutionGroup="Journey_">
 		<xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_dateVehicleJourney_version">
 	<xsd:include schemaLocation="netex_datedVehicleJourney_support.xsd"/>
 	<xsd:include schemaLocation="netex_serviceJourney_version.xsd"/>
@@ -18,11 +17,9 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date>
-					<Modified>2011-02-05</Modified>Name Space changes  
+				<Date><Modified>2011-02-05</Modified>Name Space changes  
 				</Date>
-				<Date>
-					<Modified>2020-07-29</Modified>Issue #97 Add NormalDatedJourney and DatedVehicleJourney journeys  in timetableframe
+				<Date><Modified>2020-07-29</Modified>Issue #97 Add NormalDatedJourney and DatedVehicleJourney journeys  in timetableframe
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -222,7 +219,7 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="DriverRef" minOccurs="0">
-			<xsd:annotation>
+				<xsd:annotation>
 					<xsd:documentation>** DEPRECATED ** not to be used - It is expected that the driver's DUTY refer the DatedJourneyPattern, not the way arround !</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
@@ -332,7 +329,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			<xsd:documentation>Type for NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-				<xsd:extension base="VehicleJourney_VersionStructure">
+			<xsd:extension base="VehicleJourney_VersionStructure">
 				<xsd:sequence>
 					<xsd:group ref="DatedVehicleJourneyGroup"/>
 				</xsd:sequence>


### PR DESCRIPTION
Update of the Pr411 (that was merged and rolled back due to issues with examples uising UIC periods) and PR518 (broken for whatever github reason)

This version integrates the decisions from the Meeting # 13 and # 14:

Update of examples to use OperatingDayRef in dated jouneys (keep the old UIC periods commented with an explicit mention of the deprecation).
UicOperatingPeriod deletion is now replaced by a simple deprecation (clearly stated in comments) for backward compatibility reasons.