### PR TITLE
Update netex_usageParameterEligibility_version.xsd

### DIFF
--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
@@ -464,17 +464,19 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Parent USER PROFILE or GROUP TICKET for which this  specifes the member rules.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="UserProfileRef" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>DEPRECATED: use list of userProfiles - kept for backwards compatibility</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="userProfiles" minOccurs="0" type="userProfileRefs_RelStructure">
-				<xsd:annotation>
-					<xsd:documentation>The user profiles that are eligible to be a companion. If more than one, this list describes a possible set of ORed USER PROFILES that can be used interchangeably as the same COMPANION PROFILE, 
+			<xsd:choice>
+				<xsd:element ref="UserProfileRef" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED: use list of userProfiles - kept for backwards compatibility</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="userProfiles" type="userProfileRefs_RelStructure" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>The user profiles that are eligible to be a companion. If more than one, this list describes a possible set of ORed USER PROFILES that can be used interchangeably as the same COMPANION PROFILE, 
 						e.g. profile 1 OR profile 2. </xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
 			<xsd:element name="CompanionRelationshipType" type="CompanionRelationshipEnumeration" default="anyone" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Required Relationship of companion to eliigble user +V1.1.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
@@ -464,7 +464,15 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Parent USER PROFILE or GROUP TICKET for which this  specifes the member rules.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="UserProfileRef" minOccurs="0"/>
+			<xsd:choice minOccurs="0">
+				<xsd:element ref="UserProfileRef" minOccurs="0"/>
+				<xsd:element name="userProfiles" minOccurs="0" type="userProfileRefs_RelStructure">
+					<xsd:annotation>
+						<xsd:documentation>A possible set of ORed USER PROFILES that can be used interchangeably as the same COMPANION PROFILE, 
+							e.g. profile 1 OR profile 2. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
 			<xsd:element name="CompanionRelationshipType" type="CompanionRelationshipEnumeration" default="anyone" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Required Relationship of companion to eliigble user +V1.1.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
@@ -479,7 +479,7 @@ Rail transport, Roads and Road transport
 			</xsd:choice>
 			<xsd:element name="CompanionRelationshipType" type="CompanionRelationshipEnumeration" default="anyone" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Required Relationship of companion to eliigble user +V1.1.</xsd:documentation>
+					<xsd:documentation>Required Relationship of companion to eligible user. +V1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="MinimumNumberOfPersons" type="NumberOfPassengers" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
@@ -464,15 +464,17 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Parent USER PROFILE or GROUP TICKET for which this  specifes the member rules.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:choice minOccurs="0">
-				<xsd:element ref="UserProfileRef" minOccurs="0"/>
-				<xsd:element name="userProfiles" minOccurs="0" type="userProfileRefs_RelStructure">
-					<xsd:annotation>
-						<xsd:documentation>A possible set of ORed USER PROFILES that can be used interchangeably as the same COMPANION PROFILE, 
-							e.g. profile 1 OR profile 2. </xsd:documentation>
-					</xsd:annotation>
-				</xsd:element>
-			</xsd:choice>
+			<xsd:element ref="UserProfileRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED: use list of userProfiles - kept for backwards compatibility</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="userProfiles" minOccurs="0" type="userProfileRefs_RelStructure">
+				<xsd:annotation>
+					<xsd:documentation>The user profiles that are eligible to be a companion. If more than one, this list describes a possible set of ORed USER PROFILES that can be used interchangeably as the same COMPANION PROFILE, 
+						e.g. profile 1 OR profile 2. </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="CompanionRelationshipType" type="CompanionRelationshipEnumeration" default="anyone" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Required Relationship of companion to eliigble user +V1.1.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
@@ -473,7 +473,7 @@ Rail transport, Roads and Road transport
 				<xsd:element name="userProfiles" type="userProfileRefs_RelStructure" minOccurs="0">
 					<xsd:annotation>
 						<xsd:documentation>The user profiles that are eligible to be a companion. If more than one, this list describes a possible set of ORed USER PROFILES that can be used interchangeably as the same COMPANION PROFILE, 
-						e.g. profile 1 OR profile 2. </xsd:documentation>
+						e.g. profile 1 OR profile 2. +V2.0</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>


### PR DESCRIPTION
Following the discussion on Basecamp (https://3.basecamp.com/3256016/buckets/2570434/messages/6590868001) we would like to add the possibility to use a list of ORed UserProfiles to CompanionProfile. This is especially useful when prices are the same for several profiles and there are minimum/maximum requirements for more than one UserProfile, e.g. 1-2 adult OR senior OR student if travelling with children as a group
