### PR TITLE
Remove OpeningNecessaryForce

### DIFF
--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -1242,11 +1242,6 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Whether there is an audio signal indicating passing through</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="OpeningNecessaryForce" type="NecessaryForceEnumeration" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Necessary force to open the door</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->


### PR DESCRIPTION
Fix #539.

Duplicate introduced here, date suggests 2019, actually 2022.
```
                                <Date><Modified>2019-03-25</Modified>FR49 CD #65  Accessibility changes
CD Add new attributes  to EntranceEquipment: AudioOrVideoIntercom, Airlock, DoorstepMark AudioPassthroughIndicator, OpeningNecessaryForce
```    

https://github.com/NeTEx-CEN/NeTEx/commit/e7242a0377fb37fa06dad36918989f620db900ef