### PR TITLE
Enhance door control element height (Fix #541)

### DIFF
--- a/examples/functions/stopPlace/Netex_10_StopPlace_withParking_1.xml
+++ b/examples/functions/stopPlace/Netex_10_StopPlace_withParking_1.xml
@@ -1017,6 +1017,7 @@ Changes
 										<EntranceEquipment version="any" id="nptg:9100WIMBLDN_A2b-EI5_e1">
 											<Door>true</Door>
 											<KeptOpen>true</KeptOpen>
+											<DoorControlElementHeight>0.8</DoorControlElementHeight>
 											<WheelchairPassable>true</WheelchairPassable>
 										</EntranceEquipment>
 									</placeEquipments>
@@ -1035,6 +1036,7 @@ Changes
 										<EntranceEquipment version="any" id="nptg:9100WIMBLDN_A2b-EI6">
 											<Door>true</Door>
 											<KeptOpen>true</KeptOpen>
+											<DoorControlElementHeight>0.8</DoorControlElementHeight>
 											<WheelchairPassable>true</WheelchairPassable>
 										</EntranceEquipment>
 									</placeEquipments>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -1192,6 +1192,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Whether doors are automatic.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="DoorControlElementHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Indicates door control element height (in centimeter)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="GlassDoor" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Whether door is made of glass.</xsd:documentation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -1194,7 +1194,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="DoorControlElementHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Indicates door control element height (in centimeter). This could be e.g. a door handle or a door button</xsd:documentation>
+					<xsd:documentation>Indicates door control element height. This could be e.g. a door handle or a door button.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="GlassDoor" type="xsd:boolean" minOccurs="0">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -1194,7 +1194,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="DoorControlElementHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Indicates door control element height (in centimeter)</xsd:documentation>
+					<xsd:documentation>Indicates door control element height (in centimeter). This could be e.g. a door handle or a door button</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="GlassDoor" type="xsd:boolean" minOccurs="0">


### PR DESCRIPTION
We would like to add the door control element height to the 'EntranceAccessibilityGroup'. This could be e.g. a door handle or a door button. 