### PR TITLE
Add external ref to StopPlace and Quay (Fix #451)

### DIFF
--- a/xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd
@@ -60,7 +60,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="Assignment_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation>Dummy Abstract Assignment. An Assignment assigns a property to an other element. It has a name and an order.</xsd:documentation>
+			<xsd:documentation>Dummy Abstract Assignment. An Assignment assigns a property to another element. It has a name and an order.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="Assignment_VersionStructure_" abstract="true">

--- a/xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd
@@ -82,7 +82,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:group name="AssignmentGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for an ASSIGNMENT. An ASSIGNMENT assigns a property to an another element. It has a name and an order.</xsd:documentation>
+			<xsd:documentation>Elements for an ASSIGNMENT. An ASSIGNMENT assigns a property to another element. It has a name and an order.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="Name" type="MultilingualString" minOccurs="0">

--- a/xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd
@@ -99,7 +99,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:element name="Assignment" abstract="true" substitutionGroup="Assignment_">
 		<xsd:annotation>
-			<xsd:documentation>A set of properties to be applied to an another element. It has a name and an order.</xsd:documentation>
+			<xsd:documentation>A set of properties to be applied to another element. It has a name and an order.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd
@@ -60,12 +60,12 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="Assignment_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation>Dummy Abstract Assignment An Assignment assigns a property to an assignment element. It has a name and n order.</xsd:documentation>
+			<xsd:documentation>Dummy Abstract Assignment. An Assignment assigns a property to an other element. It has a name and an order.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="Assignment_VersionStructure_" abstract="true">
 		<xsd:annotation>
-			<xsd:documentation>Type for  ASSIGNMENT.</xsd:documentation>
+			<xsd:documentation>Type for ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="DataManagedObjectStructure">
@@ -74,7 +74,7 @@ Rail transport, Roads and Road transport
 				</xsd:sequence>
 				<xsd:attribute name="order" type="xsd:integer">
 					<xsd:annotation>
-						<xsd:documentation>Order in which to show  ASSIGNMENT,</xsd:documentation>
+						<xsd:documentation>Order in which to show an ASSIGNMENT.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>
@@ -82,7 +82,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:group name="AssignmentGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for an ASSIGNMENT. An Assignment assignes a property to an aelent element. It has a name and n order.</xsd:documentation>
+			<xsd:documentation>Elements for an ASSIGNMENT. An ASSIGNMENT assigns a property to an another element. It has a name and an order.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
@@ -92,14 +92,14 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="Description" type="MultilingualString" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Description of  ASSIGNMENT.</xsd:documentation>
+					<xsd:documentation>Description of ASSIGNMENT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:element name="Assignment" abstract="true" substitutionGroup="Assignment_">
 		<xsd:annotation>
-			<xsd:documentation>A set of properties to be applied  to an another element. It has a name and an order.</xsd:documentation>
+			<xsd:documentation>A set of properties to be applied to an another element. It has a name and an order.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -122,7 +122,7 @@ Rail transport, Roads and Road transport
 	</xsd:element>
 	<xsd:complexType name="Assignment_VersionStructure" abstract="true">
 		<xsd:annotation>
-			<xsd:documentation>Type for  ASSIGNMENT.</xsd:documentation>
+			<xsd:documentation>Type for ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:restriction base="Assignment_VersionStructure_">

--- a/xsd/netex_framework/netex_reusableComponents/netex_mode_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_mode_support.xsd
@@ -273,7 +273,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="funicular">
 				<xsd:annotation>
-					<xsd:documentation>cable railway on steep slope using two counterbalanced carriages.</xsd:documentation>
+					<xsd:documentation>cable railway on steep slope, typcially using two counterbalanced carriages.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="snowAndIce">

--- a/xsd/netex_framework/netex_reusableComponents/netex_mode_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_mode_support.xsd
@@ -82,7 +82,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="car"/>
 			<xsd:enumeration value="taxi">
 				<xsd:annotation>
-					<xsd:documentation>Taxi can now be modeled as VEHICLE MODE as well.</xsd:documentation>
+					<xsd:documentation>Taxi can now be modelled as VEHICLE MODE as well.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="shuttle"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_mode_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_mode_support.xsd
@@ -273,7 +273,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="funicular">
 				<xsd:annotation>
-					<xsd:documentation>cable railway on steep slope, typcially using two counterbalanced carriages.</xsd:documentation>
+					<xsd:documentation>cable railway on steep slope, typically using two counterbalanced carriages.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="snowAndIce">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
@@ -350,7 +350,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="ExternalStopPlaceRef" type="ExternalObjectRefStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>An alternative code that uniquely identifies the STOP PLACE. Specifically for use in AVMS systems that require an alias, if. For VDV compatibility.</xsd:documentation>
+					<xsd:documentation>An alternative code that uniquely identifies the STOP PLACE. Specifically for use in AVMS systems that require an alias. For VDV compatibility.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
@@ -348,6 +348,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Short public code for passengers to use when uniquely identifying the stop by SMS and other self-service channels.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="ExternalStopPlaceRef" type="ExternalObjectRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>An alternative code that uniquely identifies the STOP PLACE. Specifically for use in AVMS systems that require an alias, if. For VDV compatibility.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:complexType name="AliasStructure">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
@@ -584,6 +584,11 @@ contained within its parent QUAY.</xsd:documentation>
 					<xsd:documentation>A 20 bit number used for wireless cleardown of stop displays by some AVL systems.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="ExternalQuayRef" type="ExternalObjectRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>An alternative code that uniquely identifies the QUAY. Specifically for use in AVMS and journey planning systems that require an alias, if. For VDV compatibility.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
@@ -586,7 +586,7 @@ contained within its parent QUAY.</xsd:documentation>
 			</xsd:element>
 			<xsd:element name="ExternalQuayRef" type="ExternalObjectRefStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>An alternative code that uniquely identifies the QUAY. Specifically for use in AVMS and journey planning systems that require an alias, if. For VDV compatibility.</xsd:documentation>
+					<xsd:documentation>An alternative code that uniquely identifies the QUAY. Specifically for use in AVMS and journey planning systems that require an alias. For VDV compatibility.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>


### PR DESCRIPTION
This is the agreed fix for issue #451 .
New Elements ExternalStopPlaceRef and ExternalQuayRef are added to StopPlace and Quay. 
They can be used for storing national stop and quay identifiers in the case where these do not conform to the ID format described in EPIP .
