### PR TITLE
Deckplan seating plan (redo of 571, 574 and 575)

### DIFF
--- a/NeTEx.spp
+++ b/NeTEx.spp
@@ -147,7 +147,7 @@
 					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_securityList_version.xsd" HomeFolder="Yes"/>
 					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_serviceRestrictions_support.xsd" HomeFolder="Yes"/>
 					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_serviceRestrictions_version.xsd" HomeFolder="Yes"/>
-				</Folder>			
+				</Folder>
 				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_all_objects_reusableComponents.xsd"/>
 			</Folder>
 			<Folder FolderName="netex_framework_frames">
@@ -203,7 +203,7 @@
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_all_objects_part1_tacticalPlanning.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_commonSection_support.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_commonSection_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_deckPlan_support.xsd"/>				
+				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_deckPlan_support.xsd"/>
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_fareZone_support.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_fareZone_version.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_journeyPattern_support.xsd" HomeFolder="Yes"/>
@@ -298,7 +298,7 @@
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_deckEntranceAlignment_support.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_deckEntranceAlignment_version.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_deckPlanAssignment_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_deckPlanAssignment_version.xsd" HomeFolder="Yes"/>				
+				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_deckPlanAssignment_version.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_flexibleService_support.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_flexibleService_version.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_interchange_support.xsd" HomeFolder="Yes"/>
@@ -773,7 +773,7 @@
 				</Folder>
 				<Folder FolderName="deckPlans">
 					<File FilePath="examples\functions\deckPlans\DeckPlans-Example.xml" HomeFolder="Yes"/>
-				</Folder>				
+				</Folder>
 			</Folder>
 			<Folder FolderName="standards">
 				<Folder FolderName="noptis">
@@ -1018,5 +1018,6 @@
 		<File FilePath="xsd\netex_part_2\part2_frames\netex_timetableFrame_version.xsd"/>
 		<File FilePath="xsd\netex_part_2\part2_frames\netex_vehicleScheduleFrame_version.xsd"/>
 	</Folder>
+	<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_seatingPlan_support.xsd"/>
 	<File FilePath="README.md" HomeFolder="Yes"/>
 </Project>

--- a/NeTEx.spp
+++ b/NeTEx.spp
@@ -78,55 +78,77 @@
 				<File FilePath="xsd\netex_framework\netex_genericFramework\netex_zoneProjection_version.xsd" HomeFolder="Yes"/>
 			</Folder>
 			<Folder FolderName="netex_reusableComponents_TM_RC">
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_access_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_address_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_address_version.xsd" HomeFolder="Yes"/>
+				<Folder FolderName="modes_RC">
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_mode_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_mode_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_modeOfOperation_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_modeOfOperation_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_submode_version.xsd" HomeFolder="Yes"/>
+				</Folder>
+				<Folder FolderName="time_related_RC">
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_availabilityCondition_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_availabilityCondition_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_dayType_propertiesOfDay.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_dayType_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_dayType_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_serviceCalendar_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_serviceCalendar_version.xsd" HomeFolder="Yes"/>
+				</Folder>
+				<Folder FolderName="organisations_RC">
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_otherOrganisation_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_otherOrganisation_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_transportOrganisation_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_transportOrganisation_version.xsd" HomeFolder="Yes"/>
+				</Folder>
+				<Folder FolderName="places_RC">
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_access_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_address_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_address_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_country_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_topographicPlace_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_topographicPlace_version.xsd" HomeFolder="Yes"/>
+				</Folder>
+				<Folder FolderName="vehicles_RC">
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_deckPlan_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_deckPlan_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_seatingPlan_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_seatingPlan_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_trainElement_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_trainElement_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_vehicleSeating_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_vehicleType_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_vehicleType_version.xsd" HomeFolder="Yes"/>
+				</Folder>
+				<Folder FolderName="equipment_RC">
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_equipment_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_equipment_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_equipmentPlace_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_equipmentVehiclePassenger_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_equipmentVehiclePassenger_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_facility_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_facility_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_facilityUic_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_nm_chargingEquipmentProfile_support.xsd"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_nm_equipmentEnergy_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_nm_equipmentEnergy_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_sensorEquipment_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_sensorEquipment_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_spotEquipment_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_spotEquipment_version.xsd" HomeFolder="Yes"/>
+				</Folder>
+				<Folder FolderName="general_RC">
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_linkByValue_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_notice_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_notice_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_noticeAssignment_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_schematicMap_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_schematicMap_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_securityList_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_securityList_version.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_serviceRestrictions_support.xsd" HomeFolder="Yes"/>
+					<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_serviceRestrictions_version.xsd" HomeFolder="Yes"/>
+				</Folder>			
 				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_all_objects_reusableComponents.xsd"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_availabilityCondition_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_availabilityCondition_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_country_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_dayType_propertiesOfDay.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_dayType_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_dayType_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_equipment_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_equipment_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_equipmentPlace_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_equipmentVehiclePassenger_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_equipmentVehiclePassenger_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_facility_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_facility_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_facilityUic_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_linkByValue_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_mode_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_mode_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_modeOfOperation_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_modeOfOperation_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_nm_chargingEquipmentProfile_support.xsd"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_nm_equipmentEnergy_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_nm_equipmentEnergy_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_notice_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_notice_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_noticeAssignment_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_otherOrganisation_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_otherOrganisation_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_schematicMap_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_schematicMap_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_securityList_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_securityList_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_serviceCalendar_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_serviceCalendar_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_serviceRestrictions_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_serviceRestrictions_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_submode_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_topographicPlace_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_topographicPlace_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_trainElement_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_trainElement_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_transportOrganisation_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_transportOrganisation_version.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_vehicleSeating_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_vehicleType_support.xsd" HomeFolder="Yes"/>
-				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_vehicleType_version.xsd" HomeFolder="Yes"/>
 			</Folder>
 			<Folder FolderName="netex_framework_frames">
 				<File FilePath="xsd\netex_framework\netex_frames\netex_all_frames_framework.xsd" HomeFolder="Yes"/>
@@ -181,6 +203,7 @@
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_all_objects_part1_tacticalPlanning.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_commonSection_support.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_commonSection_version.xsd" HomeFolder="Yes"/>
+				<File FilePath="xsd\netex_framework\netex_reusableComponents\netex_deckPlan_support.xsd"/>				
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_fareZone_support.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_fareZone_version.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_1\part1_tacticalPlanning\netex_journeyPattern_support.xsd" HomeFolder="Yes"/>
@@ -272,6 +295,10 @@
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_datedPassingTimes_version.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_datedVehicleJourney_support.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_datedVehicleJourney_version.xsd" HomeFolder="Yes"/>
+				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_deckEntranceAlignment_support.xsd" HomeFolder="Yes"/>
+				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_deckEntranceAlignment_version.xsd" HomeFolder="Yes"/>
+				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_deckPlanAssignment_support.xsd" HomeFolder="Yes"/>
+				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_deckPlanAssignment_version.xsd" HomeFolder="Yes"/>				
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_flexibleService_support.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_flexibleService_version.xsd" HomeFolder="Yes"/>
 				<File FilePath="xsd\netex_part_2\part2_journeyTimes\netex_interchange_support.xsd" HomeFolder="Yes"/>
@@ -744,6 +771,9 @@
 					<File FilePath="examples\functions\newModes\NewModes-ChauffeuredServiceExample.xml" HomeFolder="Yes"/>
 					<File FilePath="examples\functions\newModes\NewModes-CycleSharingExample.xml" HomeFolder="Yes"/>
 				</Folder>
+				<Folder FolderName="deckPlans">
+					<File FilePath="examples\functions\deckPlans\DeckPlans-Example.xml" HomeFolder="Yes"/>
+				</Folder>				
 			</Folder>
 			<Folder FolderName="standards">
 				<Folder FolderName="noptis">

--- a/examples/functions/deckPlans/DeckPlans-Example.xml
+++ b/examples/functions/deckPlans/DeckPlans-Example.xml
@@ -1,0 +1,1752 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery version="1.2.2" xsi:schemaLocation="http://www.netex.org.uk/netex ../../../xsd/NeTEx_publication.xsd" xmlns="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<!-- Example of a double decker bus
+
+
+   A DECK PLAN is provided for a double decker bus with spiral staircase.  ALl the seats are individually identified and have seat equipment
+
+    The Entrances have sensors
+    The lower deck has fold up seats facing iundards either side at the front , and 4 rows of bench seats at thh back with an extra seat in the back middle
+    There is a wheel chair space at 4D
+   There is a button  to request a stop by the exit door and at the top of th staircase
+    The Stair case has Stair equipment describing th step height and handrail.
+ 
+@@@@ Lower Front @@@@
+@@@@@@@@@@@@@@@@@@@@@
+/ Entrance   @Driver@
+\ Door       @      @
+@@@@@@@@@    @@@@@@@@
+@ 1A              1D@
+@ 3A              3D@
+@ 4A            [4D]@
+@@@@@@@@@    @@@@@@@@
+/ Exit        Stairs@
+\ Door      to Upper@
+@@@@@@@@@    @@@@@@@@
+@ 5A 5B @ 	@ 5C 5D@
+@ 6A 6B @    @ 6C 6D@
+@ 7A 7B @    @ 7C 7D@
+@ 8A 8B @ 8E @ 8C 8D@
+@@@@@@@@@@@@@@@@@@@@@
+@@@@ lower Back @@@@@
+
+    Th upper deck has 10 rows  bench seats 2 x  2 , with a gap  for the stairhead
+    The seats on the top deck have seat sensors ( so that can show upstairs seating available)
+
+@@@ Upper Front @@@@@
+@@@@@@@@@@@@@@@@@@@@@
+@01A 01B@ 	@021 01D@
+@02A 02B@ 	@02C 02D@
+@03A 03B@ 	@03C 03D@
+@@@@@@@@@   @@@@@@@@@
+@04A 04B@     Stairs@
+@05A 05B@   to lower@
+@@@@@@@@@   @@@@@@@@@
+@06A 06B@   @06C 06D@
+@07A 07B@   @07C 07D@
+@08A 08B@   @08C 08D@
+@09A 09B@   @09C 09D@
+@10A 10B@10E@10C 10D@
+@@@@@@@@@@@@@@@@@@@@@
+@@@@Upper Back@@@@@@@
+
+     DECK PLAN (Doouble decker bus)
+         DECK (lower)           
+            OTHERSPACE (Driver)
+            PASSENGER SPACE
+              DECK ENTRANCEs (Front, Rear, Stairwell)
+                ENTRANCE EQUIPMENT
+                ENTRANCE SENSOR
+              PASSENGER SPOTs (x25)
+ 
+			  SPOT ROWs (x8)
+			  SPot COlumns (x5)
+            OTHER SPACE (Stairwell)
+        DECK (upper)                
+            PASSENGER SPACE
+               DECK ENTRANCE ( Stairwell)
+               PASSENGER SPOTs (x41)
+                 SEAT EQUIPMENT
+                 SPOT SENSOR  
+			  SPOT ROWs (x10)
+			  SPot COlumns (x5)
+
+(C) CEN 2023
+-->
+	<PublicationTimestamp>2020-12-17T09:30:47.0Z</PublicationTimestamp>
+	<ParticipantRef>SYS001</ParticipantRef>
+	<!-- ======WHAT WAS REQUESTED ========== -->
+	<PublicationRequest version="1.0">
+		<RequestTimestamp>2020-12-17T09:30:46.0Z</RequestTimestamp>
+		<ParticipantRef>SYS002</ParticipantRef>
+		<Description>Request for Erebus 1 tariff</Description>
+		<topics>
+			<NetworkFrameTopic>
+				<selectionValidityConditions>
+					<AvailabilityCondition version="any" id="r1">
+						<FromDate>2020-01-01T00:00:00Z</FromDate>
+					</AvailabilityCondition>
+				</selectionValidityConditions>
+				<NetworkFilterByValue>
+					<objectReferences>
+						<OperatorRef version="any" ref="noc:erebus"/>
+					</objectReferences>
+				</NetworkFilterByValue>
+			</NetworkFrameTopic>
+		</topics>
+	</PublicationRequest>
+	<PublicationRefreshInterval>P1M</PublicationRefreshInterval>
+	<Description>Example of DeckPlans</Description>
+	<!-- =============== RESULTS =========== -->
+	<dataObjects>
+		<CompositeFrame version="1.0" id="mb:deck_plan_example" dataSourceRef="mb:erebus" responsibilitySetRef="mb:tariffs">
+			<ValidBetween>
+				<FromDate>2023-01-01T00:00:00</FromDate>
+				<ToDate>2023-12-31T12:00:00</ToDate>
+			</ValidBetween>
+			<Name>Deck Plan    Example</Name>
+			<Description>This is an example showing how one might encode a Deck plan for a double decker bus in NeTEx. It includes seat  an, entrance and sensor equipment.</Description>
+			<!--==== CODESPACEs ==== -->
+			<codespaces>
+				<CodespaceRef ref="mb_data"/>
+			</codespaces>
+			<!--==== FRAME DEFAULTS ==== -->
+			<FrameDefaults>
+				<!---  The default means that actually we could leave off all id s that belong to the mb: namespace. -->
+				<DefaultCodespaceRef ref="mb_data"/>
+				<DefaultDataSourceRef ref="mb:erebus" version="any"/>
+				<DefaultCurrency>EUR</DefaultCurrency>
+			</FrameDefaults>
+			<frames>
+				<!--==== OPERATOR COMMON RESOURCES==== -->
+				<ResourceFrame version="1.0" id="mb:deck_plan_example" responsibilitySetRef="mb:vehicle_data">
+					<Name>erebus Operator specific common resources</Name>
+					<codespaces>
+						<Codespace id="mb_data">
+							<Xmlns>mb</Xmlns>
+							<XmlnsUrl>http://www.erebus.eu/</XmlnsUrl>
+							<Description>erebus data</Description>
+						</Codespace>
+					</codespaces>
+					<dataSources>
+						<DataSource id="mb:erebus" version="any">
+							<Email>feedback@erebus.eu</Email>
+						</DataSource>
+					</dataSources>
+					<!-- ========Responsibility Sets========== -->
+					<responsibilitySets>
+						<ResponsibilitySet version="any" id="mb:vehicle_data">
+							<Name>Operator data</Name>
+							<roles>
+								<ResponsibilityRoleAssignment version="any" id="mb:vehicle_data@creates">
+									<DataRoleType>creates</DataRoleType>
+									<StakeholderRoleType>Planning</StakeholderRoleType>
+									<ResponsibleOrganisationRef ref="noc:erebus" version="any">erebus</ResponsibleOrganisationRef>
+								</ResponsibilityRoleAssignment>
+							</roles>
+						</ResponsibilitySet>
+					</responsibilitySets>
+					<!--==== CODE VALUES  ==== -->
+					<typesOfValue>
+						<ValueSet version="any" id="BikeEquip" classOfValues="TypeOfEquipment">
+							<Name>Bike equipment</Name>
+							<values>
+								<TypeOfEquipment version="any" id="battery">
+									<Name>Battery</Name>
+								</TypeOfEquipment>
+								<TypeOfEquipment version="any" id="charger">
+									<Name>Charger</Name>
+								</TypeOfEquipment>
+							</values>
+						</ValueSet>
+					</typesOfValue>
+					<organisations>
+						<!-- ==== ORGANISATIONS ==== -->
+						<Operator version="any" id="noc:erebus">
+							<PublicCode>MBK</PublicCode>
+							<Name>erebus</Name>
+							<ShortName>erebus</ShortName>
+							<TradingName>erebus SA</TradingName>
+							<OrganisationType>operator</OrganisationType>
+							<Address>
+								<Street>Alpha1</Street>
+								<Town>Metropolis</Town>
+								<PostCode>RH10 9UA</PostCode>
+								<PostalRegion>Metroland</PostalRegion>
+							</Address>
+							<PrimaryMode>bus</PrimaryMode>
+						</Operator>
+					</organisations>
+					<!-- ==== EQUIPMENT ==== -->
+					<equipments>
+						<SeatEquipment version="any" id="bench_seat">
+							<Name>Bench seat</Name>
+							<HeightFromFloor>0.48</HeightFromFloor>
+							<SeatBackHeight>0.50</SeatBackHeight>
+							<SeatDepth>0.50</SeatDepth>
+							<IsFoldup>false</IsFoldup>
+						</SeatEquipment>
+						<SeatEquipment version="any" id="pulldown_seat">
+							<Name>Pulldown seat></Name>
+							<HeightFromFloor>0.48</HeightFromFloor>
+							<SeatBackHeight>0.40</SeatBackHeight>
+							<SeatDepth>0.40</SeatDepth>
+							<IsFoldup>true</IsFoldup>
+						</SeatEquipment>
+						<SeatEquipment version="any" id="single_seat">
+							<Name>Bench seat</Name>
+							<HeightFromFloor>0.48</HeightFromFloor>
+							<SeatBackHeight>0.50</SeatBackHeight>
+							<SeatDepth>0.45</SeatDepth>
+							<IsFoldup>false</IsFoldup>
+						</SeatEquipment>
+						<EntranceSensor version="any" id="door_sensor">
+							<Name>External Door sensor</Name>
+							<CommunicationMethod>cable</CommunicationMethod>
+						</EntranceSensor>
+						<EntranceSensor version="any" id="entrance_sensor">
+							<Name>Internal sensor on bottom step</Name>
+							<CommunicationMethod>cable</CommunicationMethod>
+						</EntranceSensor>
+						<SpotSensor version="any" id="seat_sensor">
+							<Name>Seat sensor</Name>
+							<CommunicationMethod>cable</CommunicationMethod>
+						</SpotSensor>
+						<WheelchairVehicleEquipment version="any" id="wheelchair_space">
+							<HasWheelchairSpaces>true</HasWheelchairSpaces>
+							<NumberOfWheelchairAreas>1</NumberOfWheelchairAreas>
+							<WidthOfAccessArea>2.00</WidthOfAccessArea>
+							<HeightOfAccessArea>1.80</HeightOfAccessArea>
+							<WheelchairTurningCircle>2.00</WheelchairTurningCircle>
+							<CompanionSeat>true</CompanionSeat>
+						</WheelchairVehicleEquipment>
+						<LuggageBayEquipment version="any" id="luggage_space">
+							<HeightFromFloor>0</HeightFromFloor>
+						</LuggageBayEquipment>
+						<TicketingEquipment version="any" id="onboard_ticket_machine">
+							<TicketMachines>true</TicketMachines>
+							<PaymentMethods>cashAndCard contactlessPaymentCard  travelCard</PaymentMethods>
+						</TicketingEquipment>
+						<HelpPointEquipment version="any" id="stop_button">
+							<HeightFromGround>1.00</HeightFromGround>
+							<StopRequestButton>true</StopRequestButton>
+						</HelpPointEquipment>
+						<EntranceEquipment version="any" id="automatic_door">
+							<SafeForGuideDog>true</SafeForGuideDog>
+							<AutomaticDoor>true</AutomaticDoor>
+							<WheelchairPassable>true</WheelchairPassable>
+						</EntranceEquipment>
+						<StaircaseEquipment version="any" id="dd_staircase">
+							<NumberOfSteps>12</NumberOfSteps>
+							<StepHeight>0.10</StepHeight>
+							<HandrailType>oneSide</HandrailType>
+							<HandrailHeight>1.00</HandrailHeight>
+							<ContinuousHandrail>true</ContinuousHandrail>
+							<SpiralStair>true</SpiralStair>
+							<NumberOfFlights>1</NumberOfFlights>
+						</StaircaseEquipment>
+					</equipments>
+					<serviceFacilitySets>
+						<ServiceFacilitySet version="any" id="dd_facilities">
+							<PassengerCommsFacilityList>freeWifi</PassengerCommsFacilityList>
+							<TicketingServiceFacilityList>purchase</TicketingServiceFacilityList>
+							<LuggageCarriageFacilityList>noCycles </LuggageCarriageFacilityList>
+						</ServiceFacilitySet>
+					</serviceFacilitySets>
+					<vehicleTypes>
+						<VehicleType version="any" id="double_decker">
+							<Name>Double Decker Bus</Name>
+							<Description>Double decker bus with staircase. Wheelchair and luggage spaces on lower deck.</Description>
+							<ReversingDirection>false</ReversingDirection>
+							<SelfPropelled>true</SelfPropelled>
+							<PropulsionType>human</PropulsionType>
+							<FuelType>diesel</FuelType>
+							<TransportMode>bus</TransportMode>
+							<PassengerCapacity version="any" id="double_decker">
+								<SeatingCapacity>60</SeatingCapacity>
+								<StandingCapacity>20</StandingCapacity>
+								<PushchairCapacity>2</PushchairCapacity>
+								<WheelchairPlaceCapacity>1</WheelchairPlaceCapacity>
+							</PassengerCapacity>
+							<LowFloor>false</LowFloor>
+							<BoardingHeight>0.15</BoardingHeight>
+							<Length>10</Length>
+							<Height>4</Height>
+							<Weight>2000</Weight>
+						</VehicleType>
+					</vehicleTypes>
+					<deckPlans>
+						<DeckPlan version="any" id="double_decker_bus">
+							<deckLevels>
+								<DeckLevel version="any" id="dd@level_1">
+									<Label>Lower</Label>
+								</DeckLevel>
+								<DeckLevel version="any" id="dd@level_2">
+									<Label>Upper</Label>
+								</DeckLevel>
+							</deckLevels>
+							<decks>
+								<Deck version="any" id="dd@deck_1">
+									<Name>Lower Deck</Name>
+									<Label>1</Label>
+									<DeckLevelRef ref="dd@level_1" version="any"/>
+									<deckSpaces>
+										<OtherDeckSpace version="any" id="dd@deck_1@driver_area">
+											<actualVehicleEquipments>
+												<ActualVehicleEquipment version="any" id="dd@deck_1@driver_area">
+													<Units>1</Units>
+													<TicketingEquipmentRef version="any" ref="onboard_ticket_machine"/>
+												</ActualVehicleEquipment>
+											</actualVehicleEquipments>
+											<Name>Driver seat</Name>
+											<PublicUse>false</PublicUse>
+											<TotalCapacity>1</TotalCapacity>
+										</OtherDeckSpace>
+										<PassengerSpace version="any" id="dd@deck_1@seating">
+											<ServiceFacilitySetRef version="any" ref="dd_facilities"/>
+											<Name>Lower Deck seating area</Name>
+											<PublicUse>true</PublicUse>
+											<FareClass>standardClass</FareClass>
+											<AccessibilityAssessment version="any" id="dd@deck_1@seating">
+												<MobilityImpairedAccess>true</MobilityImpairedAccess>
+												<limitations>
+													<AccessibilityLimitation>
+														<WheelchairAccess>true</WheelchairAccess>
+														<StepFreeAccess>false</StepFreeAccess>
+														<AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+													</AccessibilityLimitation>
+												</limitations>
+											</AccessibilityAssessment>
+											<AirConditioned>true</AirConditioned>
+											<SmokingAllowed>false</SmokingAllowed>
+											<deckEntrances>
+												<PassengerEntrance version="any" id="dd@deck_1@front">
+													<Label>D1</Label>
+													<Width>1.00</Width>
+													<Height>1.90</Height>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@front@door">
+															<Units>1</Units>
+															<EntranceEquipmentRef version="any" ref="automatic_door"/>
+														</ActualVehicleEquipment>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@front@sensor">
+															<Units>1</Units>
+															<EntranceSensorRef version="any" ref="door_sensor"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<Name>Front Door</Name>
+													<DeckEntranceType>external</DeckEntranceType>
+													<EntranceSide>left</EntranceSide>
+													<IsAutomatic>true</IsAutomatic>
+													<sensorsInEntrance>
+														<SensorInEntrance version="any" id="dd@deck_1@front">
+															<EntranceSensorRef version="any" ref="door_sensor"/>
+														</SensorInEntrance>
+													</sensorsInEntrance>
+												</PassengerEntrance>
+												<PassengerEntrance version="any" id="dd@deck_1@rear">
+													<Label>D2</Label>
+													<Width>0.95</Width>
+													<Height>1.90</Height>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@rear@door">
+															<Units>1</Units>
+															<EntranceEquipmentRef version="any" ref="automatic_door"/>
+														</ActualVehicleEquipment>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@rear@sensor">
+															<EntranceSensorRef version="any" ref="door_sensor"/>
+														</ActualVehicleEquipment>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@rear@stop_button">
+															<HelpPointEquipmentRef version="any" ref="stop_button"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<Name>Rear Door</Name>
+													<DeckEntranceType>external</DeckEntranceType>
+													<EntranceSide>left</EntranceSide>
+													<IsAutomatic>true</IsAutomatic>
+													<sensorsInEntrance>
+														<SensorInEntrance version="any" id="dd@deck_1@rear">
+															<EntranceSensorRef version="any" ref="door_sensor"/>
+														</SensorInEntrance>
+													</sensorsInEntrance>
+												</PassengerEntrance>
+												<PassengerEntrance version="any" id="dd@deck_1@stairs">
+													<Label>Ii</Label>
+													<Width>0.80</Width>
+													<Height>1.90</Height>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@stairs@sensor">
+															<EntranceSensorRef version="any" ref="entrance_sensor"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<Name>Entrance to stairs</Name>
+													<DeckEntranceType>internal</DeckEntranceType>
+													<sensorsInEntrance>
+														<SensorInEntrance version="any" id="dd@deck_1@stairs">
+															<EntranceSensorRef version="any" ref="entrance_sensor"/>
+														</SensorInEntrance>
+													</sensorsInEntrance>
+												</PassengerEntrance>
+											</deckEntrances>
+											<deckEntranceUsages>
+												<DeckEntranceUsage version="any" id="dd@deck_1@front">
+													<UsageType>entry</UsageType>
+												</DeckEntranceUsage>
+												<DeckEntranceUsage version="any" id="dd@deck_1@rear">
+													<UsageType>exit</UsageType>
+												</DeckEntranceUsage>
+											</deckEntranceUsages>
+											<TotalCapacity>43</TotalCapacity>
+											<deckSpaceCapacities>
+												<DeckSpaceCapacity version="any" id="dd@deck_1@seat">
+													<LocatableSpotType>seat</LocatableSpotType>
+													<Capacity>22</Capacity>
+												</DeckSpaceCapacity>
+												<DeckSpaceCapacity version="any" id="dd@deck_1@standingSpace">
+													<LocatableSpotType>standingSpace</LocatableSpotType>
+													<Capacity>20</Capacity>
+												</DeckSpaceCapacity>
+												<DeckSpaceCapacity version="any" id="dd@deck_1@wheelchair">
+													<LocatableSpotType>wheelchairSpace</LocatableSpotType>
+													<Capacity>1</Capacity>
+												</DeckSpaceCapacity>
+												<DeckSpaceCapacity version="any" id="dd@deck_1@pushchair">
+													<LocatableSpotType>pushchairSpace</LocatableSpotType>
+													<Capacity>2</Capacity>
+												</DeckSpaceCapacity>
+											</deckSpaceCapacities>
+											<passengerSpots>
+												<!--  ==Row 1 -->
+												<PassengerSpot version="any" id="dd@deck_1@1A">
+													<Label>1A</Label>
+													<Orientation>leftwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@1A">
+															<SeatEquipmentRef version="any" ref="pulldown_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r1"/>
+													<SpotColumnRef version="any" ref="dd@l1@c1"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@1D">
+													<Label>1D</Label>
+													<Orientation>rightwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@1D">
+															<SeatEquipmentRef version="any" ref="pulldown_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r1"/>
+													<SpotColumnRef version="any" ref="dd@l1@c4"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  ==Row 2 -->
+												<PassengerSpot version="any" id="dd@deck_1@2A">
+													<Label>2A</Label>
+													<Orientation>leftwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@2A">
+															<SeatEquipmentRef version="any" ref="pulldown_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r2"/>
+													<SpotColumnRef version="any" ref="dd@l1@c1"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@2D">
+													<Label>2D</Label>
+													<Orientation>rightwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@2D">
+															<SeatEquipmentRef version="any" ref="pulldown_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r2"/>
+													<SpotColumnRef version="any" ref="dd@l1@c4"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  ==Row 3 -->
+												<PassengerSpot version="any" id="dd@deck_1@3A">
+													<Label>3A</Label>
+													<Orientation>leftwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@3A">
+															<SeatEquipmentRef version="any" ref="pulldown_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r3"/>
+													<SpotColumnRef version="any" ref="dd@l1@c1"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@3D">
+													<Label>Wheelchair space</Label>
+													<Orientation>rightwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@3D">
+															<Units>1</Units>
+															<WheelchairVehicleEquipmentRef version="any" ref="wheelchair_space"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r3"/>
+													<SpotColumnRef version="any" ref="dd@l1@c4"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  ==Row 4 -->
+												<PassengerSpot version="any" id="dd@deck_1@4A">
+													<Label>4A</Label>
+													<Orientation>leftwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@4A">
+															<SeatEquipmentRef version="any" ref="single_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r4"/>
+													<SpotColumnRef version="any" ref="dd@l1@c1"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  ==Row 5 -->
+												<PassengerSpot version="any" id="dd@deck_1@5A">
+													<Label>5A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@5A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r5"/>
+													<SpotColumnRef version="any" ref="dd@l1@c1"/>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@5B">
+													<Label>5A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@5B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r5"/>
+													<SpotColumnRef version="any" ref="dd@l1@c2"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@5C">
+													<Label>5C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@5C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r5"/>
+													<SpotColumnRef version="any" ref="dd@l1@c3"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@5D">
+													<Label>5D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@5D">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r5"/>
+													<SpotColumnRef version="any" ref="dd@l1@c4"/>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  ==Row 6 -->
+												<PassengerSpot version="any" id="dd@deck_1@6A">
+													<Label>6A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@6A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r6"/>
+													<SpotColumnRef version="any" ref="dd@l1@c1"/>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@6B">
+													<Label>6A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@6B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r6"/>
+													<SpotColumnRef version="any" ref="dd@l1@c2"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@6C">
+													<Label>6C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@6C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r6"/>
+													<SpotColumnRef version="any" ref="dd@l1@c3"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@6D">
+													<Label>6D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@6D">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r6"/>
+													<SpotColumnRef version="any" ref="dd@l1@c4"/>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  ==Row 7 -->
+												<PassengerSpot version="any" id="dd@deck_1@7A">
+													<Label>7A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@7A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r7"/>
+													<SpotColumnRef version="any" ref="dd@l1@c1"/>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@7B">
+													<Label>7A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@7B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r7"/>
+													<SpotColumnRef version="any" ref="dd@l1@c2"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@7C">
+													<Label>7C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@7C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r7"/>
+													<SpotColumnRef version="any" ref="dd@l1@c3"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@7D">
+													<Label>7D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@7C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r7"/>
+													<SpotColumnRef version="any" ref="dd@l1@c4"/>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  ==Row 8 -->
+												<PassengerSpot version="any" id="dd@deck_1@8A">
+													<Label>8A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@8A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r8"/>
+													<SpotColumnRef version="any" ref="dd@l1@c1"/>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@8B">
+													<Label>8B</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@8B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r8"/>
+													<SpotColumnRef version="any" ref="dd@l1@c2"/>
+													<ByAisle>false</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@8E">
+													<Label>8E</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@8E">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r8"/>
+													<SpotColumnRef version="any" ref="dd@l1@c5"/>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@8C">
+													<Label>8C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@8C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r8"/>
+													<SpotColumnRef version="any" ref="dd@l1@c3"/>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_1@8D">
+													<Label>8D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@8D">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r8"/>
+													<SpotColumnRef version="any" ref="dd@l1@c4"/>
+													<ByAisle>false</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+											</passengerSpots>
+											<luggageSpots>
+												<!--  ==Row 4 -->
+												<LuggageSpot version="any" id="dd@deck_1@4B">
+													<Label>4B</Label>
+													<Orientation>leftwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@4B">
+															<LuggageBayEquipmentRef version="any" ref="luggage_space"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l1@r4"/>
+													<SpotColumnRef version="any" ref="dd@l1@c4"/>
+												</LuggageSpot>
+											</luggageSpots>
+										</PassengerSpace>
+										<PassengerSpace version="any" id="dd@stairwell">
+											<ServiceFacilitySetRef version="any" ref="dd_facilities"/>
+											<actualVehicleEquipments>
+												<ActualVehicleEquipment version="any" id="dd@stairwell@staircase">
+													<Units>1</Units>
+													<StaircaseEquipmentRef version="any" ref="dd_staircase"/>
+												</ActualVehicleEquipment>
+												<ActualVehicleEquipment version="any" id="dd@stairwell@stop_button">
+													<Name>Stop button at top of stairs</Name>
+													<HelpPointEquipmentRef version="any" ref="stop_button"/>
+												</ActualVehicleEquipment>
+											</actualVehicleEquipments>
+											<Name>Stairwell to upper deck</Name>
+											<SmokingAllowed>false</SmokingAllowed>
+											<deckEntrances>
+												<DeckVehicleEntrance version="any" id="dd@stairwell@base">
+													<Label>Up</Label>
+													<Width>1.00</Width>
+													<Height>1.90</Height>
+													<Name>Bottom of stairwell</Name>
+													<DeckEntranceType>internal</DeckEntranceType>
+													<IsAutomatic>true</IsAutomatic>
+												</DeckVehicleEntrance>
+												<DeckVehicleEntrance version="any" id="dd@stairwell@top">
+													<Label>Down</Label>
+													<Width>1.00</Width>
+													<Height>1.90</Height>
+													<Name>Top of Stairwell</Name>
+													<DeckEntranceType>internal</DeckEntranceType>
+													<IsAutomatic>true</IsAutomatic>
+												</DeckVehicleEntrance>
+											</deckEntrances>
+											<deckEntranceCouples>
+												<DeckEntranceCouple version="any" id="dd@stairwell@base">
+													<FromDeckEntranceRef ref="dd@deck_1@stairs"/>
+													<ToDeckEntranceRef ref="dd@stairwell@base"/>
+												</DeckEntranceCouple>
+												<DeckEntranceCouple version="any" id="dd@stairwell@top">
+													<FromDeckEntranceRef ref="dd@stairwell@top"/>
+													<ToDeckEntranceRef ref="dd@deck_2@stairs"/>
+												</DeckEntranceCouple>
+											</deckEntranceCouples>
+											<deckEntranceUsages>
+												<DeckEntranceUsage version="any" id="dd@stairwell@top">
+													<UsageType>entryAndExit</UsageType>
+												</DeckEntranceUsage>
+												<DeckEntranceUsage version="any" id="dd@stairwell@base">
+													<UsageType>entryAndExit</UsageType>
+												</DeckEntranceUsage>
+											</deckEntranceUsages>
+										</PassengerSpace>
+									</deckSpaces>
+									<spotRows>
+										<SpotRow version="any" id="dd@l1@r1">
+											<Label>Row 1</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l1@r2">
+											<Label>Row 2</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l1@r3">
+											<Label>Row 3</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l1@r4">
+											<Label>Row 4</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l1@r5">
+											<Label>Row 5</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l1@r6">
+											<Label>Row 6</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l1@r7">
+											<Label>Row </Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l1@r8">
+											<Label>Row 8</Label>
+										</SpotRow>
+									</spotRows>
+									<spotColumns>
+										<SpotColumn version="any" id="dd@l1@c1">
+											<Label>Column A</Label>
+										</SpotColumn>
+										<SpotColumn version="any" id="dd@l1@c2">
+											<Label>Column B</Label>
+										</SpotColumn>
+										<SpotColumn version="any" id="dd@l1@c3">
+											<Label>Column C</Label>
+										</SpotColumn>
+										<SpotColumn version="any" id="dd@l1@c4">
+											<Label>Column D</Label>
+										</SpotColumn>
+										<SpotColumn version="any" id="dd@l1@c5">
+											<Label>Column E</Label>
+										</SpotColumn>
+									</spotColumns>
+								</Deck>
+								<Deck version="any" id="dd@deck_2">
+									<Name>Upper Deck</Name>
+									<Label>3</Label>
+									<DeckLevelRef ref="dd@level_2" version="any"/>
+									<deckSpaces>
+										<PassengerSpace version="any" id="dd@deck_2@seating">
+											<Name>Upper Deck seating area</Name>
+											<AccessibilityAssessment version="any" id="dd@deck_2@seating">
+												<MobilityImpairedAccess>false</MobilityImpairedAccess>
+												<limitations>
+													<AccessibilityLimitation>
+														<WheelchairAccess>false</WheelchairAccess>
+														<StepFreeAccess>false</StepFreeAccess>
+														<AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+													</AccessibilityLimitation>
+												</limitations>
+											</AccessibilityAssessment>
+											<AirConditioned>true</AirConditioned>
+											<SmokingAllowed>false</SmokingAllowed>
+											<deckEntrances>
+												<DeckVehicleEntrance version="any" id="dd@deck_2@stairs">
+													<Width>0.80</Width>
+													<Height>2.00</Height>
+													<Name>ENtrance to top of  stairs</Name>
+													<DeckEntranceType>internal</DeckEntranceType>
+												</DeckVehicleEntrance>
+											</deckEntrances>
+											<deckSpaceCapacities>
+												<DeckSpaceCapacity version="any" id="dd@deck_2@seat">
+													<LocatableSpotType>seat</LocatableSpotType>
+													<Capacity>37</Capacity>
+												</DeckSpaceCapacity>
+												<DeckSpaceCapacity version="any" id="dd@deck_2@standingSpace">
+													<LocatableSpotType>standingSpace</LocatableSpotType>
+													<Capacity>12</Capacity>
+												</DeckSpaceCapacity>
+											</deckSpaceCapacities>
+											<passengerSpots>
+												<!--  == Row 1 === -->
+												<PassengerSpot version="any" id="dd@deck_2@01A">
+													<Label>1A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@01A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r01"/>
+													<SpotColumnRef version="any" ref="dd@l2@c1"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@01A">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@01B">
+													<Label>1B</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@01B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r01"/>
+													<SpotColumnRef version="any" ref="dd@l2@c2"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@01B">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@01C">
+													<Label>1C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@01C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r01"/>
+													<SpotColumnRef version="any" ref="dd@l2@c3"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@01C">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@01D">
+													<Label>1D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@01D">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r01"/>
+													<SpotColumnRef version="any" ref="dd@l2@c4"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@01D">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  == Row 2 === -->
+												<PassengerSpot version="any" id="dd@deck_2@02A">
+													<Label>2A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@02A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r02"/>
+													<SpotColumnRef version="any" ref="dd@l2@c1"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@02A">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@02B">
+													<Label>2B</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@02B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r02"/>
+													<SpotColumnRef version="any" ref="dd@l2@c2"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@02">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@02C">
+													<Label>2C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@02C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r02"/>
+													<SpotColumnRef version="any" ref="dd@l2@c3"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@02C">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@02D">
+													<Label>2D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@02D">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r02"/>
+													<SpotColumnRef version="any" ref="dd@l2@c4"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@02D">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  == Row 3 === -->
+												<PassengerSpot version="any" id="dd@deck_2@03A">
+													<Label>3A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@03A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r03"/>
+													<SpotColumnRef version="any" ref="dd@l2@c1"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@03A">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@03B">
+													<Label>3B</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@03B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r03"/>
+													<SpotColumnRef version="any" ref="dd@l2@c2"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@03B">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@03C">
+													<Label>3C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@03C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r03"/>
+													<SpotColumnRef version="any" ref="dd@l2@c3"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@03C">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@03D">
+													<Label>3D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@03D">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r03"/>
+													<SpotColumnRef version="any" ref="dd@l2@c4"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@03D">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  == Row 4 === -->
+												<PassengerSpot version="any" id="dd@deck_2@04A">
+													<Label>4A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@04A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r04"/>
+													<SpotColumnRef version="any" ref="dd@l2@c1"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@04A">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@04B">
+													<Label>4B</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@04B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r04"/>
+													<SpotColumnRef version="any" ref="dd@l2@c2"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@04B">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<!--  == Row 5 === -->
+												<PassengerSpot version="any" id="dd@deck_2@05A">
+													<Label>5A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@05A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r05"/>
+													<SpotColumnRef version="any" ref="dd@l2@c1"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@05A">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@05B">
+													<Label>5B</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@05B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r05"/>
+													<SpotColumnRef version="any" ref="dd@l2@c2"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@05B">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<!--  == Row 6 === -->
+												<PassengerSpot version="any" id="dd@deck_2@06A">
+													<Label>6A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@06A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r06"/>
+													<SpotColumnRef version="any" ref="dd@l2@c1"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@06A">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@06B">
+													<Label>6B</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@06B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r06"/>
+													<SpotColumnRef version="any" ref="dd@l2@c2"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@06B">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@06C">
+													<Label>6C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@06C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r06"/>
+													<SpotColumnRef version="any" ref="dd@l2@c3"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@06C">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@06D">
+													<Label>6D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@06D">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r06"/>
+													<SpotColumnRef version="any" ref="dd@l2@c4"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@06D">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  == Row 7 === -->
+												<PassengerSpot version="any" id="dd@deck_2@07A">
+													<Label>7A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@07A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r07"/>
+													<SpotColumnRef version="any" ref="dd@l2@c1"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@07A">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@07B">
+													<Label>7B</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@07B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r07"/>
+													<SpotColumnRef version="any" ref="dd@l2@c2"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@07B">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@07C">
+													<Label>7C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@07C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r07"/>
+													<SpotColumnRef version="any" ref="dd@l2@c3"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@07C">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@07D">
+													<Label>7D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@07D">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r07"/>
+													<SpotColumnRef version="any" ref="dd@l2@c4"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@07D">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  == Row 8 === -->
+												<PassengerSpot version="any" id="dd@deck_2@08A">
+													<Label>8A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@08A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r08"/>
+													<SpotColumnRef version="any" ref="dd@l2@c1"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@08A">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@08B">
+													<Label>8B</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@08B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r08"/>
+													<SpotColumnRef version="any" ref="dd@l2@c2"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@08B">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@08C">
+													<Label>8C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@08C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r08"/>
+													<SpotColumnRef version="any" ref="dd@l2@c3"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@08C">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@08D">
+													<Label>8D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@08D">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r08"/>
+													<SpotColumnRef version="any" ref="dd@l2@c4"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@08D">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  == Row 9 === -->
+												<PassengerSpot version="any" id="dd@deck_2@09A">
+													<Label>9A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@09A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r09"/>
+													<SpotColumnRef version="any" ref="dd@l2@c1"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@09A">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@09B">
+													<Label>9B</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@09B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r09"/>
+													<SpotColumnRef version="any" ref="dd@l2@c2"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@09B">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@09C">
+													<Label>9C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@09C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r09"/>
+													<SpotColumnRef version="any" ref="dd@l2@c3"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@09C">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@09D">
+													<Label>9D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@09D">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r09"/>
+													<SpotColumnRef version="any" ref="dd@l2@c4"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@09D">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<!--  == Row 10 === -->
+												<PassengerSpot version="any" id="dd@deck_2@10A">
+													<Label>10A</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@10A">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r10"/>
+													<SpotColumnRef version="any" ref="dd@l2@c1"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@10A">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@10B">
+													<Label>10B</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@10B">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r10"/>
+													<SpotColumnRef version="any" ref="dd@l2@c2"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@10B">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@10E">
+													<Label>10E</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@10E">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r10"/>
+													<SpotColumnRef version="any" ref="dd@l2@c5"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@10E">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>true</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@10C">
+													<Label>10C</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@10C">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r10"/>
+													<SpotColumnRef version="any" ref="dd@l2@c3"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@10C">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>true</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+												<PassengerSpot version="any" id="dd@deck_2@10D">
+													<Label>10D</Label>
+													<Orientation>forwards</Orientation>
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment version="any" id="dd@deck_1@10D">
+															<SeatEquipmentRef version="any" ref="bench_seat"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+													<SpotRowRef version="any" ref="dd@l2@r10"/>
+													<SpotColumnRef version="any" ref="dd@l2@c4"/>
+													<sensorsInSpot>
+														<SensorInSpot version="any" id="dd@deck_2@10D">
+															<SpotSensorRef version="any" ref="seat_sensor"/>
+														</SensorInSpot>
+													</sensorsInSpot>
+													<ByAisle>false</ByAisle>
+													<ByWindow>false</ByWindow>
+												</PassengerSpot>
+											</passengerSpots>
+										</PassengerSpace>
+									</deckSpaces>
+									<spotRows>
+										<SpotRow version="any" id="dd@l2@r01">
+											<Label>Row 1</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l2@r02">
+											<Label>Row 2</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l2@r03">
+											<Label>Row 3</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l2@r04">
+											<Label>Row 4</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l2@r05">
+											<Label>Row 5</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l2@r06">
+											<Label>Row 6</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l2@r07">
+											<Label>Row </Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l2@r08">
+											<Label>Row 8</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l2@r09">
+											<Label>Row 9</Label>
+										</SpotRow>
+										<SpotRow version="any" id="dd@l2@r10">
+											<Label>Row 10</Label>
+										</SpotRow>
+									</spotRows>
+									<spotColumns>
+										<SpotColumn version="any" id="dd@l2@c1">
+											<Label>Column A</Label>
+										</SpotColumn>
+										<SpotColumn version="any" id="dd@l2@c2">
+											<Label>Column B</Label>
+										</SpotColumn>
+										<SpotColumn version="any" id="dd@l2@c3">
+											<Label>Column C</Label>
+										</SpotColumn>
+										<SpotColumn version="any" id="dd@l2@c4">
+											<Label>Column D</Label>
+										</SpotColumn>
+										<SpotColumn version="any" id="dd@l2@c5">
+											<Label>Column E</Label>
+										</SpotColumn>
+									</spotColumns>
+								</Deck>
+							</decks>
+						</DeckPlan>
+					</deckPlans>
+					<schematicMaps>
+						<SchematicMap version="any" id="dd">
+							<Name>Basic Elements for  map of bus</Name>
+							<ImageUri>http:erebus.eu/plans/double_decker_floor_plan</ImageUri>
+							<members>
+								<SchematicMapMember version="any" id="dd@deck_1@">
+									<Name>Bottom Deck</Name>
+									<DeckRef version="any" ref="dd@deck_1"/>
+								</SchematicMapMember>
+								<SchematicMapMember version="any" id="dd@deck_1@front_entrance">
+									<Name>Forward Entrance</Name>
+									<PassengerEntranceRef version="any" ref="dd@deck_1@front"/>
+								</SchematicMapMember>
+								<SchematicMapMember version="any" id="dd@deck_1@rear_entrance">
+									<Name>Rear Entrance</Name>
+									<PassengerEntranceRef version="any" ref="dd@deck_1@rear"/>
+								</SchematicMapMember>
+								<SchematicMapMember version="any" id="dd@deck_1@stairs">
+									<Name>Stairs </Name>
+									<PassengerEntranceRef version="any" ref="dd@deck_1@stairs"/>
+								</SchematicMapMember>
+								<SchematicMapMember version="any" id="dd@deck_2@">
+									<Name>Top Deck</Name>
+									<DeckRef version="any" ref="dd@deck_2"/>
+								</SchematicMapMember>
+							</members>
+						</SchematicMap>
+					</schematicMaps>
+				</ResourceFrame>
+				<ServiceFrame version="1.0" id="mb:deck_plan_example" responsibilitySetRef="mb:vehicle_data">
+					<Name>Deck Plan  Assignment   Example</Name>
+					<Description>This is an example showing how one might assign a Deck Entrance to a journey so as to state which entrance will be at which point on teh platform .  More sense for a train of ferry .</Description>
+					<stopAssignments>
+						<PassengerStopAssignment version="any" id="sj001a" order="1">
+							<Name>To a particalr stopt</Name>
+							<ScheduledStopPointRef versionRef="EXTERNAL" ref="Gotham_bus_station"/>
+							<StopPlaceRef versionRef="EXTERNAL" ref="Gotham_bus"/>
+							<QuayRef versionRef="EXTERNAL" ref="Gotham_bus@P1"/>
+							<BoardingPositionRef versionRef="EXTERNAL" ref="Gotham_bus@P1@A"/>
+							<trainElements>
+								<TrainStopAssignment version="any" id="sj001a" order="1">
+									<BoardingUse>true</BoardingUse>
+									<AlightingUse>false</AlightingUse>
+									<PositionOfTrainElement>1</PositionOfTrainElement>
+									<BoardingPositionRef versionRef="EXTERNAL" ref="Gotham_bus@P1@A"/>
+									<EntranceToVehicle>Board at front</EntranceToVehicle>
+									<deckEntranceAssignments>
+										<DeckEntranceAssignment version="any" id="sj001a@front">
+											<PassengerEntranceRef version="any" ref="dd@deck_1@front"/>
+										</DeckEntranceAssignment>
+									</deckEntranceAssignments>
+								</TrainStopAssignment>
+								<TrainStopAssignment version="any" id="sj001a" order="2">
+									<BoardingUse>false</BoardingUse>
+									<AlightingUse>true</AlightingUse>
+									<PositionOfTrainElement>1</PositionOfTrainElement>
+									<BoardingPositionRef versionRef="EXTERNAL" ref="Gotham_bus@P1@B"/>
+									<EntranceToVehicle>exit  at rear</EntranceToVehicle>
+									<deckEntranceAssignments>
+										<DeckEntranceAssignment version="any" id="sj001a@rear">
+											<PassengerEntranceRef version="any" ref="dd@deck_1@rear"/>
+										</DeckEntranceAssignment>
+									</deckEntranceAssignments>
+								</TrainStopAssignment>
+							</trainElements>
+						</PassengerStopAssignment>
+					</stopAssignments>
+				</ServiceFrame>
+				<!--==== TIMEABLE ==== -->
+				<TimetableFrame version="1.0" id="mb:deck_plan_example" responsibilitySetRef="mb:vehicle_data">
+					<Name>Deck Plan    Example</Name>
+					<Description>This is an example showing how one might assign a deck plan to a journey.</Description>
+					<!-- =======Journeys========== -->
+					<vehicleJourneys>
+						<ServiceJourney version="any" id="sj001">
+							<DepartureTime>10:10:00</DepartureTime>
+							<dayTypes>
+								<DayTypeRef versionRef="EXTERNAL" ref="weekday"/>
+							</dayTypes>
+							<ServicePatternRef versionRef="EXTERNAL" ref="r123"/>
+							<VehicleTypeRef version="any" ref="double_decker"/>
+							<parts>
+								<JourneyPart version="any" id="sj001@a">
+									<Description>In to centre </Description>
+									<MainPartRef version="any" ref="sj001@a"/>
+									<FromStopPointRef versionRef="EXTERNAL" ref="stop001"/>
+									<ToStopPointRef versionRef="EXTERNAL" ref="stop015"/>
+									<StartTime>10:10:00</StartTime>
+									<EndTime>10:30:00</EndTime>
+								</JourneyPart>
+								<JourneyPart version="any" id="sj001@b">
+									<Description>Across centre - doors open </Description>
+									<MainPartRef version="any" ref="sj001@a"/>
+									<FromStopPointRef versionRef="EXTERNAL" ref="stop015"/>
+									<ToStopPointRef versionRef="EXTERNAL" ref="stop021"/>
+									<StartTime>10:31:00</StartTime>
+									<EndTime>10:50:00</EndTime>
+								</JourneyPart>
+							</parts>
+						</ServiceJourney>
+					</vehicleJourneys>
+					<deckPlanAssignments>
+						<!-- This is an highly artifical exampel to shwo a different deck plan assignment on two different journey parts -->
+						<DeckPlanAssignment version="any" id="sj001a" order="1">
+							<Name>Assign double decker bus to Journey - doors shut</Name>
+							<DeckPlanRef version="any" ref="double_decker_bus"/>
+							<VehicleTypeRef version="any" ref="double_decker"/>
+							<ServiceJourneyRef version="any" ref="sj001"/>
+							<JourneyPartRef version="any" ref="sj001@a"/>
+						</DeckPlanAssignment>
+						<DeckPlanAssignment version="any" id="sj001b" order="2">
+							<Name>Assign double decker bus to Journey - doors open</Name>
+							<DeckPlanRef versionRef="EXTERNAL" ref="double_decker_bus_ALTERNATIVE_CONFIG"/>
+							<VehicleTypeRef version="any" ref="double_decker"/>
+							<ServiceJourneyRef version="any" ref="sj001"/>
+							<JourneyPartRef version="any" ref="sj001@b"/>
+						</DeckPlanAssignment>
+					</deckPlanAssignments>
+					<vehicleJourneyStopAssignments>
+						<VehicleJourneyStopAssignment version="any" id="sj001a" order="1">
+							<Name>Ties  a STOP ASSIGNMENT to a specific  VEHICLE JOURNEY  </Name>
+							<VehicleJourneyRef version="any" ref="sj001"/>
+							<PassengerStopAssignmentRef version="any" ref="sj001a"/>
+						</VehicleJourneyStopAssignment>
+						 
+					</vehicleJourneyStopAssignments>
+				</TimetableFrame>
+			</frames>
+		</CompositeFrame>
+	</dataObjects>
+</PublicationDelivery>

--- a/examples/functions/deckPlans/DeckPlans-Example.xml
+++ b/examples/functions/deckPlans/DeckPlans-Example.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<PublicationDelivery version="1.2.2" xsi:schemaLocation="http://www.netex.org.uk/netex ../../../xsd/NeTEx_publication.xsd" xmlns="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2.2" xsi:schemaLocation="http://www.netex.org.uk/netex ../../../xsd/NeTEx_publication.xsd">
 	<!-- Example of a double decker bus
 
 
@@ -187,7 +187,7 @@
 							<IsFoldup>false</IsFoldup>
 						</SeatEquipment>
 						<SeatEquipment version="any" id="pulldown_seat">
-							<Name>Pulldown seat></Name>
+							<Name>Pulldown seat&gt;</Name>
 							<HeightFromFloor>0.48</HeightFromFloor>
 							<SeatBackHeight>0.40</SeatBackHeight>
 							<SeatDepth>0.40</SeatDepth>
@@ -1743,7 +1743,6 @@
 							<VehicleJourneyRef version="any" ref="sj001"/>
 							<PassengerStopAssignmentRef version="any" ref="sj001a"/>
 						</VehicleJourneyStopAssignment>
-						 
 					</vehicleJourneyStopAssignments>
 				</TimetableFrame>
 			</frames>

--- a/examples/functions/site/Netex_11_Sites_OlympicPark_1.xml
+++ b/examples/functions/site/Netex_11_Sites_OlympicPark_1.xml
@@ -512,7 +512,7 @@ It is based on the 2012 London Olympic Park. See accompanying paper for diagram
 								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V11_WARM"/>
 							</members>
 						</GroupOfSites>
-					</groupsOfSites>					
+					</groupsOfSites>
 					<!--- ==== Gateway Stations === -->
 					<stopPlaces>
 						<!-- ========== Rail========= -->
@@ -4291,7 +4291,7 @@ It is based on the 2012 London Olympic Park. See accompanying paper for diagram
 										</LevelInStructure>
 									</levelsInStructure>
 								</SiteStructure>
-							</siteStructures>							
+							</siteStructures>
 						</PointOfInterest>
 						<PointOfInterest version="any" id="naptPoi:8100OPK_V2_HOCK">
 							<Name>Hockey Centre</Name>
@@ -4817,7 +4817,7 @@ It is based on the 2012 London Olympic Park. See accompanying paper for diagram
 						<TariffZone version="any" id="Zone4">
 							<ShortName>Zone4</ShortName>
 						</TariffZone>
-					</tariffZones>					
+					</tariffZones>
 				</SiteFrame>
 				<!-- - ==== UK Code values used === -->
 				<ResourceFrame version="001" created="2011-02-23T10:00:00Z" id="nptg:Types">

--- a/examples/functions/site/Netex_11_Sites_OlympicPark_1.xml
+++ b/examples/functions/site/Netex_11_Sites_OlympicPark_1.xml
@@ -149,7 +149,7 @@ It is based on the 2012 London Olympic Park. See accompanying paper for diagram
 		A COMPOSITE FRAME is used to group the other frames as a single version
  
  
-(C) CEN Copyright 2010
+(C) CEN Copyright 2010, 2023
 -->
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" xsi:schemaLocation="http://www.netex.org.uk/netex ../../../xsd/NeTEx_publication.xsd">
 	<PublicationTimestamp>2001-12-17T09:30:47.0Z</PublicationTimestamp>
@@ -491,6 +491,28 @@ It is based on the 2012 London Olympic Park. See accompanying paper for diagram
 							<CountryRef ref="gb">ENG</CountryRef>
 						</TopographicPlace>
 					</topographicPlaces>
+					<groupsOfSites>
+						<GroupOfSites version="any" id="Olympic_park">
+							<Name>Sites in Olympic Park</Name>
+							<members>
+								<StopPlaceRef version="any" ref="naptStop:910GSTRFD"/>
+								<StopPlaceRef version="any" ref="naptStop:940GZZLUSTD"/>
+								<StopPlaceRef version="any" ref="naptStop:940GZZCRSTD"/>
+								<StopPlaceRef version="any" ref="naptStop:940GZZLUWHM"/>
+								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V1_STDM"/>
+								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V2_HOCK"/>
+								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V3_HAND"/>
+								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V4_AQUA"/>
+								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V5_WPOL"/>
+								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V6_BKTB"/>
+								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V7_VELO"/>
+								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V8_BMXT"/>
+								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V9_EMAN"/>
+								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V10_PRSC"/>
+								<PointOfInterestRef version="any" ref="naptPoi:8100OPK_V11_WARM"/>
+							</members>
+						</GroupOfSites>
+					</groupsOfSites>					
 					<!--- ==== Gateway Stations === -->
 					<stopPlaces>
 						<!-- ========== Rail========= -->
@@ -4224,6 +4246,52 @@ It is based on the 2012 London Olympic Park. See accompanying paper for diagram
 							<Lighting>wellLit</Lighting>
 							<PersonCapacity>80000</PersonCapacity>
 							<ParentSiteRef version="any" ref="naptPoi:8100OPK"/>
+							<levels>
+								<Level version="any" id="naptPoi:8100OPK_V1_STDM-L1">
+									<Name>Level 1</Name>
+									<PublicUse>true</PublicUse>
+								</Level>
+								<Level version="any" id="naptPoi:8100OPK_V1_STDM-L2">
+									<Name>Level 2</Name>
+									<PublicUse>true</PublicUse>
+								</Level>
+								<Level version="any" id="naptPoi:8100OPK_V1_STDM-L3">
+									<Name>Level 3</Name>
+									<PublicUse>true</PublicUse>
+								</Level>
+							</levels>
+							<siteStructures>
+								<SiteStructure version="any" id="naptPoi:8100OPK_V1_STDM-S1">
+									<Name>East Access Block</Name>
+									<levelsInStructure>
+										<LevelInStructure version="any" id="naptPoi:8100OPK_V1_STDM-S1" order="1">
+											<FloorLabel>1</FloorLabel>
+											<LevelRef ref="naptPoi:8100OPK_V1_STDM-L1"/>
+										</LevelInStructure>
+										<LevelInStructure version="any" id="naptPoi:8100OPK_V1_STDM-S1" order="2">
+											<FloorLabel>2</FloorLabel>
+											<LevelRef ref="naptPoi:8100OPK_V1_STDM-L1"/>
+										</LevelInStructure>
+										<LevelInStructure version="any" id="naptPoi:8100OPK_V1_STDM-S1" order="3">
+											<FloorLabel>3</FloorLabel>
+											<LevelRef ref="naptPoi:8100OPK_V1_STDM-L1"/>
+										</LevelInStructure>
+									</levelsInStructure>
+								</SiteStructure>
+								<SiteStructure version="any" id="naptPoi:8100OPK_V1_STDM-S2">
+									<Name>West  Access Block</Name>
+									<levelsInStructure>
+										<LevelInStructure version="any" id="naptPoi:8100OPK_V1_STDM-S2" order="1">
+											<FloorLabel>1</FloorLabel>
+											<LevelRef ref="naptPoi:8100OPK_V1_STDM-L1"/>
+										</LevelInStructure>
+										<LevelInStructure version="any" id="naptPoi:8100OPK_V1_STDM-S2" order="2">
+											<FloorLabel>2</FloorLabel>
+											<LevelRef ref="naptPoi:8100OPK_V1_STDM-L1"/>
+										</LevelInStructure>
+									</levelsInStructure>
+								</SiteStructure>
+							</siteStructures>							
 						</PointOfInterest>
 						<PointOfInterest version="any" id="naptPoi:8100OPK_V2_HOCK">
 							<Name>Hockey Centre</Name>
@@ -4734,6 +4802,22 @@ It is based on the 2012 London Olympic Park. See accompanying paper for diagram
 							<ParentSiteRef version="any" ref="naptPoi:8100OPK"/>
 						</PointOfInterest>
 					</pointsOfInterest>
+					<groupsOfTariffZones>
+						<GroupOfTariffZones version="any" id="lul_zones">
+							<members>
+								<TariffZoneRef version="any" ref="Zone3"/>
+								<TariffZoneRef version="any" ref="Zone4"/>
+							</members>
+						</GroupOfTariffZones>
+					</groupsOfTariffZones>
+					<tariffZones>
+						<TariffZone version="any" id="Zone3">
+							<ShortName>Zone3</ShortName>
+						</TariffZone>
+						<TariffZone version="any" id="Zone4">
+							<ShortName>Zone4</ShortName>
+						</TariffZone>
+					</tariffZones>					
 				</SiteFrame>
 				<!-- - ==== UK Code values used === -->
 				<ResourceFrame version="001" created="2011-02-23T10:00:00Z" id="nptg:Types">

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -3496,7 +3496,7 @@ Correct COnstraints for PointOnRoute
 			<xsd:selector xpath=".//netex:SimpleVehicleType"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
-		</xsd:key> 
+		</xsd:key>
 		<!-- =====TypeOfDriverPermit==(NM)========================== -->
 		<!-- =====TypeOfDriverPermit unique========================== -->
 		<xsd:unique name="TypeOfDriverPermit_UniqueBy_Id_Version">
@@ -4062,7 +4062,7 @@ Correct COnstraints for PointOnRoute
 		<xsd:key name="SpotSensor_AnyVersionedKey">
 			<xsd:selector xpath=".//netex:SpotSensor"/>
 			<xsd:field xpath="@id"/>
-			<xsd:field xpath="@version"/>			
+			<xsd:field xpath="@version"/>
 		</xsd:key>
 		<!-- =====SensorInEntrance==(NM)========================== -->
 		<!-- =====SensorInEntrance unique========================== -->
@@ -4126,7 +4126,7 @@ Correct COnstraints for PointOnRoute
 			<xsd:selector xpath=".//netex:AcceptedDriverPermit"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
-		</xsd:key> 		
+		</xsd:key>
 		<!-- =====VehicleModel============================== -->
 		<!-- =====VehicleModel unique========================== -->
 		<xsd:unique name="VehicleModel_UniqueBy_Id_Version">
@@ -4189,7 +4189,7 @@ Correct COnstraints for PointOnRoute
 			<xsd:selector xpath=".//netex:VehicleEquipmentProfileMember"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
-		</xsd:key> 		
+		</xsd:key>
 		<!-- =====ChargingEquipmentProfile============================== -->
 		<!-- =====ChargingEquipmentProfile unique========================== -->
 		<xsd:unique name="ChargingEquipmentProfile_UniqueBy_Id_Version">

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_publication">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_publication">
 	<!-- ===SIRI system IDs for  request =========================================================== -->
 	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri/siri_base-v2.0.xsd"/>
 	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri_utility/siri_participant-v2.0.xsd"/>
@@ -3496,7 +3496,637 @@ Correct COnstraints for PointOnRoute
 			<xsd:selector xpath=".//netex:SimpleVehicleType"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
+		</xsd:key> 
+		<!-- =====TypeOfDriverPermit==(NM)========================== -->
+		<!-- =====TypeOfDriverPermit unique========================== -->
+		<xsd:unique name="TypeOfDriverPermit_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [TypeOfDriverPermit Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:TypeOfDriverPermit"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====TypeOfDriverPermit Key ========================== -->
+		<xsd:keyref name="TypeOfDriverPermit_KeyRef" refer="netex:TypeOfDriverPermit_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:TypeOfDriverPermitRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="TypeOfDriverPermit_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:TypeOfDriverPermit"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====SpotRow==(NM)========================== -->
+		<!-- =====SpotRow unique========================== -->
+		<xsd:unique name="SpotRow_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [SpotRow Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:SpotRow"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====SpotRow Key ========================== -->
+		<xsd:keyref name="SpotRow_KeyRef" refer="netex:SpotRow_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SpotRowRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="SpotRow_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SpotRow"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====SpotColumn==(NM)========================== -->
+		<!-- =====SpotColumn unique========================== -->
+		<xsd:unique name="SpotColumn_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [SpotColumn Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:SpotColumn"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====SpotColumn Key ========================== -->
+		<xsd:keyref name="SpotColumn_KeyRef" refer="netex:SpotColumn_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SpotColumnRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="SpotColumn_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SpotColumn"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====PassengerSpot==(NM)========================== -->
+		<!-- =====PassengerSpot unique========================== -->
+		<xsd:unique name="PassengerSpot_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [PassengerSpot Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:PassengerSpot"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====PassengerSpot Key ========================== -->
+		<xsd:keyref name="PassengerSpot_KeyRef" refer="netex:PassengerSpot_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:PassengerSpotRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="PassengerSpot_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:PassengerSpot"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====LuggageSpot ==(NM)========================== -->
+		<!-- =====LuggageSpot unique========================== -->
+		<xsd:unique name="LuggageSpot_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [LuggageSpot Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:LuggageSpot"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====LuggageSpot Key ========================== -->
+		<xsd:keyref name="LuggageSpot_KeyRef" refer="netex:LuggageSpot_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:LuggageSpotRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="LuggageSpot_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:LuggageSpot"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====PassengerVehicleSpot==(NM)========================== -->
+		<!-- =====PassengerVehicleSpot unique========================== -->
+		<xsd:unique name="PassengerVehicleSpot_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [PassengerVehicleSpot Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:PassengerVehicleSpot"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====PassengerVehicleSpot Key ========================== -->
+		<xsd:keyref name="PassengerVehicleSpot_KeyRef" refer="netex:PassengerVehicleSpot_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:PassengerVehicleSpotRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="PassengerVehicleSpot_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:PassengerVehicleSpot"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====TypeOfLocatableSpot==(NM)========================== -->
+		<!-- =====TypeOfLocatableSpot unique========================== -->
+		<xsd:unique name="TypeOfLocatableSpot_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [TypeOfLocatableSpot Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:TypeOfLocatableSpot"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====TypeOfLocatableSpot Key ========================== -->
+		<xsd:keyref name="TypeOfLocatableSpot_KeyRef" refer="netex:TypeOfLocatableSpot_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:TypeOfLocatableSpotRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="TypeOfLocatableSpot_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:TypeOfLocatableSpot"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====DeckPlan==(NM)========================== -->
+		<!-- =====DeckPlan unique========================== -->
+		<xsd:unique name="DeckPlan_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [DeckPlan Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:DeckPlan"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====DeckPlan Key ========================== -->
+		<xsd:keyref name="DeckPlan_KeyRef" refer="netex:DeckPlan_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckPlanRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="DeckPlan_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckPlan"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====Deck==(NM)========================== -->
+		<!-- =====Deck unique========================== -->
+		<xsd:unique name="Deck_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [Deck Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:Deck"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====Deck Key ========================== -->
+		<xsd:keyref name="Deck_KeyRef" refer="netex:Deck_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="Deck_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:Deck"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====PassengerSpace==(NM)========================== -->
+		<!-- =====PassengerSpace unique========================== -->
+		<xsd:unique name="PassengerSpace_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [PassengerSpace Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:PassengerSpace"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====PassengerSpace Key ========================== -->
+		<xsd:keyref name="PassengerSpace_KeyRef" refer="netex:PassengerSpace_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:PassengerSpaceRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="PassengerSpace_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:PassengerSpace"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====TypeOfLocatableSpot==(NM)========================== -->
+		<!-- =====OtherDeckSpace unique========================== -->
+		<xsd:unique name="OtherDeckSpace_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [OtherDeckSpace Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:OtherDeckSpace"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====OtherDeckSpace Key ========================== -->
+		<xsd:keyref name="OtherDeckSpace_KeyRef" refer="netex:OtherDeckSpace_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:OtherDeckSpaceRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="OtherDeckSpace_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:OtherDeckSpace"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====PassengerEntrance==(NM)========================== -->
+		<!-- =====PassengerEntrance unique========================== -->
+		<xsd:unique name="PassengerEntrance_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [PassengerEntrance Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:PassengerEntrance | .//netex:FromDeckEntrance | .//netex:ToDeckEntrance"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====PassengerEntrance Key ========================== -->
+		<xsd:keyref name="PassengerEntrance_KeyRef" refer="netex:PassengerEntrance_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:PassengerEntranceRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="PassengerEntrance_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:PassengerEntrance"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====OtherDeckEntrance==(NM)========================== -->
+		<!-- =====OtherDeckEntrance unique========================== -->
+		<xsd:unique name="OtherDeckEntrance_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [OtherDeckEntrance Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:OtherDeckEntrance"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====OtherDeckEntrance Key ========================== -->
+		<xsd:keyref name="OtherDeckEntrance_KeyRef" refer="netex:OtherDeckEntrance_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:OtherDeckEntranceRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="OtherDeckEntrance_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:OtherDeckEntrance"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====DeckVehicleEntrance==(NM)========================== -->
+		<!-- =====DeckVehicleEntrance unique========================== -->
+		<xsd:unique name="DeckVehicleEntrance_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [DeckVehicleEntrance Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:DeckVehicleEntrance"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====DeckVehicleEntrance Key ========================== -->
+		<xsd:keyref name="DeckVehicleEntrance_KeyRef" refer="netex:DeckVehicleEntrance_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckVehicleEntranceRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="DeckVehicleEntrance_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckVehicleEntrance"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====DeckEntranceUsage==(NM)========================== -->
+		<!-- =====DeckEntranceUsage unique========================== -->
+		<xsd:unique name="DeckEntranceUsage_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [DeckEntranceUsage Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:DeckEntranceUsage"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====DeckEntranceUsage Key ========================== -->
+		<xsd:keyref name="DeckEntranceUsage_KeyRef" refer="netex:DeckEntranceUsage_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckEntranceUsageRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="DeckEntranceUsage_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckEntranceUsage"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====DeckEntranceCouple==(NM)========================== -->
+		<!-- =====DeckEntranceCouple unique========================== -->
+		<xsd:unique name="DeckEntranceCouple_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [DeckEntranceCouple Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:DeckEntranceCouple"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====DeckEntranceCouple Key ========================== -->
+		<xsd:keyref name="DeckEntranceCouple_KeyRef" refer="netex:DeckEntranceCouple_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckEntranceCoupleRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="DeckEntranceCouple_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckEntranceCouple"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====DeckLevel==(NM)========================== -->
+		<!-- =====DeckLevel unique========================== -->
+		<xsd:unique name="DeckLevel_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [DeckLevel Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:DeckLevel"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====DeckLevel Key ========================== -->
+		<xsd:keyref name="DeckLevel_KeyRef" refer="netex:DeckLevel_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckLevelRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="DeckLevel_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckLevel"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====DeckCapacity==(NM)========================== -->
+		<!-- =====DeckCapacity unique========================== -->
+		<xsd:unique name="DeckCapacity_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [DeckCapacity Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:DeckCapacity"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====DeckCapacity Key ========================== -->
+		<xsd:keyref name="DeckCapacity_KeyRef" refer="netex:DeckCapacity_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckCapacityRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="DeckCapacity_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckCapacity"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====TypeOfDeckSpace==(NM)========================== -->
+		<!-- =====TypeOfDeckSpace unique========================== -->
+		<xsd:unique name="TypeOfDeckSpace_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [TypeOfDeckSpace Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:TypeOfDeckSpace"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====TypeOfDeckSpace Key ========================== -->
+		<xsd:keyref name="TypeOfDeckSpace_KeyRef" refer="netex:TypeOfDeckSpace_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:TypeOfDeckSpaceRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="TypeOfDeckSpace_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:TypeOfDeckSpace"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====TypeOfDeckEntrance==(NM)========================== -->
+		<!-- =====TypeOfDeckEntrance unique========================== -->
+		<xsd:unique name="TypeOfDeckEntrance_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [TypeOfDeckEntrance Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:TypeOfDeckEntrance"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====TypeOfDeckEntrance Key ========================== -->
+		<xsd:keyref name="TypeOfDeckEntrance_KeyRef" refer="netex:TypeOfDeckEntrance_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:TypeOfDeckEntranceRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="TypeOfDeckEntrance_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:TypeOfDeckEntrance"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====DeckPlanAssignment==(NM)========================== -->
+		<!-- =====DeckPlanAssignment unique========================== -->
+		<xsd:unique name="DeckPlanAssignment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [DeckPlanAssignment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:DeckPlanAssignment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====DeckPlanAssignment Key ========================== -->
+		<xsd:keyref name="DeckPlanAssignment_KeyRef" refer="netex:DeckPlanAssignment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckPlanAssignmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="DeckPlanAssignment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckPlanAssignment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====DeckEntranceAssignment==(NM)========================== -->
+		<!-- =====DeckEntranceAssignment unique========================== -->
+		<xsd:unique name="DeckEntranceAssignment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [DeckEntranceAssignment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:DeckEntranceAssignment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====DeckEntranceAssignment Key ========================== -->
+		<xsd:keyref name="DeckEntranceAssignment_KeyRef" refer="netex:DeckEntranceAssignment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckEntranceAssignmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="DeckEntranceAssignment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:DeckEntranceAssignment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====SeatEquipment==(NM)========================== -->
+		<!-- =====SeatEquipment unique========================== -->
+		<xsd:unique name="SeatEquipment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [SeatEquipment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:SeatEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====SeatEquipment Key ========================== -->
+		<xsd:keyref name="SeatEquipment_KeyRef" refer="netex:SeatEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SeatEquipmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="SeatEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SeatEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====BedEquipment==(NM)========================== -->
+		<!-- =====BedEquipment unique========================== -->
+		<xsd:unique name="BedEquipment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [BedEquipment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:BedEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====BedEquipment Key ========================== -->
+		<xsd:keyref name="BedEquipment_KeyRef" refer="netex:BedEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:BedEquipmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="BedEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:BedEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====LuggageBayEquipment==(NM)========================== -->
+		<!-- =====LuggageBayEquipment unique========================== -->
+		<xsd:unique name="LuggageBayEquipment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [LuggageBayEquipment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:LuggageBayEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====LuggageBayEquipment Key ========================== -->
+		<xsd:keyref name="LuggageBayEquipment_KeyRef" refer="netex:LuggageBayEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:LuggageBayEquipmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="LuggageBayEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:LuggageBayEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====EntranceSensor==(NM)========================== -->
+		<!-- =====EntranceSensor unique========================== -->
+		<xsd:unique name="EntranceSensor_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [EntranceSensor Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:EntranceSensor"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====EntranceSensor Key ========================== -->
+		<xsd:keyref name="EntranceSensor_KeyRef" refer="netex:EntranceSensor_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:EntranceSensorRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="EntranceSensor_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:EntranceSensor"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====SpotSensor==(NM)========================== -->
+		<!-- =====SpotSensor unique========================== -->
+		<xsd:unique name="SpotSensor_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [SpotSensor Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:SpotSensor"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====SpotSensor Key ========================== -->
+		<xsd:keyref name="SpotSensor_KeyRef" refer="netex:SpotSensor_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SpotSensorRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="SpotSensor_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SpotSensor"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>			
+		</xsd:key>
+		<!-- =====SensorInEntrance==(NM)========================== -->
+		<!-- =====SensorInEntrance unique========================== -->
+		<xsd:unique name="SensorInEntrance_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [SensorInEntrance Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:SensorInEntrance"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====SensorInEntrance Key ========================== -->
+		<xsd:keyref name="SensorInEntrance_KeyRef" refer="netex:SensorInEntrance_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SensorInEntranceRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="SensorInEntrance_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SensorInEntrance"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====SensorInSpot==(NM)========================== -->
+		<!-- =====SensorInSpot unique========================== -->
+		<xsd:unique name="SensorInSpot_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [SensorInSpot Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:SensorInSpot"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====SensorInSpot Key ========================== -->
+		<xsd:keyref name="SensorInSpot_KeyRef" refer="netex:SensorInSpot_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SensorInSpotRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="SensorInSpot_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SensorInSpot"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====AcceptedDriverPermit==(NM)========================== -->
+		<!-- =====AcceptedDriverPermit unique========================== -->
+		<xsd:unique name="AcceptedDriverPermit_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [AcceptedDriverPermit Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:AcceptedDriverPermit"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====AcceptedDriverPermit Key ========================== -->
+		<xsd:keyref name="AcceptedDriverPermit_KeyRef" refer="netex:AcceptedDriverPermit_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:AcceptedDriverPermitRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="AcceptedDriverPermit_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:AcceptedDriverPermit"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key> 		
 		<!-- =====VehicleModel============================== -->
 		<!-- =====VehicleModel unique========================== -->
 		<xsd:unique name="VehicleModel_UniqueBy_Id_Version">
@@ -3539,6 +4169,27 @@ Correct COnstraints for PointOnRoute
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====VehicleEquipmentProfileMember============================== -->
+		<!-- =====VehicleEquipmentProfileMember unique========================== -->
+		<xsd:unique name="VehicleEquipmentProfileMember_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [VehicleEquipmentProfileMember Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:VehicleEquipmentProfileMember"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====VehicleEquipmentProfileMember Key ========================== -->
+		<xsd:keyref name="VehicleEquipmentProfileMember_KeyRef" refer="netex:VehicleEquipmentProfileMember_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:VehicleEquipmentProfileMemberRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="VehicleEquipmentProfileMember_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:VehicleEquipmentProfileMember"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key> 		
 		<!-- =====ChargingEquipmentProfile============================== -->
 		<!-- =====ChargingEquipmentProfile unique========================== -->
 		<xsd:unique name="ChargingEquipmentProfile_UniqueBy_Id_Version">
@@ -6392,24 +7043,24 @@ Correct COnstraints for PointOnRoute
 			<xsd:field xpath="@version"/>
 			<xsd:field xpath="@order"/>
 		</xsd:key>
-		<!-- =====VehicleTypeStopAssignment============================== -->
-		<!-- =====VehicleTypeStopAssignment unique========================== -->
-		<xsd:unique name="VehicleTypeStopAssignment_UniqueBy_Id_Version">
+		<!-- =====VehicleJourneyStopAssignment============================== -->
+		<!-- =====VehicleJourneyStopAssignment unique========================== -->
+		<xsd:unique name="VehicleJourneyStopAssignment_UniqueBy_Id_Version">
 			<xsd:annotation>
-				<xsd:documentation>Every [VehicleTypeStopAssignment Id + Version] must be unique within document.</xsd:documentation>
+				<xsd:documentation>Every [VehicleJourneyStopAssignment Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:VehicleTypeStopAssignment"/>
+			<xsd:selector xpath=".//netex:VehicleJourneyStopAssignment"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>
-		<!-- =====VehicleTypeStopAssignment Key ========================== -->
-		<xsd:keyref name="VehicleTypeStopAssignment_KeyRef" refer="netex:VehicleTypeStopAssignment_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:VehicleTypeStopAssignmentRef"/>
+		<!-- =====VehicleJourneyStopAssignment Key ========================== -->
+		<xsd:keyref name="VehicleJourneyStopAssignment_KeyRef" refer="netex:VehicleJourneyStopAssignment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:VehicleJourneyStopAssignmentRef"/>
 			<xsd:field xpath="@ref"/>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
-		<xsd:key name="VehicleTypeStopAssignment_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:VehicleTypeStopAssignment"/>
+		<xsd:key name="VehicleJourneyStopAssignment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:VehicleJourneyStopAssignment"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>

--- a/xsd/netex_framework/netex_frames/netex_resourceFrame_version.xsd
+++ b/xsd/netex_framework/netex_frames/netex_resourceFrame_version.xsd
@@ -114,8 +114,8 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="ModesInFrameGroup"/>
 			<xsd:group ref="EquipmentInFrameGroup"/>
 			<xsd:group ref="FacilitySetsInFrameGroup"/>
-			<xsd:group ref="VehicleInFrameGroup"/> 
-			<xsd:group ref="DeckPlanInFrameGroup"/> 
+			<xsd:group ref="VehicleInFrameGroup"/>
+			<xsd:group ref="DeckPlanInFrameGroup"/>
 			<xsd:group ref="SchematicMapInFrameGroup"/>
 			<xsd:group ref="GeneralElementstInFrameGroup"/>
 			<xsd:group ref="SecurityListsInFrameGroup"/>

--- a/xsd/netex_framework/netex_frames/netex_resourceFrame_version.xsd
+++ b/xsd/netex_framework/netex_frames/netex_resourceFrame_version.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_resourceFrame_version">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_resourceFrame_version">
 	<xsd:include schemaLocation="netex_commonFrame_version.xsd"/>
 	<xsd:include schemaLocation="../netex_reusableComponents/netex_transportOrganisation_version.xsd"/>
 	<xsd:include schemaLocation="../netex_all_objects_framework.xsd"/>
@@ -17,13 +17,15 @@
 				<Date>
 					<Modified>2011-02-05</Modified>
 				</Date>
-				<Date><Modified>2017-03-28</Modified>CR031 Add Zones to RESOURCE FRAME 
+				<Date><Modified>2017-03-28</Modified>CR031 Add Zones to RESOURCE FRAME
 				</Date>
 				<Date><Modified>2017-06-28</Modified>CR048 Add Security Lists to RESOURCE FRAME
 				</Date>
 				<Date><Modified>2020-08-12</Modified>Issue 104 Add ResponsibilityRoles to RESOURCE FRAME
 				</Date>
 				<Date><Modified>2020-10-20</Modified>New Modes Add Facility sets to RESOURCE FRAME.
+				</Date>
+				<Date><Modified>2023-02-02</Modified>Add DECK PLAN CHANGES.
 				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines RESOURCE FRAME types.</p>
@@ -65,7 +67,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="ResourceFrame" substitutionGroup="CommonFrame">
 		<xsd:annotation>
-			<xsd:documentation>A coherent set of reference values for TYPE OF VALUEs , ORGANISATIONs, VEHICLE TYPEs etc that have a common validity, as specified by a set of frame VALIDITY CONDITIONs. Used to define common resources that will be referenced by other types of FRAME.</xsd:documentation>
+			<xsd:documentation>A coherent set of reference values for TYPE OF VALUEs, ORGANISATIONs, VEHICLE TYPEs etc that have a common validity, as specified by a set of frame VALIDITY CONDITIONs. Used to define common resources that will be referenced by other types of FRAME.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -112,7 +114,8 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="ModesInFrameGroup"/>
 			<xsd:group ref="EquipmentInFrameGroup"/>
 			<xsd:group ref="FacilitySetsInFrameGroup"/>
-			<xsd:group ref="VehicleInFrameGroup"/>
+			<xsd:group ref="VehicleInFrameGroup"/> 
+			<xsd:group ref="DeckPlanInFrameGroup"/> 
 			<xsd:group ref="SchematicMapInFrameGroup"/>
 			<xsd:group ref="GeneralElementstInFrameGroup"/>
 			<xsd:group ref="SecurityListsInFrameGroup"/>
@@ -148,7 +151,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="GeneralElementstInFrameGroup">
 		<xsd:annotation>
-			<xsd:documentation>General  Elements of a RESOURCE FRAME.</xsd:documentation>
+			<xsd:documentation>General Elements of a RESOURCE FRAME.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="groupsOfEntities" type="groupOfEntitiesInFrame_RelStructure" minOccurs="0">

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_support.xsd
@@ -200,6 +200,6 @@ Rail transport, Roads and Road transport
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
-	</xsd:complexType>	
+	</xsd:complexType>
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_support.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_zone_version">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_zone_version">
 	<xsd:include schemaLocation="netex_pointAndLink_support.xsd"/>
 	<xsd:annotation>
 		<xsd:appinfo>
@@ -29,7 +29,7 @@
 				<Language>[ISO 639-2/B] ENG</Language>
 				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
 				<Rights>Unclassified
- <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+ <Copyright>CEN, Crown Copyright 2009-2023</Copyright>
 				</Rights>
 				<Source>
 					<ul>
@@ -54,7 +54,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>ZONE identifier types for NeTEx.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ====Zone======================================================= -->
+	<!-- ==== ZONE ======================================================= -->
 	<xsd:simpleType name="ZoneIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a ZONE.</xsd:documentation>
@@ -75,8 +75,6 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<xsd:complexType name="zoneRefs_RelStructure">
-		<xsd:annotation>
-		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="oneToManyRelationshipStructure">
 				<xsd:sequence>
@@ -85,7 +83,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<!-- ======================================================================= -->
+	<!-- ========= TARIFF ZONE ============================================================== -->
 	<xsd:element name="TariffZoneRef_" type="ZoneRefStructure" abstract="true" substitutionGroup="ZoneRef">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type Reference to a TARIFF ZONE.</xsd:documentation>
@@ -165,5 +163,43 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
+	<!-- ==  GROUP OF TARIFFZONEs  ============================================== -->
+	<xsd:element name="GroupOfTariffZonesRef" type="GroupOfTariffZonesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a GROUP OF TARIFF ZONEs.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="GroupOfTariffZonesRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a GROUP OF TARIFF ZONEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="GroupOfEntitiesRefStructure">
+				<xsd:attribute name="ref" type="GroupOfTariffZonesIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a GROUP OF TARIFF ZONEs.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="GroupOfTariffZonesIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a GROUP OF TARIFF ZONEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="GroupOfEntitiesIdType"/>
+	</xsd:simpleType>
+	<xsd:complexType name="groupOfTariffZoneRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of GROUP OF TARIFF ZONEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="GroupOfTariffZonesRef" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
@@ -21,17 +21,13 @@
 				<Date>
 					<Modified>2017-03-28  Add Zones to RESOURCE FRAME</Modified>
 				</Date>
-				<Date>
-					<Modified>2017-11-08</Modified>Add  TARIFF ZONE Presentation Group
+				<Date><Modified>2017-11-08</Modified>Add  TARIFF ZONE Presentation Group
 				</Date>
-				<Date>
-					<Modified>2018-03-09</Modified>Correct Type on GENERAL ZONE element
+				<Date><Modified>2018-03-09</Modified>Correct Type on GENERAL ZONE element
 				</Date>
-				<Date>
-					<Modified>2019-02-25</Modified>UK-18 Introduce a dummy TariffZone_ type to workaround substitutiongroup restrictions  in XML spy
+				<Date><Modified>2019-02-25</Modified>UK-18 Introduce a dummy TariffZone_ type to workaround substitutiongroup restrictions  in XML spy
 				</Date>
-				<Date>
-					<Modified>2021-01-25</Modified>Add GroupOfTariffZones
+				<Date><Modified>2021-01-25</Modified>Add GroupOfTariffZones
 				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines ZONE types.</p>

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_zone_version">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_zone_version">
 	<xsd:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="../../gml/gml_extract_all_objects_v_3_2_1.xsd"/>
 	<!--Actual dependency-->
 	<xsd:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="../../gml/gmlBasic2d-extract-v3_2_1-.xsd"/>
@@ -21,13 +21,17 @@
 				<Date>
 					<Modified>2017-03-28  Add Zones to RESOURCE FRAME</Modified>
 				</Date>
-				<Date><Modified>2017-11-08</Modified>Add  TARIFF ZONE Presentation Group
+				<Date>
+					<Modified>2017-11-08</Modified>Add  TARIFF ZONE Presentation Group
 				</Date>
-				<Date><Modified>2018-03-09</Modified>Correct Type on GENERAL ZONE element
+				<Date>
+					<Modified>2018-03-09</Modified>Correct Type on GENERAL ZONE element
 				</Date>
-				<Date><Modified>2019-02-25</Modified>UK-18 Introduce a dummy TariffZone_ type to workaround substitutiongroup restrictions  in XML spy
+				<Date>
+					<Modified>2019-02-25</Modified>UK-18 Introduce a dummy TariffZone_ type to workaround substitutiongroup restrictions  in XML spy
 				</Date>
-				<Date><Modified>2021-01-25</Modified>Add GroupOfTariffZones
+				<Date>
+					<Modified>2021-01-25</Modified>Add GroupOfTariffZones
 				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines ZONE types.</p>
@@ -41,7 +45,7 @@
 				<Language>[ISO 639-2/B] ENG</Language>
 				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
 				<Rights>Unclassified
- 					<Copyright>CEN, Crown Copyright 2009-2019</Copyright>
+ 					<Copyright>CEN, Crown Copyright 2009-2023</Copyright>
 				</Rights>
 				<Source>
 					<ul>
@@ -92,7 +96,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<!-- ====Zone======================================================= -->
+	<!-- ==== ZONE ======================================================= -->
 	<xsd:element name="Zone" type="Zone_VersionStructure" abstract="false" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A two-dimensional PLACE within the service area of a public transport operator (administrative zone, TARIFF ZONE, ACCESS ZONE, etc.).</xsd:documentation>
@@ -144,7 +148,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ======================================================================= -->
+	<!-- ============= GENERAL ZONE ========================================================== -->
 	<xsd:element name="GeneralZone" abstract="false" substitutionGroup="Zone">
 		<xsd:annotation>
 			<xsd:documentation>A GENERAL ZONE used to define a zonal fare structure in a zone-counting or zone-matrix system.</xsd:documentation>
@@ -182,7 +186,75 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="Zone_VersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<!-- ======================================================================= -->
+	<!-- ===  GROUP OF TARIFF ZONES ================================================= -->
+	<xsd:complexType name="groupsOfTariffZones_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for list of  GROUP OF TARIFF ZONES.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="GroupOfTariffZones" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="GroupOfTariffZones" abstract="false" substitutionGroup="GroupOfEntities">
+		<xsd:annotation>
+			<xsd:documentation>A grouping of TariffZones which will be commonly referenced for a specific purpose. +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="GroupOfTariffZones_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="GroupOfEntitiesGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="GroupOfTariffZonesGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="GroupOfTariffZonesIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="GroupOfTariffZones_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for GROUP OF TARIFF ZONES.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="GroupOfEntities_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="GroupOfTariffZonesGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="GroupOfTariffZonesGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for GROUP OF TARIFF ZONES.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="PublicCode" type="ExternalObjectRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Public code for GROUP OF TARIFF ZONES.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="members" type="tariffZoneRefs_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>TARIFF ZONEs  in a GROUP OF TARIFF ZONES </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======= TARIFF ZONE  ================================================ -->
 	<xsd:element name="TariffZone_" type="Zone_VersionStructure" abstract="true" substitutionGroup="Zone">
 		<xsd:annotation>
 			<xsd:documentation>Dummy TARIFF ZONE  to workaround xML spy Substitution Group limitations</xsd:documentation>
@@ -258,83 +330,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ==  GROUP OF TARIFF ZONEs ============================================== -->
-	<xsd:element name="GroupOfTariffZones" abstract="false" substitutionGroup="GroupOfEntities">
-		<xsd:annotation>
-			<xsd:documentation>A grouping of TARIFF ZONEs which will be commonly referenced for a specific purpose.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexType>
-			<xsd:complexContent>
-				<xsd:restriction base="GroupOfTariffZones_VersionStructure">
-					<xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="DataManagedObjectGroup"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="GroupOfEntitiesGroup"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="GroupOfTariffZonesGroup"/>
-						</xsd:sequence>
-					</xsd:sequence>
-					<xsd:attribute name="id" type="GroupOfTariffZonesIdType"/>
-				</xsd:restriction>
-			</xsd:complexContent>
-		</xsd:complexType>
-	</xsd:element>
-	<xsd:complexType name="GroupOfTariffZones_VersionStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for GROUP OF TARIFF ZONEs.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="GroupOfEntities_VersionStructure">
-				<xsd:sequence>
-					<xsd:group ref="GroupOfTariffZonesGroup"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:group name="GroupOfTariffZonesGroup">
-		<xsd:annotation>
-			<xsd:documentation>Elements for GROUP OF TARIFF ZONEs.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="members" type="tariffZoneRefs_RelStructure" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>TARIFF ZONEs in GROUP OF TARIFF ZONEs.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:group>
-	<xsd:element name="GroupOfTariffZonesRef" type="GroupOfTariffZonesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
-		<xsd:annotation>
-			<xsd:documentation>Reference to a GROUP OF TARIFF ZONEs.</xsd:documentation>
-		</xsd:annotation>
-	</xsd:element>
-	<xsd:complexType name="GroupOfTariffZonesRefStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for a GROUP OF TARIFF ZONEs.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:restriction base="GroupOfEntitiesRefStructure">
-				<xsd:attribute name="ref" type="GroupOfTariffZonesIdType" use="required">
-					<xsd:annotation>
-						<xsd:documentation>Identifier of a GROUP OF TARIFF ZONEs.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:restriction>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:simpleType name="GroupOfTariffZonesIdType">
-		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a GROUP OF TARIFF ZONEs.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="GroupOfEntitiesIdType"/>
-	</xsd:simpleType>
-	<!-- ======================================================================= -->
+	<!-- ===============TYPE OF ZONE ======================================================== -->
 	<xsd:element name="TypeOfZone" abstract="false" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>Classification of a ZONe.</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_all_objects_reusableComponents.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_all_objects_reusableComponents.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_all_objects_reusableComponents"> 
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_all_objects_reusableComponents">
 	<!-- ====== Topographic ==================================================== -->
 	<xsd:include schemaLocation="netex_address_support.xsd"/>
 	<xsd:include schemaLocation="netex_address_version.xsd"/>
@@ -20,11 +20,11 @@
 	<xsd:include schemaLocation="netex_equipmentPlace_version.xsd"/>
 	<xsd:include schemaLocation="netex_equipment_version.xsd"/>
 	<xsd:include schemaLocation="netex_equipmentVehiclePassenger_support.xsd"/>
-	<xsd:include schemaLocation="netex_equipmentVehiclePassenger_version.xsd"/> 
+	<xsd:include schemaLocation="netex_equipmentVehiclePassenger_version.xsd"/>
 	<xsd:include schemaLocation="netex_spotEquipment_support.xsd"/>
 	<xsd:include schemaLocation="netex_spotEquipment_version.xsd"/>
 	<xsd:include schemaLocation="netex_sensorEquipment_support.xsd"/>
-	<xsd:include schemaLocation="netex_sensorEquipment_version.xsd"/> 
+	<xsd:include schemaLocation="netex_sensorEquipment_version.xsd"/>
 	<xsd:include schemaLocation="netex_nm_equipmentEnergy_support.xsd"/>
 	<xsd:include schemaLocation="netex_nm_equipmentEnergy_version.xsd"/>
 	<xsd:include schemaLocation="netex_nm_chargingEquipmentProfile_support.xsd"/>
@@ -58,9 +58,9 @@
 	<xsd:include schemaLocation="netex_vehicleType_support.xsd"/>
 	<xsd:include schemaLocation="netex_vehicleType_version.xsd"/>
 	<xsd:include schemaLocation="netex_trainElement_support.xsd"/>
-	<xsd:include schemaLocation="netex_trainElement_version.xsd"/>  
+	<xsd:include schemaLocation="netex_trainElement_version.xsd"/>
 	<xsd:include schemaLocation="netex_seatingPlan_support.xsd"/>
 	<xsd:include schemaLocation="netex_seatingPlan_version.xsd"/>
 	<xsd:include schemaLocation="netex_deckPlan_support.xsd"/>
-	<xsd:include schemaLocation="netex_deckPlan_version.xsd"/> 
+	<xsd:include schemaLocation="netex_deckPlan_version.xsd"/>
 </xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_all_objects_reusableComponents.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_all_objects_reusableComponents.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_all_objects_reusableComponents">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_all_objects_reusableComponents"> 
 	<!-- ====== Topographic ==================================================== -->
 	<xsd:include schemaLocation="netex_address_support.xsd"/>
 	<xsd:include schemaLocation="netex_address_version.xsd"/>
@@ -20,7 +20,11 @@
 	<xsd:include schemaLocation="netex_equipmentPlace_version.xsd"/>
 	<xsd:include schemaLocation="netex_equipment_version.xsd"/>
 	<xsd:include schemaLocation="netex_equipmentVehiclePassenger_support.xsd"/>
-	<xsd:include schemaLocation="netex_equipmentVehiclePassenger_version.xsd"/>
+	<xsd:include schemaLocation="netex_equipmentVehiclePassenger_version.xsd"/> 
+	<xsd:include schemaLocation="netex_spotEquipment_support.xsd"/>
+	<xsd:include schemaLocation="netex_spotEquipment_version.xsd"/>
+	<xsd:include schemaLocation="netex_sensorEquipment_support.xsd"/>
+	<xsd:include schemaLocation="netex_sensorEquipment_version.xsd"/> 
 	<xsd:include schemaLocation="netex_nm_equipmentEnergy_support.xsd"/>
 	<xsd:include schemaLocation="netex_nm_equipmentEnergy_version.xsd"/>
 	<xsd:include schemaLocation="netex_nm_chargingEquipmentProfile_support.xsd"/>
@@ -54,5 +58,9 @@
 	<xsd:include schemaLocation="netex_vehicleType_support.xsd"/>
 	<xsd:include schemaLocation="netex_vehicleType_version.xsd"/>
 	<xsd:include schemaLocation="netex_trainElement_support.xsd"/>
-	<xsd:include schemaLocation="netex_trainElement_version.xsd"/>
+	<xsd:include schemaLocation="netex_trainElement_version.xsd"/>  
+	<xsd:include schemaLocation="netex_seatingPlan_support.xsd"/>
+	<xsd:include schemaLocation="netex_seatingPlan_version.xsd"/>
+	<xsd:include schemaLocation="netex_deckPlan_support.xsd"/>
+	<xsd:include schemaLocation="netex_deckPlan_version.xsd"/> 
 </xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd
@@ -573,5 +573,31 @@
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
+	<!-- ==== SENSOR IN ENTRANCE  =========================================== -->
+	<xsd:simpleType name="SensorInEntranceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of SENSOR IN ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SensorInEntranceRef" type="SensorInEntranceRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a SENSOR IN ENTRANCE. +V2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SensorInEntranceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SENSOR IN ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="SensorInEntranceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SENSOR IN ENTRANCE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>	
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd
@@ -13,8 +13,7 @@
 				<Date>
 					<Created>2023-01-30</Created>
 				</Date>
-				<Date>
-					<Modified>2023-02-01</Modified>
+				<Date><Modified>2023-02-01</Modified>
           Name Space changes
         </Date>
 				<Description>
@@ -598,6 +597,6 @@
 				</xsd:attribute>
 			</xsd:restriction>
 		</xsd:simpleContent>
-	</xsd:complexType>	
+	</xsd:complexType>
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd
@@ -1,0 +1,577 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_deckPlan_support">
+	<!-- ======================================================================= -->
+	<xsd:include schemaLocation="netex_seatingPlan_support.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>V1.0 Nicholas Knowles</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for NeTEx version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-01-30</Created>
+				</Date>
+				<Date>
+					<Modified>2023-02-01</Modified>
+          Name Space changes
+        </Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the DECK PLAN types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_deckPlan_support.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>
+				<Relation>
+					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
+				</Relation>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright 2023-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel  standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx DECK PLAN types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>DECK PLAN identifier  types</xsd:documentation>
+	</xsd:annotation>
+	<!-- ==== DECK PLAN==================================================== -->
+	<xsd:complexType name="deckPlanRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DECK PLANs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="DeckPlanRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="DeckPlanIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK PLAN.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckPlanRef" type="DeckPlanRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK PLAN. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckPlanRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK PLAN.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="DeckPlanIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK PLAN.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ==== DECK  ==================================================== -->
+	<xsd:complexType name="deckRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DECKs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="DeckRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="DeckIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckRef" type="DeckRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="DeckIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ===== DECK COMPONENT ======================================================== -->
+	<xsd:simpleType name="DeckComponentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK COMPONENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="EquipableSpaceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckComponentRef" type="DeckComponentRefStructure" substitutionGroup="EquipableSpaceRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK COMPONENT. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckComponentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK COMPONENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="EquipableSpaceRefStructure">
+				<xsd:attribute name="ref" type="DeckComponentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== DECK SPACE ======================================= -->
+	<xsd:simpleType name="DeckSpaceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="DeckComponentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckSpaceRef" type="DeckSpaceRefStructure" abstract="true" substitutionGroup="DeckComponentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK SPACE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckSpaceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="DeckComponentRefStructure">
+				<xsd:attribute name="ref" type="DeckSpaceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK SPACE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== PASSENGER SPACE ======================================= -->
+	<xsd:simpleType name="PassengerSpaceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PASSENGER SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="DeckSpaceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="PassengerSpaceRef" type="PassengerSpaceRefStructure" substitutionGroup="DeckSpaceRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PASSENGER SPACE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PassengerSpaceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a PASSENGER SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="DeckSpaceRefStructure">
+				<xsd:attribute name="ref" type="PassengerSpaceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PASSENGER SPACE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="PassengerSpaceTypeEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for type of epassenger space.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:normalizedString">
+			<xsd:enumeration value="seatingArea"/>
+			<xsd:enumeration value="passsengerCabin"/>
+			<xsd:enumeration value="crewSpace"/>
+			<xsd:enumeration value="corridor"/>
+			<xsd:enumeration value="restaurant"/>
+			<xsd:enumeration value="toilet"/>
+			<xsd:enumeration value="galley"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- ====== OTHER DECK SPACE ======================================= -->
+	<xsd:simpleType name="OtherDeckSpaceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a OTHER DECK SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="DeckSpaceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="OtherDeckSpaceRef" type="OtherDeckSpaceRefStructure" substitutionGroup="DeckSpaceRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a OTHER DECK SPACE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="OtherDeckSpaceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a OTHER DECK SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="DeckSpaceRefStructure">
+				<xsd:attribute name="ref" type="OtherDeckSpaceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a OTHER DECK SPACE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== DECK ENTRANCE ======================================= -->
+	<xsd:simpleType name="DeckEntranceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="DeckComponentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckEntranceRef" type="DeckEntranceRefStructure" abstract="true" substitutionGroup="DeckComponentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK ENTRANCE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckEntranceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="DeckComponentRefStructure">
+				<xsd:attribute name="ref" type="DeckEntranceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK ENTRANCE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="DeckEntranceTypeEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for type of DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:normalizedString">
+			<xsd:enumeration value="external"/>
+			<xsd:enumeration value="internal"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="VehicleSideEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for Relation to vehicle of ENtrance.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="left"/>
+			<xsd:enumeration value="right"/>
+			<xsd:enumeration value="front"/>
+			<xsd:enumeration value="back"/>
+			<xsd:enumeration value="other"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- ====== PASSENGER ENTRANCE ======================================= -->
+	<xsd:simpleType name="PassengerEntranceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PASSENGER ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="DeckEntranceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="PassengerEntranceRef" type="PassengerEntranceRefStructure" substitutionGroup="DeckEntranceRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PASSENGER ENTRANCE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PassengerEntranceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a PASSENGER ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="DeckEntranceRefStructure">
+				<xsd:attribute name="ref" type="PassengerEntranceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PASSENGER ENTRANCE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== DECK VEHICLE ENTRANCE ======================================= -->
+	<xsd:simpleType name="DeckVehicleEntranceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK VEHICLE ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="DeckEntranceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckVehicleEntranceRef" type="DeckVehicleEntranceRefStructure" substitutionGroup="DeckEntranceRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK VEHICLE ENTRANCE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckVehicleEntranceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK VEHICLE ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="DeckEntranceRefStructure">
+				<xsd:attribute name="ref" type="DeckVehicleEntranceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK VEHICLE ENTRANCE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== OTHER DECK ENTRANCE ======================================= -->
+	<xsd:simpleType name="OtherDeckEntranceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a OTHER DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="DeckEntranceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="OtherDeckEntranceRef" type="OtherDeckEntranceRefStructure" substitutionGroup="DeckEntranceRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a OTHER DECK ENTRANCE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="OtherDeckEntranceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a OTHER DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="DeckEntranceRefStructure">
+				<xsd:attribute name="ref" type="OtherDeckEntranceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a OTHER DECK ENTRANCE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== DECK ENTRANCE USAGE======================================= -->
+	<xsd:simpleType name="DeckEntranceUsageIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK ENTRANCE USAGE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="DeckComponentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckEntranceUsageRef" type="DeckEntranceUsageRefStructure" substitutionGroup="DeckComponentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK ENTRANCE USAGE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckEntranceUsageRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK ENTRANCE USAGE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="DeckComponentRefStructure">
+				<xsd:attribute name="ref" type="DeckEntranceUsageIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK ENTRANCE USAGE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="EntranceUsageEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for type of entrance Usage..</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:normalizedString">
+			<xsd:enumeration value="entryAndExit"/>
+			<xsd:enumeration value="entry"/>
+			<xsd:enumeration value="exit"/>
+			<xsd:enumeration value="emergencyExit"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- ====== DECK ENTRANCE COUPLE ====================================== -->
+	<xsd:simpleType name="DeckEntranceCoupleIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK ENTRANCE COUPLE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="DeckComponentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckEntranceCoupleRef" type="DeckEntranceCoupleRefStructure" substitutionGroup="DeckComponentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK ENTRANCE COUPLE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckEntranceCoupleRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK ENTRANCE COUPLE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="DeckComponentRefStructure">
+				<xsd:attribute name="ref" type="DeckEntranceCoupleIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK ENTRANCE COUPLE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== DECK WINDOW ======================================= -->
+	<xsd:simpleType name="DeckWindowIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK WINDOW.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="DeckComponentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckWindowRef" type="DeckWindowRefStructure" substitutionGroup="DeckComponentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK WINDOW. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckWindowRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK WINDOW.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="DeckComponentRefStructure">
+				<xsd:attribute name="ref" type="DeckWindowIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK WINDOW.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== DECK WINDOW ======================================= -->
+	<xsd:simpleType name="DeckLevelIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK LEVEL.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckLevelRef" type="DeckLevelRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK LEVEL. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckLevelRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK LEVEL.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="DeckLevelIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK LEVEL.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======= DECK SPACE CAPACITY =========================================== -->
+	<xsd:simpleType name="DeckSpaceCapacityIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK SPACE CAPACITY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckSpaceCapacityRef" type="DeckSpaceCapacityRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK SPACE CAPACITY. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckSpaceCapacityRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK SPACE CAPACITY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="DeckSpaceCapacityIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK SPACE CAPACITY</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--==== PURPOSE OF EQUIPMENT =========================================================-->
+	<xsd:simpleType name="TypeOfDeckSpaceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a TYPE OF DECK SPACE PROFILE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="TypeOfValueIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="TypeOfDeckSpaceRef" type="TypeOfDeckSpaceProfileRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a TYPE OF DECK SPACE PROFILE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="TypeOfDeckSpaceProfileRefStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a TYPE OF DECK SPACE PROFILE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="TypeOfValueRefStructure">
+				<xsd:attribute name="ref" type="TypeOfDeckSpaceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Reference to a TYPE OF DECK SPACE PROFILE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--==== TYPE OF DECK ENTRANCE  =========================================================-->
+	<xsd:simpleType name="TypeOfDeckEntranceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a TYPE OF DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="TypeOfValueIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="TypeOfDeckEntranceRef" type="TypeOfDeckEntranceRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a TYPE OF DECK ENTRANCE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="TypeOfDeckEntranceRefStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a TYPE OF DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="TypeOfValueRefStructure">
+				<xsd:attribute name="ref" type="TypeOfDeckEntranceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Reference to a TYPE OF DECK ENTRANCE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -1,0 +1,1362 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_deckPlan_version">
+	<xsd:include schemaLocation="netex_deckPlan_support.xsd"/>
+	<xsd:include schemaLocation="netex_seatingPlan_version.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>V1.0 Nicholas Knowles</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for NeTEx version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-01-30</Created>
+				</Date>
+				<Date>
+					<Modified>2023-01-30</Modified>
+          Name Space changes
+        </Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the DECK PLAN types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_deckPlan_version.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>
+				<Relation>
+					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
+				</Relation>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright  2022-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel,   standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx DECK PLAN types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>DECK PLAN data types</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:group name="DeckPlanInFrameGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK PLAN in Frame.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="deckPlans" type="deckPlansInFrame_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DECK OKANs in FRAME.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:complexType name="deckPlansInFrame_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for containment in frame of DECK PLANs</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="DeckPlan" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ==== DECK PLAN ==================================================== -->
+	<xsd:element name="DeckPlan" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A  plan for the layout of seating and other areas of use of an entire VEHICLE (train, coach, vessel etc.) or individual TRAIN ELEMENT for all or part of a journey.  +v2.0
+
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DeckPlan_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckPlanGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DeckPlanIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of DECK PLAN.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DeckPlan_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK PLAN.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DataManagedObjectStructure">
+				<xsd:sequence>
+					<xsd:group ref="DeckPlanGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckPlanGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK PLAN.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of DECK PLAN.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Description" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Description of DECK PLAN.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="deckLevels" type="deckLevels_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DECK LEVELs in DECK PLAN.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="decks" type="decks_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DECKs in DECK PLAN.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======= DECK ================================================== -->
+	<xsd:complexType name="decks_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list ofDECKs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="Deck" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="Deck" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>An area within a VEHICLE (i.e. bus, boat, coach, car, plan, etc.) or TRAIN ELEMENT made up of one or more DECK SPACEs.  A subdivision of  a DECK PLAN
+. +V2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="Deck_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:group ref="DeckGroup"/>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DeckIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of VEHICLE EQUIPMENT PROILE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="Deck_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DataManagedObjectStructure">
+				<xsd:group ref="DeckGroup">
+					<xsd:annotation>
+						<xsd:documentation>Elements for an DECK.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:group>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of DECK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Label" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of DECK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="DeckLevelRef" minOccurs="0"/>
+			<xsd:element name="deckSpaces" type="deckSpaces_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DECK SPACEs in DECK PLAN.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="spotRows" type="spotRows_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Rows on DECK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="spotColumns" type="spotColumns_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>COLUMNs  on DECK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== DECK COMPONENT ======================================================= -->
+	<xsd:element name="DeckComponent" type="DeckComponent_VersionStructure" abstract="true" substitutionGroup="EquipableSpace">
+		<xsd:annotation>
+			<xsd:documentation> An abstract element providing common features for spatially located elements within the DECK PLAN.+v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckComponent_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK COMPONENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="EquipableSpace_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="DeckComponentGroup">
+						<xsd:annotation>
+							<xsd:documentation>Elements for a DECK COMPONENT.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckComponentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK COMPONENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of DECK COMPONENT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Description" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Description of DECK COMPONENT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="PublicUse" type="xsd:boolean" default="true" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether DECK COMPONENT is for public use. Default is true.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="DeckLevelRef" minOccurs="0"/>
+			<xsd:element ref="ClassOfUseRef" minOccurs="0"/>
+			<xsd:element name="FareClass" type="FareClassEnumeration" default="any" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Edit care class for which capacity is specifyed. Default is any, i.e. capacity is for all classes.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="AccessibilityAssessment" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== DECK SPACE =================================== -->
+	<xsd:complexType name="deckSpaces_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DECK SPACEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="DeckSpaceRef"/>
+					<xsd:element ref="DeckSpace_"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="DeckSpace_" type="DeckComponent_VersionStructure" abstract="true" substitutionGroup="DeckComponent">
+		<xsd:annotation>
+			<xsd:documentation>Dummy type to work around SG limitations</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="DeckSpace" abstract="true" substitutionGroup="DeckComponent">
+		<xsd:annotation>
+			<xsd:documentation>An area within a VEHICLE  (i.e. bus, boat, coach, car)  or TRAIN ELEMENT delimiting a particular use such as seating, WC, bar, gangway, etc. May be specialised, e.g. as PASSENGER SPACE ; may contain other spaces. Different types of space may overlap.  +v2.0.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DeckSpace_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckComponentGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a PASSENGER CARRYING REQUIREMENT TYPE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckSpaceGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DeckSpaceIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of DECK SPACE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DeckSpace_VersionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DeckComponent_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="DeckSpaceGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckSpaceGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Covered" type="xsd:boolean" default="true" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether DECK SPACE is covered. Default is true.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="AirConditioned" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether DECK SPACE is air conditioned.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="SmokingAllowed" type="xsd:boolean" default="false" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether smoking is allowed in DECK SPACE. Defaukts is false.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="TypeOfDeckSpaceRef" minOccurs="0"/>
+			<xsd:element name="ParentDeckSpaceRef" type="DeckSpaceRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Deck space containing this deck space</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:group ref="DeckSpaceEntranceGroup"/>
+			<xsd:element name="TotalCapacity" type="NumberOfPassengers" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The total capacity of people for the DECK SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="deckSpaceCapacities" type="deckSpaceCapacities_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Capacities of DECK SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="DeckSpaceEntranceGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="deckEntrances" type="deckEntrances_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DECK ENTRANCEs to DECK SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="deckEntranceCouples" type="deckEntranceCouples_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DECK ENTRANCE COUPLEs for DECK SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="deckEntranceUsages" type="deckEntranceUsages_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DECK ENTRANCE USAGEs for DECK SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="deckWindows" type="deckWindows_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DECK WINDOWs on DECK SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== PASSENGER  SPACE =================================== -->
+	<xsd:complexType name="passengerSpaces_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of PASSENGER SPACEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="PassengerSpaceRef"/>
+					<xsd:element ref="PassengerSpace"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="PassengerSpace" substitutionGroup="DeckSpace_">
+		<xsd:annotation>
+			<xsd:documentation> +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="PassengerSpace_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipableSpaceGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a EQUIPABLE SPACE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckComponentGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a PASSENGER CARRYING REQUIREMENT TYPE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckSpaceGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="PassengerSpaceGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="PassengerSpaceIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of PASSENGER SPACE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="PassengerSpace_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a PASSENGER SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DeckSpace_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="PassengerSpaceGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="PassengerSpaceGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a PASSENGER SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="StandingAllowed" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether standing is allowed in DECK SPACE. </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="passengerSpots" type="passengerSpots_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>PASSENGER SPOTs, i.e. seats in PASSENGER SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="luggageSpots" type="luggageSpots_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>LUGGAGE SPOTS in PASSENGER SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="passengerVehicleSpots" type="passengerVehicleSpots_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>PASSENGER VEHICLE SPOTs in PASSENGER SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== OTHER DECK  SPACE =================================== -->
+	<xsd:complexType name="otherDeckSpaces_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of OTHER DECK SPACEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="OtherDeckSpaceRef"/>
+					<xsd:element ref="OtherDeckSpace"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="OtherDeckSpace" substitutionGroup="DeckSpace_">
+		<xsd:annotation>
+			<xsd:documentation> +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="OtherDeckSpace_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipableSpaceGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a EQUIPABLE SPACE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckComponentGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a PASSENGER CARRYING REQUIREMENT TYPE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckSpaceGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="OtherDeckSpaceGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="OtherDeckSpaceIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of OTHER DECK SPACE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="OtherDeckSpace_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a OTHER DECK SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DeckSpace_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="OtherDeckSpaceGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="OtherDeckSpaceGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a OTHER DECK SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence/>
+	</xsd:group>
+	<!-- ====== DECK ENTRANCE =================================== -->
+	<xsd:element name="DeckEntrance_" type="DeckComponent_VersionStructure" abstract="true" substitutionGroup="DeckComponent">
+		<xsd:annotation>
+			<xsd:documentation>Dummy type to work around SG limitations</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="deckEntrances_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DECK ENTRANCEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="DeckEntranceRef"/>
+					<xsd:element ref="DeckEntrance_"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="DeckEntrance" abstract="true" substitutionGroup="DeckComponent">
+		<xsd:annotation>
+			<xsd:documentation>An entrance to or within a  DECK.  +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DeckEntrance_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipableSpaceGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a EQUIPABLE SPACE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckComponentGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a PASSENGER CARRYING REQUIREMENT TYPE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckEntranceGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DeckEntranceIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of DECK ENTRANCE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DeckEntrance_VersionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DeckComponent_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="DeckEntranceGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckEntranceGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="DeckEntranceType" type="DeckEntranceTypeEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Type of DECK ENTRANCE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="EntranceSide" type="VehicleSideEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Side of ENTRANCE relative to forward orientation of VEHICLE. to .</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="DistanceFromFront" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Distance of forward edge of door from front of Vehicle..</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="IsAutomatic" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether the door is automatic.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="TypeOfDeckEntranceRef" minOccurs="0"/>
+			<xsd:element name="sensorsInEntrance" type="sensorsInEntrance_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>ENTRANCE SENSORS in the DECK ENTRANCE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== PASSENGER  ENTRANCE =================================== -->
+	<xsd:element name="PassengerEntrance" substitutionGroup="DeckEntrance_">
+		<xsd:annotation>
+			<xsd:documentation> A normal entrance for passengers to or within a DECK.
++v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="PassengerEntrance_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipableSpaceGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a EQUIPABLE SPACE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckComponentGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a PASSENGER CARRYING REQUIREMENT TYPE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckEntranceGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="PassengerEntranceGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="PassengerEntranceIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of PASSENGER ENTRANCE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="PassengerEntrance_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a PASSENGER ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DeckEntrance_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="PassengerEntranceGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="PassengerEntranceGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a PASSENGER ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence/>
+	</xsd:group>
+	<!-- ====== DECK VEHICLE  ENTRANCE =================================== -->
+	<xsd:element name="DeckVehicleEntrance" substitutionGroup="DeckEntrance_">
+		<xsd:annotation>
+			<xsd:documentation> A normal entrance for passengers to or within a DECK.
++v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DeckVehicleEntrance_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipableSpaceGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a EQUIPABLE SPACE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckComponentGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a PASSENGER CARRYING REQUIREMENT TYPE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckEntranceGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckVehicleEntranceGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DeckVehicleEntranceIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of DECK VEHICLE ENTRANCE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DeckVehicleEntrance_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK VEHICLE ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DeckEntrance_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="DeckVehicleEntranceGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckVehicleEntranceGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK VEHICLE ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence/>
+	</xsd:group>
+	<!-- ====== OTHER DECK ENTRANCE =================================== -->
+	<xsd:element name="OtherDeckEntrance" substitutionGroup="DeckEntrance_">
+		<xsd:annotation>
+			<xsd:documentation> An entrance  to or within a  DECK for use for other purposes than normal passenger access. E.g. crew, emergency exit, etc.
++v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="OtherDeckEntrance_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipableSpaceGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a EQUIPABLE SPACE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckComponentGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a PASSENGER CARRYING REQUIREMENT TYPE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckEntranceGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="OtherDeckEntranceGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="OtherDeckEntranceIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of OTHER DECK ENTRANCE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="OtherDeckEntrance_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a OTHER DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DeckEntrance_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="OtherDeckEntranceGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="OtherDeckEntranceGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a OTHER DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence/>
+	</xsd:group>
+	<!-- ======DECK ENTRANCE USAGE. ====================================================== -->
+	<xsd:complexType name="deckEntranceUsages_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DECK ENTRANCE USAGEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="DeckEntranceUsage" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="DeckEntranceUsage" substitutionGroup="VersionedChild">
+		<xsd:annotation>
+			<xsd:documentation> Permitted usage of a specific PASSENGER ENTRANCE to access a particular DECK SPACE.
++v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DeckEntranceUsage_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:group ref="DeckEntranceUsageGroup"/>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DeckEntranceUsageIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of VEHICLE EQUIPMENT PROILE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DeckEntranceUsage_VersionedChildStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK ENTRANCE USAGE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:group ref="DeckEntranceUsageGroup"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckEntranceUsageGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK ENTRANCE USAGE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of DECK ENTRANCE USAGE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Description" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Description of DECK ENTRANCE USAGE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="UsageType" type="EntranceUsageEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Nature of usage: entry, ecit etc. See allowed values.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="DeckEntranceRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======DECK ENTRANCE COUPLE. ====================================================== -->
+	<xsd:complexType name="deckEntranceCouples_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DECK ENTRANCE COUPLEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="DeckEntranceCouple" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="DeckEntranceCouple" substitutionGroup="VersionedChild">
+		<xsd:annotation>
+			<xsd:documentation> Explicit linking of a pair of DECK ENTRANCEs, e.g. between train carriages.
++v2.0
+</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DeckEntranceCouple_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:group ref="DeckEntranceCoupleGroup"/>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DeckEntranceCoupleIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of DECK ENTRANCE COUPLE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DeckEntranceCouple_VersionedChildStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK ENTRANCE COUPLE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:group ref="DeckEntranceCoupleGroup"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckEntranceCoupleGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK ENTRANCE COUPLE..</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of DECK ENTRANCE COUPLE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="FromDeckEntranceRef" type="DeckEntranceRefStructure">
+				<xsd:annotation>
+					<xsd:documentation>DECK ENTRANCE from which couple links..</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ToDeckEntranceRef" type="DeckEntranceRefStructure">
+				<xsd:annotation>
+					<xsd:documentation>DECK ENTRANCE to which couple links..</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== DECK WINDOW =================================== -->
+	<xsd:complexType name="deckWindows_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DECK WINDOWs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="DeckWindowRef"/>
+					<xsd:element ref="DeckWindow"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="DeckWindow" substitutionGroup="DeckComponent">
+		<xsd:annotation>
+			<xsd:documentation> A window onto a DECK SPACE.
++v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DeckWindow_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipableSpaceGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a EQUIPABLE SPACE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckComponentGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a PASSENGER CARRYING REQUIREMENT TYPE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckWindowGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DeckWindowIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of DECK WINDOW.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DeckWindow_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK WINDOW.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DeckComponent_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="DeckWindowGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckWindowGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK WINDOW.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SequenceFromFront" type="xsd:integer" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Sequence of window from the front of the DECK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="DistanceFromFront" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>SDistance of Window from front of DECK</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="HasBlind" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether window has blind.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="CanBeOpened" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether window can be opened.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== DECK LEVEL =================================== -->
+	<xsd:complexType name="deckLevels_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DECK LEVELs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="DeckLevel" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="DeckLevel" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>An identified level (1, 2 ,3 ) within the DECK PLAN of a VEHICLE (boat, airplane, etc). +v2.0
+.
++v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DeckLevel_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckLevelGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DeckLevelIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of DECK LEVEL.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DeckLevel_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK LEVEL.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DataManagedObjectStructure">
+				<xsd:sequence>
+					<xsd:group ref="DeckLevelGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckLevelGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK LEVEL.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Label" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Label of DECK LEVEL.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of DECK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Description" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Description of DECK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="PublicUse" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether DECK  is for public use.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== DECK SPACE CAPACITY =================================== -->
+	<xsd:complexType name="deckSpaceCapacities_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DECK SPACE CAPACITies.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="DeckSpaceCapacity" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="DeckSpaceCapacity">
+		<xsd:annotation>
+			<xsd:documentation> Capacity of a DECK SPACE for passengers or LOCATABLE SPOTs.+v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DeckSpaceCapacity_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckSpaceCapacityGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DeckSpaceCapacityIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of DECK SPACE CAPACITY.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DeckSpaceCapacity_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK SPACE CAPACITY </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="DeckSpaceCapacityGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckSpaceCapacityGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK SPACE CAPACITY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="LocatableSpotType" type="TypeOfLocatableSpotEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Type of Locatable spot  for which this is the capacity </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="TypeOfLocatableSpotRef" minOccurs="0"/>
+			<xsd:element name="Capacity" type="NumberOfPassengers" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The total capacity  for passengers or vehciles of the type.  </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ========= TYPE OF DECK SPACE ============================================ -->
+	<xsd:element name="TypeOfDeckSpace" abstract="false" substitutionGroup="TypeOfValue">
+		<xsd:annotation>
+			<xsd:documentation> Classification for DECK SPACE, e.g. as WC, Restaurant, luggage area, etc.
++v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="TypeOfDeckSpace_ValueStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="TypeOfValueGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="TypeOfDeckSpaceIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of TYPE OF DECK SPACE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="TypeOfDeckSpace_ValueStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a TYPE OF DECK SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="TypeOfValue_VersionStructure"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- =========TYPE OF DECK ENTRANCE. ============================================ -->
+	<xsd:element name="TypeOfDeckEntrance" abstract="false" substitutionGroup="TypeOfValue">
+		<xsd:annotation>
+			<xsd:documentation>Classification for DECK ENTRANCE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="TypeOfDeckEntrance_ValueStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="TypeOfValueGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="TypeOfDeckEntranceIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of PURPOSE OF EQUIMENT PROFILE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="TypeOfDeckEntrance_ValueStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a TYPE OF DECK ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="TypeOfValue_VersionStructure"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -315,7 +315,7 @@
 	</xsd:element>
 	<xsd:element name="DeckSpace" abstract="true" substitutionGroup="DeckComponent">
 		<xsd:annotation>
-			<xsd:documentation>An area within a VEHICLE  (i.e. bus, boat, coach, car)  or TRAIN ELEMENT delimiting a particular use such as seating, WC, bar, gangway, etc. May be specialised, e.g. as PASSENGER SPACE ; may contain other spaces. Different types of space may overlap.  +v2.0.</xsd:documentation>
+			<xsd:documentation>An area within a VEHICLE (i.e. bus, boat, coach, car)  or TRAIN ELEMENT delimiting a particular use such as seating, WC, bar, gangway, etc. May be specialised, e.g. as PASSENGER SPACE ; may contain other spaces. Different types of space may overlap.  +v2.0.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -441,7 +441,8 @@
 	</xsd:complexType>
 	<xsd:element name="PassengerSpace" substitutionGroup="DeckSpace_">
 		<xsd:annotation>
-			<xsd:documentation> +v2.0</xsd:documentation>
+			<xsd:documentation> A specialisation of DECK SPACE defining an area within a VEHICLE (i.e. bus, boat, coach, car) or TRAIN ELEMENT for use by passengers. _2.0
++v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -538,7 +539,7 @@
 	</xsd:complexType>
 	<xsd:element name="OtherDeckSpace" substitutionGroup="DeckSpace_">
 		<xsd:annotation>
-			<xsd:documentation> +v2.0</xsd:documentation>
+			<xsd:documentation> A specialisation of DECK SPACE defining an area within a VEHICLE (i.e. bus, boat, coach, car) or TRAIN ELEMENT for restricted use, such as a crew area. +v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -770,8 +771,7 @@
 	<!-- ====== DECK VEHICLE  ENTRANCE =================================== -->
 	<xsd:element name="DeckVehicleEntrance" substitutionGroup="DeckEntrance_">
 		<xsd:annotation>
-			<xsd:documentation> A normal entrance for passengers to or within a DECK.
-+v2.0</xsd:documentation>
+			<xsd:documentation>An entrance for passenger vehicles to or within a DECK. +v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -1039,6 +1039,68 @@
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
+	<!-- ====== SENSOR IN ENTRANCE =================================== -->
+	<xsd:complexType name="sensorsInEntrance_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of SENSORs in ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="SensorInEntrance" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SensorInEntrance">
+		<xsd:annotation>
+			<xsd:documentation>Use of a specific ENTRANCE SENSOR to monitor a specific DECK ENTRANCE. 
++ v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SensorInEntrance_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SensorInEntranceGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SensorInEntranceIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of SENSOR IN ENTRANCE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SensorInEntrance_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SENSOR IN ENTRANCE </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="SensorInEntranceGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SensorInEntranceGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SENSOR IN ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="DeckEntranceRef" minOccurs="0"/>
+			<xsd:element ref="EntranceSensorRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>	
 	<!-- ====== DECK WINDOW =================================== -->
 	<xsd:complexType name="deckWindows_RelStructure">
 		<xsd:annotation>
@@ -1149,7 +1211,7 @@
 	</xsd:complexType>
 	<xsd:element name="DeckLevel" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation>An identified level (1, 2 ,3 ) within the DECK PLAN of a VEHICLE (boat, airplane, etc). +v2.0
+			<xsd:documentation>An identified level (1, 2 , 3, etc. ) within the DECK PLAN of a VEHICLE (boat, train, airplane, etc). +v2.0
 .
 +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -1230,7 +1292,7 @@
 	</xsd:complexType>
 	<xsd:element name="DeckSpaceCapacity">
 		<xsd:annotation>
-			<xsd:documentation> Capacity of a DECK SPACE for passengers or LOCATABLE SPOTs.+v2.0</xsd:documentation>
+			<xsd:documentation>The capacity of a DECK SPACE for passengers and other payload in terms of TYPES OF LOCATABLE SPOTs. +v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -14,8 +14,7 @@
 				<Date>
 					<Created>2023-01-30</Created>
 				</Date>
-				<Date>
-					<Modified>2023-01-30</Modified>
+				<Date><Modified>2023-01-30</Modified>
           Name Space changes
         </Date>
 				<Description>
@@ -1100,7 +1099,7 @@
 			<xsd:element ref="DeckEntranceRef" minOccurs="0"/>
 			<xsd:element ref="EntranceSensorRef" minOccurs="0"/>
 		</xsd:sequence>
-	</xsd:group>	
+	</xsd:group>
 	<!-- ====== DECK WINDOW =================================== -->
 	<xsd:complexType name="deckWindows_RelStructure">
 		<xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_equipmentVehiclePassenger_support">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_equipmentVehiclePassenger_support">
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_equipment_support.xsd"/>
 	<xsd:annotation>
 		<xsd:appinfo>
@@ -15,7 +15,7 @@
 					<Modified>2007-06-12</Modified>
 				</Date>
 				<Description>
-					<p>NeTEx - Network Exchange. This subschema defines VEHICLE EQUIPMENT   types for Place access.</p>
+					<p>NeTEx - Network Exchange. This subschema defines VEHICLE EQUIPMENT types for Place access.</p>
 				</Description>
 				<Format>
 					<MediaType>text/xml</MediaType>
@@ -26,7 +26,7 @@
 				<Language>[ISO 639-2/B] ENG</Language>
 				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
 				<Rights>Unclassified
- <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+ <Copyright>CEN, Crown Copyright 2009-2023</Copyright>
 				</Rights>
 				<Source>
 					<ul>
@@ -114,9 +114,29 @@ Rail transport, Roads and Road transport
 	<xsd:element name="WheelchairVehicleRef" type="WheelchairVehicleRefStructure" substitutionGroup="VehicleEquipmentRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>
+			<xsd:documentation>DEPRECATED</xsd:documentation>			
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="WheelchairVehicleRefStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>DEPRECATED</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VehicleEquipmentRefStructure">
+				<xsd:attribute name="ref" type="WheelchairVehicleEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a POINT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:element name="WheelchairVehicleEquipmentRef" type="WheelchairVehicleRefStructure" substitutionGroup="VehicleEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="WheelchairVehicleEquipmentRefStructure" abstract="false">	
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -133,7 +153,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:simpleType name="AssistedBoardingLocationEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for  assisted boarding locations.</xsd:documentation>
+			<xsd:documentation>Allowed values for assisted boarding locations.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="boardAtAnyDoor"/>
@@ -143,7 +163,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="AssistanceNeededEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for  assistance needed.</xsd:documentation>
+			<xsd:documentation>Allowed values for assistance needed.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="levelAccess"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
@@ -114,7 +114,7 @@ Rail transport, Roads and Road transport
 	<xsd:element name="WheelchairVehicleRef" type="WheelchairVehicleRefStructure" substitutionGroup="VehicleEquipmentRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>
-			<xsd:documentation>DEPRECATED</xsd:documentation>			
+			<xsd:documentation>DEPRECATED</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="WheelchairVehicleRefStructure" abstract="false">
@@ -136,7 +136,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="WheelchairVehicleEquipmentRefStructure" abstract="false">	
+	<xsd:complexType name="WheelchairVehicleEquipmentRefStructure" abstract="false">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_equipmentVehiclePassenger_version">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_equipmentVehiclePassenger_version">
 	<xsd:annotation>
 		<xsd:appinfo>
 			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
@@ -16,14 +16,16 @@
 				<Date>
 					<Modified>2011-12-16</Modified>
 				</Date>
-				<Date><Modified>2021-01-29</Modified>BUG Issue #143: Correct data type on GapToPlatform
+				<Date>
+					<Modified>2021-01-29</Modified>BUG Issue #143: Correct data type on GapToPlatform
 				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines passenger vehicle EQUIPMENT </p>
 				</Description>
 				<Format>
 					<MediaType>text/xml</MediaType>
-					<Syntax>http://www.w3.org/2				<Date><Modified>2019-03-25</Modified>Fix #41 by Skinkie from 2019.01.07. Fix typo on MobilityList.
+					<Syntax>http://www.w3.org/2				<Date>
+							<Modified>2019-03-25</Modified>Fix #41 by Skinkie from 2019.01.07. Fix typo on MobilityList.
 				</Date>001/XMLSchema</Syntax>
 					<Description>XML schema, W3C Recommendation 2001</Description>
 				</Format>
@@ -85,12 +87,24 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====ACCESS=================================================================== -->
-	<xsd:element name="ActualVehicleEquipment" type="ActualVehicleEquipment_VersionStructure" abstract="true" substitutionGroup="PassengerEquipment">
+	<xsd:complexType name="actualVehicleEquipments_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>List of VACTUAL EHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="ActualVehicleEquipment" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	<xsd:element name="ActualVehicleEquipment" type="ActualVehicleEquipment_VersionStructure" abstract="false" substitutionGroup="PassengerEquipment">
 		<xsd:annotation>
 			<xsd:documentation>An item of EQUIPMENT of a particular type actually available in an individual VEHICLE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ActualVehicleEquipment_VersionStructure" abstract="true">
+	<xsd:complexType name="ActualVehicleEquipment_VersionStructure" abstract="false">
 		<xsd:annotation>
 			<xsd:documentation>Abstract Type for an ACTUAL VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -193,7 +207,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="Hoist" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>VEHICLE Hoist can be used at VEHICLE has a hoist or lift  for wheelchairs.</xsd:documentation>
+					<xsd:documentation>VEHICLE Hoist can be used at VEHICLE has a hoist or lift for wheelchairs.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="HoistOperatingRadius" type="LengthType" minOccurs="0">
@@ -267,7 +281,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="AssistedBoardingLocation" type="AssistedBoardingLocationEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether special position on platform  is needed for boarding.</xsd:documentation>
+					<xsd:documentation>Whether special position on platform is needed for boarding.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="GuideDogsAllowed" type="xsd:boolean" default="true" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -16,16 +16,14 @@
 				<Date>
 					<Modified>2011-12-16</Modified>
 				</Date>
-				<Date>
-					<Modified>2021-01-29</Modified>BUG Issue #143: Correct data type on GapToPlatform
+				<Date><Modified>2021-01-29</Modified>BUG Issue #143: Correct data type on GapToPlatform
 				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines passenger vehicle EQUIPMENT </p>
 				</Description>
 				<Format>
 					<MediaType>text/xml</MediaType>
-					<Syntax>http://www.w3.org/2				<Date>
-							<Modified>2019-03-25</Modified>Fix #41 by Skinkie from 2019.01.07. Fix typo on MobilityList.
+					<Syntax>http://www.w3.org/2				<Date><Modified>2019-03-25</Modified>Fix #41 by Skinkie from 2019.01.07. Fix typo on MobilityList.
 				</Date>001/XMLSchema</Syntax>
 					<Description>XML schema, W3C Recommendation 2001</Description>
 				</Format>
@@ -98,7 +96,7 @@ Rail transport, Roads and Road transport
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
-	</xsd:complexType>	
+	</xsd:complexType>
 	<xsd:element name="ActualVehicleEquipment" type="ActualVehicleEquipment_VersionStructure" abstract="false" substitutionGroup="PassengerEquipment">
 		<xsd:annotation>
 			<xsd:documentation>An item of EQUIPMENT of a particular type actually available in an individual VEHICLE.</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_chargingEquipmentProfile_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_chargingEquipmentProfile_version.xsd
@@ -147,8 +147,8 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="PreparationDuration" type="xsd:duration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Normal period need to set up charging.
-</xsd:documentation>
+					<xsd:documentation>Normal period need to set up charging.</xsd:documentation>
+
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="FinalisationDuration" type="xsd:duration" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_chargingEquipmentProfile_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_chargingEquipmentProfile_version.xsd
@@ -148,7 +148,6 @@ Rail transport, Roads and Road transport
 			<xsd:element name="PreparationDuration" type="xsd:duration" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Normal period need to set up charging.</xsd:documentation>
-
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="FinalisationDuration" type="xsd:duration" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
@@ -309,7 +309,7 @@
 	</xsd:simpleType>
 	<xsd:simpleType name="ComponentOrientationEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for Sepot Orientation.</xsd:documentation>
+			<xsd:documentation>Allowed values for Spot Orientation.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="forwards"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
@@ -294,7 +294,7 @@
 	</xsd:complexType>
 	<xsd:simpleType name="TypeOfLocatableSpotEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for type of epassenger space.</xsd:documentation>
+			<xsd:documentation>Allowed values for type of passenger space.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="seat"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
@@ -324,5 +324,31 @@
 			<xsd:enumeration value="angledBackRight"/>
 		</xsd:restriction>
 	</xsd:simpleType>
+	<!-- ==== SENSOR IN SPOT  =========================================== -->
+	<xsd:simpleType name="SensorInSpotIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of SENSOR IN SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SensorInSpotRef" type="SensorInSpotRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a SENSOR IN SPOT. +V2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SensorInSpotRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SENSOR IN SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="SensorInSpotIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SENSOR IN SPOT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>	
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
@@ -13,8 +13,7 @@
 				<Date>
 					<Created>2023-02-02</Created>
 				</Date>
-				<Date>
-					<Modified>2023-02-05</Modified>
+				<Date><Modified>2023-02-05</Modified>
           Name Space changes
         </Date>
 				<Description>
@@ -349,6 +348,6 @@
 				</xsd:attribute>
 			</xsd:restriction>
 		</xsd:simpleContent>
-	</xsd:complexType>	
+	</xsd:complexType>
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
@@ -1,0 +1,328 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_seatingPlan_support">
+	<!-- ======================================================================= -->
+	<xsd:include schemaLocation="../netex_responsibility/netex_relationship.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>V1.0 Nicholas Knowles</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for NeTEx version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-02-02</Created>
+				</Date>
+				<Date>
+					<Modified>2023-02-05</Modified>
+          Name Space changes
+        </Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the DECK PLAN types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_seatingPlan_support.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>
+				<Relation>
+					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
+				</Relation>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright 2022-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel  standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx SEATING PLAN types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SEATING PLAN identifier  types</xsd:documentation>
+	</xsd:annotation>
+	<!-- ==== SPOT ROW ==================================================== -->
+	<xsd:complexType name="spotRowRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of SPOT ROWs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="SpotRowRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="SpotRowIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a SPOT ROW.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SpotRowRef" type="SpotRowRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SPOT ROW. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SpotRowRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SPOT ROW.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="SpotRowIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SPOT ROW.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ==== SPOT COLUMN ================================================= -->
+	<xsd:complexType name="spotColumnRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of SPOT COLUMNs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="SpotColumnRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="SpotColumnIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a SPOT COLUMN.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SpotColumnRef" type="SpotColumnRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SPOT COLUMN. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SpotColumnRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SPOT COLUMN.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="SpotColumnIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SPOT COLUMN.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ===== LOCATABLE SPOT ======================================================== -->
+	<xsd:simpleType name="EquipableSpaceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a nEQUIPABLE SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="EquipableSpaceRef" type="EquipableSpaceRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to an EQUIPABLE SPACE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="EquipableSpaceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an EQUIPABLE SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="EquipableSpaceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ===== LOCATABLE SPOT ======================================================== -->
+	<xsd:simpleType name="LocatableSpotIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a LOCATABLE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="EquipableSpaceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="LocatableSpotRef" type="LocatableSpotRefStructure" substitutionGroup="EquipableSpaceRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a LOCATABLE SPOT. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="LocatableSpotRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a LOCATABLE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="EquipableSpaceRefStructure">
+				<xsd:attribute name="ref" type="LocatableSpotIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== PASSENGER SPOT ======================================= -->
+	<xsd:simpleType name="PassengerSpotIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PASSENGER SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="LocatableSpotIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="PassengerSpotRef" type="PassengerSpotRefStructure" abstract="true" substitutionGroup="LocatableSpotRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PASSENGER SPOT. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PassengerSpotRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a PASSENGER SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="LocatableSpotRefStructure">
+				<xsd:attribute name="ref" type="PassengerSpotIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PASSENGER SPOT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== PASSENGER VEHICLE SPOT ======================================= -->
+	<xsd:simpleType name="PassengerVehicleSpotIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PASSENGER VEHICLE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="LocatableSpotIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="PassengerVehicleSpotRef" type="PassengerVehicleSpotRefStructure" abstract="true" substitutionGroup="LocatableSpotRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PASSENGER VEHICLE SPOT. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PassengerVehicleSpotRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a PASSENGER VEHICLE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="LocatableSpotRefStructure">
+				<xsd:attribute name="ref" type="PassengerVehicleSpotIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PASSENGER VEHICLE SPOT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== LOGGAGE SPOT ======================================= -->
+	<xsd:simpleType name="LuggageSpotIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a LUGGAGE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="LocatableSpotIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="LuggageSpotRef" type="LuggageSpotRefStructure" abstract="true" substitutionGroup="LocatableSpotRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a LUGGAGE SPOT. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="LuggageSpotRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a LUGGAGE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="LocatableSpotRefStructure">
+				<xsd:attribute name="ref" type="LuggageSpotIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a LUGGAGE SPOT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--==== TYPE OF LOCATABLE SPOT =========================================================-->
+	<xsd:simpleType name="TypeOfLocatableSpotIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a TYPE OF LOCATABLE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="TypeOfValueIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="TypeOfLocatableSpotRef" type="TypeOfLocatableSpotRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a TYPE OF LOCATABLE SPOT. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="TypeOfLocatableSpotRefStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a TYPE OF LOCATABLE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="TypeOfValueRefStructure">
+				<xsd:attribute name="ref" type="TypeOfLocatableSpotIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Reference to a TYPE OF LOCATABLE SPOT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="TypeOfLocatableSpotEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for type of epassenger space.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:normalizedString">
+			<xsd:enumeration value="seat"/>
+			<xsd:enumeration value="standingSpace"/>
+			<xsd:enumeration value="wheelchairSpace"/>
+			<xsd:enumeration value="pushchairSpace"/>
+			<xsd:enumeration value="luggageSpace"/>
+			<xsd:enumeration value="bicycleSpace"/>
+			<xsd:enumeration value="vehicleSpace"/>
+			<xsd:enumeration value="specialSpace"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="ComponentOrientationEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for Sepot Orientation.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:normalizedString">
+			<xsd:enumeration value="forwards"/>
+			<xsd:enumeration value="backwards"/>
+			<xsd:enumeration value="unknown"/>
+			<xsd:enumeration value="leftwards"/>
+			<xsd:enumeration value="rightwards"/>
+			<xsd:enumeration value="angledLeft"/>
+			<xsd:enumeration value="angledRight"/>
+			<xsd:enumeration value="angledBackLeft"/>
+			<xsd:enumeration value="angledBackRight"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
@@ -16,8 +16,7 @@
 				<Date>
 					<Created>2023-01-30</Created>
 				</Date>
-				<Date>
-					<Modified>2023-01-30</Modified>
+				<Date><Modified>2023-01-30</Modified>
           Name Space changes
         </Date>
 				<Description>
@@ -699,6 +698,6 @@
 			<xsd:element ref="LocatableSpotRef" minOccurs="0"/>
 			<xsd:element ref="SpotSensorRef" minOccurs="0"/>
 		</xsd:sequence>
-	</xsd:group>	
+	</xsd:group>
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_seatingPlan_version">
 	<xsd:include schemaLocation="netex_vehicleType_version.xsd"/>
+	<xsd:include schemaLocation="netex_seatingPlan_support.xsd"/>
 	<xsd:include schemaLocation="netex_sensorEquipment_version.xsd"/>
 	<xsd:include schemaLocation="netex_equipmentVehiclePassenger_version.xsd"/>
 	<!-- ======================================================================= -->
@@ -78,7 +79,7 @@
 	</xsd:complexType>
 	<xsd:element name="SpotRow" substitutionGroup="VersionedChild">
 		<xsd:annotation>
-			<xsd:documentation>A Row of LOCATABLE SPOTs, e.g. seats, within a PASSENGER SPACE. +v2.0</xsd:documentation>
+			<xsd:documentation>A designated row of LOCATABLE SPOTs, e.g. seats, within a PASSENGER SPACE. v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -147,7 +148,7 @@
 	</xsd:complexType>
 	<xsd:element name="SpotColumn" substitutionGroup="VersionedChild">
 		<xsd:annotation>
-			<xsd:documentation>A File of LOCATABLE SPOTs within a PASSENGER SPACE, For example Column A, B, C, D. +v2.0
+			<xsd:documentation>A designated File of LOCATABLE SPOTs within a PASSENGER SPACE, For example Column A, B, C, D. +v2.0
 </xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
@@ -205,7 +206,7 @@
 	<!-- ==== EQUIPABLE SPACE ======================================================= -->
 	<xsd:element name="EquipableSpace" type="EquipableSpace_VersionStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation>A place where ACTUAL VEHICLE EQUIPMENT may be located. +v2.0</xsd:documentation>
+			<xsd:documentation>A place aboard a vehicle where ACTUAL VEHICLE EQUIPMENT may be located. +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="EquipableSpace_VersionStructure" abstract="true">
@@ -273,7 +274,7 @@
 	<!-- ==== LOCATABLE SPOT ======================================================= -->
 	<xsd:element name="LocatableSpot" type="LocatableSpot_VersionStructure" abstract="true" substitutionGroup="EquipableSpace">
 		<xsd:annotation>
-			<xsd:documentation>An identifiable individual area within a given PASSENGER SPACE,  which may potentially be allocated to a single passenger or +v2.0</xsd:documentation>
+			<xsd:documentation>An identifiable individual area within a given PASSENGER SPACE, which may potentially be allocated to a single passenger or +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="LocatableSpot_VersionStructure" abstract="true">
@@ -408,8 +409,7 @@
 	<!-- ====== PASSENGER VEHICLE SPOT =================================== -->
 	<xsd:element name="PassengerSpot" abstract="false" substitutionGroup="LocatableSpot">
 		<xsd:annotation>
-			<xsd:documentation>A  specified seat or other space for a passenger within a given DECK SPACE. +v2.0
- +v2.0.</xsd:documentation>
+			<xsd:documentation>A designated seat or other space for a passenger within a given DECK SPACE. +v2.0.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -463,7 +463,7 @@
 	</xsd:complexType>
 	<xsd:element name="PassengerVehicleSpot" abstract="false" substitutionGroup="LocatableSpot">
 		<xsd:annotation>
-			<xsd:documentation>A  specified  onboard space to carry a vehicle (car, motorcycle, cycle, etc) within a given DECK SPACE. +v2.0.</xsd:documentation>
+			<xsd:documentation> A designated space  to stow a passenger's luggage onboard.+v2.0.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -638,5 +638,67 @@
 			<xsd:extension base="TypeOfValue_VersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
+	<!-- ====== SENSOR IN SPOT =================================== -->
+	<xsd:complexType name="sensorsInSpot_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of SENSORs in SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="SensorInSpot" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SensorInSpot">
+		<xsd:annotation>
+			<xsd:documentation>Use of a specific SPOT SENSOR to monitor  a specific LOCATABLE SPOT. 
++v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SensorInSpot_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SensorInSpotGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SensorInSpotIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of SENSOR IN SPOT.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SensorInSpot_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SENSOR IN SPOT </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="SensorInSpotGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SensorInSpotGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SENSOR IN SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="LocatableSpotRef" minOccurs="0"/>
+			<xsd:element ref="SpotSensorRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>	
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
@@ -400,7 +400,7 @@
 			</xsd:element>
 			<xsd:element name="HasPower" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether PASSENGER SPOT has a powr socket</xsd:documentation>
+					<xsd:documentation>Whether PASSENGER SPOT has a power socket.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
@@ -462,7 +462,7 @@
 	</xsd:complexType>
 	<xsd:element name="PassengerVehicleSpot" abstract="false" substitutionGroup="LocatableSpot">
 		<xsd:annotation>
-			<xsd:documentation> A designated space  to stow a passenger's luggage onboard.+v2.0.</xsd:documentation>
+			<xsd:documentation> A designated space to stow a passenger's luggage onboard.+v2.0.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
@@ -537,7 +537,7 @@
 	</xsd:complexType>
 	<xsd:element name="LuggageSpot" abstract="false" substitutionGroup="LocatableSpot">
 		<xsd:annotation>
-			<xsd:documentation> A  specified  space  to stow a passenger's luggage onboard.+v2.0.</xsd:documentation>
+			<xsd:documentation> A specified space to stow a passenger's luggage onboard.+v2.0.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
@@ -1,0 +1,642 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_seatingPlan_version">
+	<xsd:include schemaLocation="netex_vehicleType_version.xsd"/>
+	<xsd:include schemaLocation="netex_sensorEquipment_version.xsd"/>
+	<xsd:include schemaLocation="netex_equipmentVehiclePassenger_version.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>V1.0 Nicholas Knowles</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for NeTEx version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-01-30</Created>
+				</Date>
+				<Date>
+					<Modified>2023-01-30</Modified>
+          Name Space changes
+        </Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the DECK PLAN types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_seatingPlan_version.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>
+				<Relation>
+					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
+				</Relation>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright  2022-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel,   standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx DECK PLAN types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SEATING PLAN data types</xsd:documentation>
+	</xsd:annotation>
+	<!-- ==== SPOT ROW==================================================== -->
+	<xsd:complexType name="spotRows_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of SPOT ROWs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="SpotRow" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SpotRow" substitutionGroup="VersionedChild">
+		<xsd:annotation>
+			<xsd:documentation>A Row of LOCATABLE SPOTs, e.g. seats, within a PASSENGER SPACE. +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SpotRow_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SpotRowGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SpotRowIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of SPOT ROW.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SpotRow_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SPOT ROW.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="SpotRowGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SpotRowGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SPOT ROW.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Label" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of SPOT ROW.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="NumberingFromFront" type="xsd:boolean" default="true" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether number of ROW starts at front.  Default is true.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== SPOT COLUMN ================================================= -->
+	<xsd:complexType name="spotColumns_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of SPOT COLUMNs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="SpotColumn" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SpotColumn" substitutionGroup="VersionedChild">
+		<xsd:annotation>
+			<xsd:documentation>A File of LOCATABLE SPOTs within a PASSENGER SPACE, For example Column A, B, C, D. +v2.0
+</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SpotColumn_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SpotColumnGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SpotColumnIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of SPOT COLUMN.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SpotColumn_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SPOT COLUMN.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="SpotColumnGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SpotColumnGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SPOT COLUMN.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Label" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of SPOT COLUMN..</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="NumberingFromLeft" type="xsd:boolean" default="true" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether number of Colmns starts from left of vehicle, facing forward, or right. Default is true.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== EQUIPABLE SPACE ======================================================= -->
+	<xsd:element name="EquipableSpace" type="EquipableSpace_VersionStructure" abstract="true" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A place where ACTUAL VEHICLE EQUIPMENT may be located. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="EquipableSpace_VersionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for a EQUIPABLE SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DataManagedObjectStructure">
+				<xsd:sequence>
+					<xsd:group ref="EquipableSpaceGroup">
+						<xsd:annotation>
+							<xsd:documentation>Elements for a EQUIPABLE SPACE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="EquipableSpaceGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for an EQUIPABLE SPACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Label" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Description of EQUIPABLE SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Orientation" type="ComponentOrientationEnumeration" default="forwards" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Orientation of EQUIPABLE SPACE . Default is forwards.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:group ref="EquipableSpaceDimensionGroup"/>
+			<xsd:element ref="FacilitySetRef" minOccurs="0"/>
+			<xsd:element name="actualVehicleEquipments" type="actualVehicleEquipments_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>ACTUAL VEHICLE EQUIPMENT  for element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="EquipableSpaceDimensionGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for an EQUIPABLE SPACE dimensions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Width" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Width of EQUIPABLE SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Length" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Length of EQUIPABLE SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Height" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Height of EQUIPABLE SPACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== LOCATABLE SPOT ======================================================= -->
+	<xsd:element name="LocatableSpot" type="LocatableSpot_VersionStructure" abstract="true" substitutionGroup="EquipableSpace">
+		<xsd:annotation>
+			<xsd:documentation>An identifiable individual area within a given PASSENGER SPACE,  which may potentially be allocated to a single passenger or +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="LocatableSpot_VersionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for a LOCATABLE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="EquipableSpace_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="LocatableSpotGroup">
+						<xsd:annotation>
+							<xsd:documentation>Elements for a LOCATABLE SPOT.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="LocatableSpotGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a LOCATABLE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="TypeOfLocatableSpotRef" minOccurs="0"/>
+			<xsd:group ref="LocatableSpotRowColumnGroup"/>
+			<xsd:element name="sensorsInSpot" type="sensorsInSpot_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>SPOT SENSORs in the LOCATABLE SPOT. </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="LocatableSpotDimensionGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a LOCATABLE SPOT dimensions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Width" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Width of LOCATABLE SPOT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Length" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Length of LOCATABLE SPOT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Height" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Height of LOCATABLE SPOT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="LocatableSpotRowColumnGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a LOCATABLE SPOT  Row and Columns.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="SpotRowRef" minOccurs="0"/>
+			<xsd:element ref="SpotColumnRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== PASSENGER SPOT =================================== -->
+	<xsd:complexType name="passengerSpots_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of PASSENGER SPOTs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="PassengerSpotRef"/>
+					<xsd:element ref="PassengerSpot"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="PassengerSpot_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a PASSENGER SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="LocatableSpot_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="PassengerSpotGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="PassengerSpotGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a PASSENGER SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="ByAisle" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether PASSENGER SPOT is by Aisle.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ByWindow" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether PASSENGER SPOT is by Window</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ByTable" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether PASSENGER SPOT faces table.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="HasArmrest" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether PASSENGER SPOT has armrest</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="LegSpace" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Leg space available.t</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="HasTray" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether PASSENGER SPOT has a tray</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="HasPower" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether PASSENGER SPOT has a powr socket</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== PASSENGER VEHICLE SPOT =================================== -->
+	<xsd:element name="PassengerSpot" abstract="false" substitutionGroup="LocatableSpot">
+		<xsd:annotation>
+			<xsd:documentation>A  specified seat or other space for a passenger within a given DECK SPACE. +v2.0
+ +v2.0.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="PassengerSpot_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipableSpaceGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a EQUIPABLE SPACE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LocatableSpotGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a LOCATABLE SPOT.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="PassengerSpotGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="PassengerSpotIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of PASSENGER SPOT.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="passengerVehicleSpots_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of PASSENGER VEHICLE SPOTs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="PassengerVehicleSpotRef"/>
+					<xsd:element ref="PassengerVehicleSpot"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="PassengerVehicleSpot" abstract="false" substitutionGroup="LocatableSpot">
+		<xsd:annotation>
+			<xsd:documentation>A  specified  onboard space to carry a vehicle (car, motorcycle, cycle, etc) within a given DECK SPACE. +v2.0.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="PassengerVehicleSpot_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipableSpaceGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a EQUIPABLE SPACE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LocatableSpotGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a LOCATABLE SPOT.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="PassengerVehicleSpotGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="PassengerVehicleSpotIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of PASSENGER VEHICLE SPOT.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="PassengerVehicleSpot_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a PASSENGER VEHICLE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="LocatableSpot_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="PassengerVehicleSpotGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="PassengerVehicleSpotGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a PASSENGER VEHICLE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="TransportTypeRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== LUGGAGE SPOT =================================== -->
+	<xsd:complexType name="luggageSpots_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of LUGGAGE SPOTs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="LuggageSpotRef"/>
+					<xsd:element ref="LuggageSpot"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="LuggageSpot" abstract="false" substitutionGroup="LocatableSpot">
+		<xsd:annotation>
+			<xsd:documentation> A  specified  space  to stow a passenger's luggage onboard.+v2.0.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="LuggageSpot_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipableSpaceGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a EQUIPABLE SPACE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LocatableSpotGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a LOCATABLE SPOT.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LuggageSpotGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="LuggageSpotIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of LUGGAGE SPOT.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="LuggageSpot_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a LUGGAGE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="LocatableSpot_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="LuggageSpotGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="LuggageSpotGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a LUGGAGE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="HeightFromFloor" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Height of  LUGGAGE SPOT ifrom floor.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ========= TYPE OF LOCATABLE SPOT ============================================ -->
+	<xsd:element name="TypeOfLocatableSpot" abstract="false" substitutionGroup="TypeOfValue">
+		<xsd:annotation>
+			<xsd:documentation> Classification for LOCATABLE SPOT. +v2.0.
++v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="TypeOfLocatableSpot_ValueStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="TypeOfValueGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="TypeOfLocatableSpotIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of TYPE OF LOCATABLE SPOT.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="TypeOfLocatableSpot_ValueStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a TYPE OF LOCATABLE SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="TypeOfValue_VersionStructure"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
@@ -595,7 +595,7 @@
 		<xsd:sequence>
 			<xsd:element name="HeightFromFloor" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Height of  LUGGAGE SPOT ifrom floor.</xsd:documentation>
+					<xsd:documentation>Height of LUGGAGE SPOT from floor.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_support.xsd
@@ -12,8 +12,7 @@
 				<Date>
 					<Created>2023-02-08</Created>
 				</Date>
-				<Date>
-					<Modified>2023-02-08</Modified>
+				<Date><Modified>2023-02-08</Modified>
           Split out from Charging  Equipoment
         </Date>
 				<Description>

--- a/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_support.xsd
@@ -144,57 +144,5 @@
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<!-- ==== SENSOR IN SPOT  =========================================== -->
-	<xsd:simpleType name="SensorInSpotIdType">
-		<xsd:annotation>
-			<xsd:documentation>Type for identifier of SENSOR IN SPOT.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="ObjectIdType"/>
-	</xsd:simpleType>
-	<xsd:element name="SensorInSpotRef" type="SensorInSpotRefStructure" substitutionGroup="VersionOfObjectRef">
-		<xsd:annotation>
-			<xsd:documentation>Identifier of a SENSOR IN SPOT. +V2.0</xsd:documentation>
-		</xsd:annotation>
-	</xsd:element>
-	<xsd:complexType name="SensorInSpotRefStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for a reference to a SENSOR IN SPOT.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:restriction base="VersionOfObjectRefStructure">
-				<xsd:attribute name="ref" type="SensorInSpotIdType" use="required">
-					<xsd:annotation>
-						<xsd:documentation>Identifier of a SENSOR IN SPOT.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:restriction>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<!-- ==== SENSOR IN ENTRANCE  =========================================== -->
-	<xsd:simpleType name="SensorInEntranceIdType">
-		<xsd:annotation>
-			<xsd:documentation>Type for identifier of SENSOR IN ENTRANCE.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="ObjectIdType"/>
-	</xsd:simpleType>
-	<xsd:element name="SensorInEntranceRef" type="SensorInEntranceRefStructure" substitutionGroup="VersionOfObjectRef">
-		<xsd:annotation>
-			<xsd:documentation>Identifier of a SENSOR IN ENTRANCE. +V2.0</xsd:documentation>
-		</xsd:annotation>
-	</xsd:element>
-	<xsd:complexType name="SensorInEntranceRefStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for a reference to a SENSOR IN ENTRANCE.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:restriction base="VersionOfObjectRefStructure">
-				<xsd:attribute name="ref" type="SensorInEntranceIdType" use="required">
-					<xsd:annotation>
-						<xsd:documentation>Identifier of a SENSOR IN ENTRANCE.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:restriction>
-		</xsd:simpleContent>
-	</xsd:complexType>
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_support.xsd
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_sensorEquipment_support">
+	<xsd:include schemaLocation="netex_equipment_support.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-02-08</Created>
+				</Date>
+				<Date>
+					<Modified>2023-02-08</Modified>
+          Split out from Charging  Equipoment
+        </Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines SENSOR EQUIPMENT types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_sensorEquipment_support.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>CEN TC278 WG3 SG9</Publisher>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright 2009-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Added fro NExTex new modes.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - SENSOR EQUIPMENT identifier types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SENSOR EQUIPMENT identifier types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ==== SENSOR EQUIPMENT =========================================== -->
+	<xsd:simpleType name="SensorEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of SENSOR EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="InstalledEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SensorEquipmentRef" type="SensorEquipmentRefStructure" substitutionGroup="EquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a SENSOR EQUIPMENT. +V2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SensorEquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SENSOR EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="InstalledEquipmentRefStructure">
+				<xsd:attribute name="ref" type="SensorEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SENSOR EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="SensorCommunicationsEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for Sensor Commications</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:normalizedString">
+			<xsd:enumeration value="cable"/>
+			<xsd:enumeration value="wifi"/>
+			<xsd:enumeration value="other"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- ===== SPOT SENSOR =================================================== -->
+	<xsd:simpleType name="SpotSensorIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of SPOT SENSOR.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="SensorEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SpotSensorRef" type="SpotSensorRefStructure" substitutionGroup="SensorEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a SPOT SENSOR. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SpotSensorRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a  SPOT SENSOR.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="SensorEquipmentRefStructure">
+				<xsd:attribute name="ref" type="SpotSensorIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SPOT SENSOR.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ===== ENTRANCE SENSOR =================================================== -->
+	<xsd:simpleType name="EntranceSensorIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of ENTRANCE SENSOR.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="SensorEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="EntranceSensorRef" type="EntranceSensorRefStructure" substitutionGroup="SensorEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of an ENTRANCE SENSOR. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="EntranceSensorRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an ENTRANCE SENSOR.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="SensorEquipmentRefStructure">
+				<xsd:attribute name="ref" type="EntranceSensorIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a ENTRANCE SENSOR.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ==== SENSOR IN SPOT  =========================================== -->
+	<xsd:simpleType name="SensorInSpotIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of SENSOR IN SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SensorInSpotRef" type="SensorInSpotRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a SENSOR IN SPOT. +V2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SensorInSpotRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SENSOR IN SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="SensorInSpotIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SENSOR IN SPOT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ==== SENSOR IN ENTRANCE  =========================================== -->
+	<xsd:simpleType name="SensorInEntranceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of SENSOR IN ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SensorInEntranceRef" type="SensorInEntranceRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a SENSOR IN ENTRANCE. +V2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SensorInEntranceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SENSOR IN ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="SensorInEntranceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SENSOR IN ENTRANCE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_version.xsd
@@ -13,8 +13,7 @@
 				<Date>
 					<Created>2023-02-06</Created>
 				</Date>
-				<Date>
-					<Modified>2023-02-06</Modified>
+				<Date><Modified>2023-02-06</Modified>
           Definition of CycleStorage number of spaces corrected. Doc change only.
         </Date>
 				<Description>

--- a/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_version.xsd
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_sensorEquipment_version">
-	<xsd:include schemaLocation="netex_deckPlan_support.xsd"/>
 	<xsd:include schemaLocation="netex_sensorEquipment_support.xsd"/>
 	<xsd:include schemaLocation="netex_equipment_version.xsd"/>
 	<!-- ======================================================================= -->
@@ -89,9 +88,7 @@
 	</xsd:element>
 	<xsd:element name="SensorEquipment" substitutionGroup="InstalledEquipment">
 		<xsd:annotation>
-			<xsd:documentation>An EQUIPMENT used to monitor use of a space or entrance.
- +V2.0
-</xsd:documentation>
+			<xsd:documentation>An EQUIPMENT used to measure values relevant for some monitoring function, for example to monitor use of a space or entrance. +V2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -248,129 +245,5 @@
 			<xsd:documentation>Elements for ENTRANCE SENSOR.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence/>
-	</xsd:group>
-	<!-- ====== SENSOR IN SPOT =================================== -->
-	<xsd:complexType name="sensorsInSpot_RelStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for a list of SENSORs in SPOT.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="strictContainmentAggregationStructure">
-				<xsd:sequence>
-					<xsd:element ref="SensorInSpot" maxOccurs="unbounded"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:element name="SensorInSpot">
-		<xsd:annotation>
-			<xsd:documentation>Use of a specific SPOT SENSOR to monitor  a specific LOCATABLE SPOT. 
-+v2.0</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexType>
-			<xsd:complexContent>
-				<xsd:restriction base="SensorInSpot_VersionedChildStructure">
-					<xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="VersionedChildGroup"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="SensorInSpotGroup"/>
-						</xsd:sequence>
-					</xsd:sequence>
-					<xsd:attribute name="id" type="SensorInSpotIdType" use="optional">
-						<xsd:annotation>
-							<xsd:documentation>Identifier of SENSOR IN SPOT.</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
-				</xsd:restriction>
-			</xsd:complexContent>
-		</xsd:complexType>
-	</xsd:element>
-	<xsd:complexType name="SensorInSpot_VersionedChildStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for a SENSOR IN SPOT </xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="VersionedChildStructure">
-				<xsd:sequence>
-					<xsd:group ref="SensorInSpotGroup"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:group name="SensorInSpotGroup">
-		<xsd:annotation>
-			<xsd:documentation>Elements for a SENSOR IN SPOT.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element ref="LocatableSpotRef" minOccurs="0"/>
-			<xsd:element ref="SpotSensorRef" minOccurs="0"/>
-		</xsd:sequence>
-	</xsd:group>
-	<!-- ====== SENSOR IN ENTRANCE =================================== -->
-	<xsd:complexType name="sensorsInEntrance_RelStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for a list of SENSORs in ENTRANCE.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="strictContainmentAggregationStructure">
-				<xsd:sequence>
-					<xsd:element ref="SensorInEntrance" maxOccurs="unbounded"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:element name="SensorInEntrance">
-		<xsd:annotation>
-			<xsd:documentation>Use of a specific ENTRANCE SENSOR to monitor a specific DECK ENTRANCE. 
-+ v2.0</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexType>
-			<xsd:complexContent>
-				<xsd:restriction base="SensorInEntrance_VersionedChildStructure">
-					<xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="VersionedChildGroup"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="SensorInEntranceGroup"/>
-						</xsd:sequence>
-					</xsd:sequence>
-					<xsd:attribute name="id" type="SensorInEntranceIdType" use="optional">
-						<xsd:annotation>
-							<xsd:documentation>Identifier of SENSOR IN ENTRANCE.</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
-				</xsd:restriction>
-			</xsd:complexContent>
-		</xsd:complexType>
-	</xsd:element>
-	<xsd:complexType name="SensorInEntrance_VersionedChildStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for a SENSOR IN ENTRANCE </xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="VersionedChildStructure">
-				<xsd:sequence>
-					<xsd:group ref="SensorInEntranceGroup"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:group name="SensorInEntranceGroup">
-		<xsd:annotation>
-			<xsd:documentation>Elements for a SENSOR IN ENTRANCE.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element ref="DeckEntranceRef" minOccurs="0"/>
-			<xsd:element ref="EntranceSensorRef" minOccurs="0"/>
-		</xsd:sequence>
 	</xsd:group>
 </xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_version.xsd
@@ -1,0 +1,376 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_sensorEquipment_version">
+	<xsd:include schemaLocation="netex_deckPlan_support.xsd"/>
+	<xsd:include schemaLocation="netex_sensorEquipment_support.xsd"/>
+	<xsd:include schemaLocation="netex_equipment_version.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-02-06</Created>
+				</Date>
+				<Date>
+					<Modified>2023-02-06</Modified>
+          Definition of CycleStorage number of spaces corrected. Doc change only.
+        </Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines SENSOR EQUIPMENT base types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_sensorEquipment_version.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright 2009-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the TransModel standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - SENSOR Types of Equipment.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SENSOR EQUIPMENT types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- === SENSOR EQUIPMENT ============================================ -->
+	<xsd:element name="SensorEquipment_" substitutionGroup="InstalledEquipment">
+		<xsd:annotation>
+			<xsd:documentation>Dummy type for +V2.0
+</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="InstalledEquipment_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipmentGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SensorEquipmentIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of ENTITY.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="SensorEquipment" substitutionGroup="InstalledEquipment">
+		<xsd:annotation>
+			<xsd:documentation>An EQUIPMENT used to monitor use of a space or entrance.
+ +V2.0
+</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SensorEquipment_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SensorEquipmentGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SensorEquipmentIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of ENTITY.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SensorEquipment_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SENSOR EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="InstalledEquipment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="SensorEquipmentGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SensorEquipmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for SENSOR EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="CommunicationMethod" type="SensorCommunicationsEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>How sensor communicates with  onboard hub. </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- === SPOT SENSOR ============================================ -->
+	<xsd:element name="SpotSensor" substitutionGroup="InstalledEquipment">
+		<xsd:annotation>
+			<xsd:documentation>An EQUIPMENT used to monitor use of a LOCATABLE SPOT such as a passenger seat
+. +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SpotSensor_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SensorEquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SpotSensorGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SpotSensorIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of ENTITY.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SpotSensor_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SPOT SENSOR.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="SensorEquipment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="SpotSensorGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SpotSensorGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for SPOT SENSOR.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence/>
+	</xsd:group>
+	<!-- === ENTRANCE SENSOR ============================================ -->
+	<xsd:element name="EntranceSensor" substitutionGroup="InstalledEquipment">
+		<xsd:annotation>
+			<xsd:documentation>AN EQUIPMENT used to monitor or count passengers using a PASSENGER ENTRANCE.
+ +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="EntranceSensor_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SensorEquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntranceSensorGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="EntranceSensorIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of ENTITY.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="EntranceSensor_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a ENTRANCE SENSOR.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="SensorEquipment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="EntranceSensorGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="EntranceSensorGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for ENTRANCE SENSOR.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence/>
+	</xsd:group>
+	<!-- ====== SENSOR IN SPOT =================================== -->
+	<xsd:complexType name="sensorsInSpot_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of SENSORs in SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="SensorInSpot" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SensorInSpot">
+		<xsd:annotation>
+			<xsd:documentation>Use of a specific SPOT SENSOR to monitor  a specific LOCATABLE SPOT. 
++v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SensorInSpot_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SensorInSpotGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SensorInSpotIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of SENSOR IN SPOT.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SensorInSpot_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SENSOR IN SPOT </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="SensorInSpotGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SensorInSpotGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SENSOR IN SPOT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="LocatableSpotRef" minOccurs="0"/>
+			<xsd:element ref="SpotSensorRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== SENSOR IN ENTRANCE =================================== -->
+	<xsd:complexType name="sensorsInEntrance_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of SENSORs in ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="SensorInEntrance" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SensorInEntrance">
+		<xsd:annotation>
+			<xsd:documentation>Use of a specific ENTRANCE SENSOR to monitor a specific DECK ENTRANCE. 
++ v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SensorInEntrance_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SensorInEntranceGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SensorInEntranceIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of SENSOR IN ENTRANCE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SensorInEntrance_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SENSOR IN ENTRANCE </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="SensorInEntranceGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SensorInEntranceGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SENSOR IN ENTRANCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="DeckEntranceRef" minOccurs="0"/>
+			<xsd:element ref="EntranceSensorRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>
+</xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_support.xsd
@@ -12,8 +12,7 @@
 				<Date>
 					<Created>2023-02-06</Created>
 				</Date>
-				<Date>
-					<Modified>2023-02-0</Modified>
+				<Date><Modified>2023-02-0</Modified>
           Split out from Charging  Equipoment
         </Date>
 				<Description>

--- a/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_support.xsd
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_spotEquipment_support">
+	<xsd:include schemaLocation="netex_equipment_support.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-02-06</Created>
+				</Date>
+				<Date>
+					<Modified>2023-02-0</Modified>
+          Split out from Charging  Equipoment
+        </Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines SPOT EQUIPMENT types</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_spotEquipment_support.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>CEN TC278 WG3 SG9</Publisher>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright 2009-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Added fro NExTex new modes.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - SPOT EQUIPMENT identifier types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SPOT EQUIPMENT identifier types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ==== SPOT EQUIPMENT =========================================== -->
+	<xsd:simpleType name="SpotEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of SPOT EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="InstalledEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SpotEquipmentRef" type="SpotEquipmentRefStructure" substitutionGroup="EquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a SPOT EQUIPMENT. +V2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SpotEquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SPOT EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="InstalledEquipmentRefStructure">
+				<xsd:attribute name="ref" type="SpotEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SPOT EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ===== SEAT EQUIPMENT =================================================== -->
+	<xsd:simpleType name="SeatEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of SEAT EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="SpotEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SeatEquipmentRef" type="SeatEquipmentRefStructure" substitutionGroup="SpotEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a SEAT EQUIPMENT. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SeatEquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a  SEAT EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="SpotEquipmentRefStructure">
+				<xsd:attribute name="ref" type="SeatEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SEAT EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ===== BED EQUIPMENT =================================================== -->
+	<xsd:simpleType name="BedEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of BED EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="SpotEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="BedEquipmentRef" type="BedEquipmentRefStructure" substitutionGroup="SpotEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a BED EQUIPMENT. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="BedEquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a BED EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="SpotEquipmentRefStructure">
+				<xsd:attribute name="ref" type="BedEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a BED EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ===== LUGGAGE BAY EQUIPMENT =================================================== -->
+	<xsd:simpleType name="LuggageBayEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of LUGGAGE BAY EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="SpotEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="LuggageBayEquipmentRef" type="LuggageBayEquipmentRefStructure" substitutionGroup="SpotEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a LUGGAGE BAY EQUIPMENT. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="LuggageBayEquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a LUGGAGE BAY EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="SpotEquipmentRefStructure">
+				<xsd:attribute name="ref" type="LuggageBayEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a LUGGAGE BAY EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
@@ -14,8 +14,7 @@
 				<Date>
 					<Created>2023-02-06</Created>
 				</Date>
-				<Date>
-					<Modified>2023-02-06</Modified>
+				<Date><Modified>2023-02-06</Modified>
           Definition of CycleStorage number of spaces corrected. Doc change only.
         </Date>
 				<Description>

--- a/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
@@ -224,7 +224,7 @@
 			</xsd:element>
 			<xsd:element name="IsReclining" type="xsd:boolean" default="false" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether seat reclines. Deafult sis false.</xsd:documentation>
+					<xsd:documentation>Whether seat reclines. Default is false.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
@@ -1,0 +1,359 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_spotEquipment_version">
+	<xsd:include schemaLocation="../netex_utility/netex_units.xsd"/>
+	<xsd:include schemaLocation="netex_spotEquipment_support.xsd"/>
+	<xsd:include schemaLocation="netex_equipment_version.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-02-06</Created>
+				</Date>
+				<Date>
+					<Modified>2023-02-06</Modified>
+          Definition of CycleStorage number of spaces corrected. Doc change only.
+        </Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines SPOT EQUIPMENT base types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_spotEquipment_version.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright 2009-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the TransModel standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - SPOT Types of Equipment.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SPOT EQUIPMENT types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- === SPOT EQUIPMENT ============================================ -->
+	<xsd:element name="SpotEquipment_" substitutionGroup="InstalledEquipment">
+		<xsd:annotation>
+			<xsd:documentation>An abstract EQUIPMENT in a LOCATABLE SPOT providing a onboard seat, bed or other amenity. +V2.0
+</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="InstalledEquipment_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipmentGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SpotEquipmentIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of ENTITY.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="SpotEquipment" substitutionGroup="InstalledEquipment">
+		<xsd:annotation>
+			<xsd:documentation>An abstract EQUIPMENT in a LOCATABLE SPOT providing a onboard seat, bed or other amenity. +V2.0
+</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SpotEquipment_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SpotEquipmentGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SpotEquipmentIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of ENTITY.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SpotEquipment_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SPOT EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="InstalledEquipment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="SpotEquipmentGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SpotEquipmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for SPOT EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Width" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Width of seat bottom.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="HeightFromFloor" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Height from bloor</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="PowerSupply" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether spot has power supply socket.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="UsbPowerSocket" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether Spot has UsbPowerSockets.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- === SEAT EQUIPMENT ============================================ -->
+	<xsd:element name="SeatEquipment" substitutionGroup="InstalledEquipment">
+		<xsd:annotation>
+			<xsd:documentation>A specialisation of SPOT EQUIPMENT describing the detailed properties of a seat. +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SeatEquipment_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SpotEquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SeatEquipmentGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SeatEquipmentIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of ENTITY.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SeatEquipment_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SEAT EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="SpotEquipment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="SeatEquipmentGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SeatEquipmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for SEAT EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SeatBackHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Height of Seat back from seat bottom.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="SeatDepth" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Depgth of Seat   from front to back.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="IsFoldup" type="xsd:boolean" default="false" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether seat folds up. default is false</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="IsReclining" type="xsd:boolean" default="false" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether seat reclines. Deafult sis false.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- === BED EQUIPMENT ============================================ -->
+	<xsd:element name="BedEquipment" substitutionGroup="InstalledEquipment">
+		<xsd:annotation>
+			<xsd:documentation>A specialisation of SPOT EQUIPMENT describing the detailed properties of a bed. +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="BedEquipment_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SpotEquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="BedEquipmentGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="BedEquipmentIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of ENTITY.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="BedEquipment_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a BED EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="SpotEquipment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="BedEquipmentGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="BedEquipmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for BED EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Length" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Length of bedt back from seat bottom.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="IsStowable" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether bed can be stowed away when not in use.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- === LUGGAGE BAY EQUIPMENT ============================================ -->
+	<xsd:element name="LuggageBayEquipment" substitutionGroup="InstalledEquipment">
+		<xsd:annotation>
+			<xsd:documentation>A specialisation of SPOT EQUIPMENT describing the detailed properties of a luggage bay. +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="LuggageBayEquipment_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SpotEquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LuggageBayEquipmentGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="LuggageBayEquipmentIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of ENTITY.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="LuggageBayEquipment_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a LUGGAGE BAY EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="SpotEquipment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="LuggageBayEquipmentGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="LuggageBayEquipmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for LUGGAGE BAY EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="IsLockable" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether bay is lockable.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="HasDoor" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether bay is has a door.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+</xsd:schema>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_vehicleType_support">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_vehicleType_support">
 	<xsd:include schemaLocation="netex_equipment_support.xsd"/>
 	<!-- ======================================================================= -->
 	<xsd:annotation>
@@ -14,28 +14,37 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date><Modified>2011-02-05</Modified>Name Space changes  
+				<Date>
+					<Modified>2011-02-05</Modified>Name Space changes  
 				</Date>
-				<Date><Modified>2012-04-15</Modified>Revise Passenger Capacity 
+				<Date>
+					<Modified>2012-04-15</Modified>Revise Passenger Capacity 
 				</Date>
-				<Date><Modified>2019-04-09</Modified>Add list of vehicle type refs for PARKING and general use
+				<Date>
+					<Modified>2019-04-09</Modified>Add list of vehicle type refs for PARKING and general use
 				</Date>
-				<Date><Modified>2020-08-11</Modified>Issue #110 Add missing fuel types			
+				<Date>
+					<Modified>2020-08-11</Modified>Issue #110 Add missing fuel types			
 				electricContact, battery, dieselBatteryHybrid, petrolBatteryHybrid, biodiesel, hydrogen, liquidGas, methane, ethanol
 				</Date>
-				<Date><Modified>2020-10-04</Modified>NewModes: Add list of VEHICLEs.
+				<Date>
+					<Modified>2020-10-04</Modified>NewModes: Add list of VEHICLEs.
 						Add TransportType, SimpleVehicleType
 						Add fuel types none, other, 
 						ADd Power Tpe enumeration
 						Add Vehicle PRofile
 				</Date>
-				<Date><Modified>2021-04-19</Modified>NewModes: GBFS compatibility Add car to vehicle Types
+				<Date>
+					<Modified>2021-04-19</Modified>NewModes: GBFS compatibility Add car to vehicle Types
 				</Date>
-				<Date><Modified>2021-07-07</Modified>NewModes: Add extra fuel types from APDS
+				<Date>
+					<Modified>2021-07-07</Modified>NewModes: Add extra fuel types from APDS
 				</Date>
-				<Date><Modified>2021-07-08</Modified>NewModes: Correction Add missing VehicleEquipmentProfile relationship to VehicleModel
+				<Date>
+					<Modified>2021-07-08</Modified>NewModes: Correction Add missing VehicleEquipmentProfile relationship to VehicleModel
 				</Date>
-				<Date><Modified>2023-01-30</Modified>TM CR: Enhancement Add Accepted Driver Permit
+				<Date>
+					<Modified>2023-01-30</Modified>TM CR: Enhancement Add Accepted Driver Permit
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -566,6 +575,32 @@ Rail transport, Roads and Road transport
 				<xsd:attribute name="ref" type="PurposeOfEquipmentProfileIdType" use="required">
 					<xsd:annotation>
 						<xsd:documentation>Reference to a PURPOSE OF EQUIPMENT PROFILE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ===== VEHICLE PEQUIPMENT PROFILE MEMBER ================================================ -->
+	<xsd:simpleType name="VehicleEquipmentProfileMemberIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a VEHICLE EQUIPMENT PROFILE MEMBER.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="VehicleEquipmentProfileMemberRef" type="VehicleEquipmentProfileMemberRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a VEHICLE EQUIPMENT PROFILE MEMBER</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="VehicleEquipmentProfileMemberRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a VEHICLE EQUIPMENT PROFILE MEMBER.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="VehicleEquipmentProfileMemberIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced VEHICLE EQUIPMENT PROFILE MEMBER</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:restriction>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
@@ -14,37 +14,28 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date>
-					<Modified>2011-02-05</Modified>Name Space changes  
+				<Date><Modified>2011-02-05</Modified>Name Space changes  
 				</Date>
-				<Date>
-					<Modified>2012-04-15</Modified>Revise Passenger Capacity 
+				<Date><Modified>2012-04-15</Modified>Revise Passenger Capacity 
 				</Date>
-				<Date>
-					<Modified>2019-04-09</Modified>Add list of vehicle type refs for PARKING and general use
+				<Date><Modified>2019-04-09</Modified>Add list of vehicle type refs for PARKING and general use
 				</Date>
-				<Date>
-					<Modified>2020-08-11</Modified>Issue #110 Add missing fuel types			
+				<Date><Modified>2020-08-11</Modified>Issue #110 Add missing fuel types			
 				electricContact, battery, dieselBatteryHybrid, petrolBatteryHybrid, biodiesel, hydrogen, liquidGas, methane, ethanol
 				</Date>
-				<Date>
-					<Modified>2020-10-04</Modified>NewModes: Add list of VEHICLEs.
+				<Date><Modified>2020-10-04</Modified>NewModes: Add list of VEHICLEs.
 						Add TransportType, SimpleVehicleType
 						Add fuel types none, other, 
 						ADd Power Tpe enumeration
 						Add Vehicle PRofile
 				</Date>
-				<Date>
-					<Modified>2021-04-19</Modified>NewModes: GBFS compatibility Add car to vehicle Types
+				<Date><Modified>2021-04-19</Modified>NewModes: GBFS compatibility Add car to vehicle Types
 				</Date>
-				<Date>
-					<Modified>2021-07-07</Modified>NewModes: Add extra fuel types from APDS
+				<Date><Modified>2021-07-07</Modified>NewModes: Add extra fuel types from APDS
 				</Date>
-				<Date>
-					<Modified>2021-07-08</Modified>NewModes: Correction Add missing VehicleEquipmentProfile relationship to VehicleModel
+				<Date><Modified>2021-07-08</Modified>NewModes: Correction Add missing VehicleEquipmentProfile relationship to VehicleModel
 				</Date>
-				<Date>
-					<Modified>2023-01-30</Modified>TM CR: Enhancement Add Accepted Driver Permit
+				<Date><Modified>2023-01-30</Modified>TM CR: Enhancement Add Accepted Driver Permit
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_vehicleType_version">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_vehicleType_version">
 	<xsd:include schemaLocation="netex_vehicleType_support.xsd"/>
 	<xsd:include schemaLocation="netex_nm_fleetEquipment_support.xsd"/>
 	<xsd:include schemaLocation="netex_nm_fleet_support.xsd"/>
@@ -20,16 +20,21 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date><Modified>2011-02-05</Modified>Name Space changes
+				<Date>
+					<Modified>2011-02-05</Modified>Name Space changes
 				</Date>
-				<Date><Modified>2017-03-27</Modified>CR0001 - Vehicle Dimensions added.
+				<Date>
+					<Modified>2017-03-27</Modified>CR0001 - Vehicle Dimensions added.
 				</Date>
-				<Date><Modified>2019-03-25</Modified>NL31 CD #60 Add new attributes BoardingHeight and GapToPlatform attributes to VehicleType. 
+				<Date>
+					<Modified>2019-03-25</Modified>NL31 CD #60 Add new attributes BoardingHeight and GapToPlatform attributes to VehicleType. 
 					 NJSK Review correct data types of new attributes to be of LengthType
 				</Date>
-				<Date><Modified>2021-07-07</Modified>NewModes-Power Description attribute to NVehicleEquipmentProfile
+				<Date>
+					<Modified>2021-07-07</Modified>NewModes-Power Description attribute to NVehicleEquipmentProfile
 				</Date>
-				<Date><Modified>2020-10-05</Modified> New Modes: Add Vehicle  mode  to VehicleType					
+				<Date>
+					<Modified>2020-10-05</Modified> New Modes: Add Vehicle  mode  to VehicleType					
 					 Refactor VehicleType into TarnsportType, VehicleType and PesonalVehicleType
 					   Replace Vehicle OperatorRef with TransportOrganisationRef.
 					   Add VehicleModelRef to Vehicle.
@@ -37,9 +42,11 @@
 					   Add Description to Vehicle.
 					   Add PropulsionType . and MaximumRange to TransportType
 				</Date>
-				<Date><Modified>2021-07-08</Modified>NewModes: Correction Add missing VehicleEquipmentProfile relationship to VehicleModel
+				<Date>
+					<Modified>2021-07-08</Modified>NewModes: Correction Add missing VehicleEquipmentProfile relationship to VehicleModel
 				</Date>
-				<Date><Modified>2023-01-30</Modified>TM CR: Enhancement Add Accepted Driver Permit
+				<Date>
+					<Modified>2023-01-30</Modified>TM CR: Enhancement Add Accepted Driver Permit
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -637,6 +644,7 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="VehicleAccessibilityRequirementsGroup"/>
 		</xsd:sequence>
 	</xsd:group>
+	<!-- ====== PASSENGER CAPACITY =================================== -->	
 	<xsd:complexType name="passengerCapacities_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a list of PASSENGER CAPACITY REQUIREMENTs.</xsd:documentation>
@@ -1211,6 +1219,83 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="TypeOfEquipmentRef" minOccurs="0"/>
 			<xsd:element ref="PurposeOfEquipmentProfileRef" minOccurs="0"/>
+			<xsd:element name="vehicleEquipmentProfileMembers" type="vehicleEquipmentProfileMembers_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Members of Vehicle Profile.  +v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======VEHICLE EQUIPMENT PROFILE MEMBER ====================================================== -->
+	<xsd:complexType name="vehicleEquipmentProfileMembers_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of VEHICLE EQUIPMENT PROFILE MEMBERs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="VehicleEquipmentProfileMember" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="VehicleEquipmentProfileMember" substitutionGroup="VersionedChild">
+		<xsd:annotation>
+			<xsd:documentation>A element within a  VEHICLE EQUIPMENT PROFILE specifying the number of units of a given TYPE OF EQUIPMENT.
+</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="VehicleEquipmentProfileMember_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:group ref="VehicleEquipmentProfileMemberGroup"/>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="VehicleEquipmentProfileMemberIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of VEHICLE EQUIPMENT PROFILE MEMBER.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="VehicleEquipmentProfileMember_VersionedChildStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a VEHICLE EQUIPMENT PROFILE MEMBER.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:group ref="VehicleEquipmentProfileMemberGroup"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="VehicleEquipmentProfileMemberGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a VEHICLE EQUIPMENT PROFILE MEMBER.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of VEHICLE EQUIPMENT PROFILE MEMBER.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Description" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Description of VEHICLE EQUIPMENT PROFILE MEMBER.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="MinimumUnits" type="xsd:integer" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Number of units of EQUIPMENT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="TypeOfEquipmentRef" minOccurs="0"/>			
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ========= PURPOSE OF EQUIPMENT ============================================ -->
@@ -1234,7 +1319,7 @@ Rail transport, Roads and Road transport
 					</xsd:sequence>
 					<xsd:attribute name="id" type="PurposeOfEquipmentProfileIdType">
 						<xsd:annotation>
-							<xsd:documentation>Identifier of PURPOSE OF EQUIMENT PROFILE.</xsd:documentation>
+							<xsd:documentation>Identifier of PURPOSE OF EQUIPMENT PROFILE.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
 				</xsd:restriction>
@@ -1243,7 +1328,7 @@ Rail transport, Roads and Road transport
 	</xsd:element>
 	<xsd:complexType name="PurposeOfEquipmentProfile_ValueStructure" abstract="false">
 		<xsd:annotation>
-			<xsd:documentation>Type for a PURPOSE OF EQUIPMENT.</xsd:documentation>
+			<xsd:documentation>Type for a PURPOSE OF EQUIPMENT PROFILE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="TypeOfValue_VersionStructure"/>
@@ -1252,7 +1337,8 @@ Rail transport, Roads and Road transport
 	<!-- =========TYPE OF DRIVER PERMIT. ============================================ -->
 	<xsd:element name="TypeOfDriverPermit" abstract="false" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
-			<xsd:documentation>A type of driving license (e.g. https://en.wikipedia.org/wiki/European_driving_licence ). +V2.0</xsd:documentation>
+			<xsd:documentation>A type of driving license (e.g. https://en.wikipedia.org/wiki/European_driving_licenceA type of driving license (e.g. https://en.wikipedia.org/wiki/European_driving_licence).",  +V2.0
+</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -1268,9 +1354,9 @@ Rail transport, Roads and Road transport
 							<xsd:group ref="TypeOfValueGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="TypeOfDriverPermitIdType" use="required">
+					<xsd:attribute name="id" type="TypeOfDriverPermitIdType">
 						<xsd:annotation>
-							<xsd:documentation>Identifier of the TYPE OF DRIVER PERMIT.</xsd:documentation>
+							<xsd:documentation>Identifier of TYPE OF DRIVER PERMIT.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
 				</xsd:restriction>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -20,21 +20,16 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date>
-					<Modified>2011-02-05</Modified>Name Space changes
+				<Date><Modified>2011-02-05</Modified>Name Space changes
 				</Date>
-				<Date>
-					<Modified>2017-03-27</Modified>CR0001 - Vehicle Dimensions added.
+				<Date><Modified>2017-03-27</Modified>CR0001 - Vehicle Dimensions added.
 				</Date>
-				<Date>
-					<Modified>2019-03-25</Modified>NL31 CD #60 Add new attributes BoardingHeight and GapToPlatform attributes to VehicleType. 
+				<Date><Modified>2019-03-25</Modified>NL31 CD #60 Add new attributes BoardingHeight and GapToPlatform attributes to VehicleType. 
 					 NJSK Review correct data types of new attributes to be of LengthType
 				</Date>
-				<Date>
-					<Modified>2021-07-07</Modified>NewModes-Power Description attribute to NVehicleEquipmentProfile
+				<Date><Modified>2021-07-07</Modified>NewModes-Power Description attribute to NVehicleEquipmentProfile
 				</Date>
-				<Date>
-					<Modified>2020-10-05</Modified> New Modes: Add Vehicle  mode  to VehicleType					
+				<Date><Modified>2020-10-05</Modified> New Modes: Add Vehicle  mode  to VehicleType					
 					 Refactor VehicleType into TarnsportType, VehicleType and PesonalVehicleType
 					   Replace Vehicle OperatorRef with TransportOrganisationRef.
 					   Add VehicleModelRef to Vehicle.
@@ -42,11 +37,9 @@
 					   Add Description to Vehicle.
 					   Add PropulsionType . and MaximumRange to TransportType
 				</Date>
-				<Date>
-					<Modified>2021-07-08</Modified>NewModes: Correction Add missing VehicleEquipmentProfile relationship to VehicleModel
+				<Date><Modified>2021-07-08</Modified>NewModes: Correction Add missing VehicleEquipmentProfile relationship to VehicleModel
 				</Date>
-				<Date>
-					<Modified>2023-01-30</Modified>TM CR: Enhancement Add Accepted Driver Permit
+				<Date><Modified>2023-01-30</Modified>TM CR: Enhancement Add Accepted Driver Permit
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -644,7 +637,7 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="VehicleAccessibilityRequirementsGroup"/>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ====== PASSENGER CAPACITY =================================== -->	
+	<!-- ====== PASSENGER CAPACITY =================================== -->
 	<xsd:complexType name="passengerCapacities_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a list of PASSENGER CAPACITY REQUIREMENTs.</xsd:documentation>
@@ -1295,7 +1288,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Number of units of EQUIPMENT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="TypeOfEquipmentRef" minOccurs="0"/>			
+			<xsd:element ref="TypeOfEquipmentRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ========= PURPOSE OF EQUIPMENT ============================================ -->

--- a/xsd/netex_part_1/part1_frames/netex_siteFrame_version.xsd
+++ b/xsd/netex_part_1/part1_frames/netex_siteFrame_version.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns1="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_siteFrame_version">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns1="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_siteFrame_version">
 	<xsd:include schemaLocation="../../netex_framework/netex_frames/netex_commonFrame_version.xsd"/>
 	<xsd:include schemaLocation="../part1_ifopt/netex_ifopt_flexibleStopPlace_version.xsd"/>
 	<xsd:include schemaLocation="../part1_ifopt/netex_ifopt_pointOfInterest_version.xsd"/>
@@ -42,7 +42,7 @@
 					<Requires>http://www.netex.org.uk/schemas/1.0/ifopt/netex_xxxxx.xsd</Requires>
 				</Relation>
 				<Rights>Unclassified
- <Copyright>CEN, Crown Copyright 2009-2017</Copyright>
+ <Copyright>CEN, Crown Copyright 2009-2023</Copyright>
 				</Rights>
 				<Source>
 					<ul>
@@ -153,6 +153,11 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>SITE related elements in frame.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
+			<xsd:element name="groupsOfSites" type="groupsOfSites_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>GROUPS of SITESs in frame. +v.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>		
 			<xsd:element name="groupsOfStopPlaces" type="groupsOfStopPlacesInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>GROUPS of STOP PLACEs in frame.</xsd:documentation>
@@ -209,17 +214,17 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="TariffZoneInFrameGroup">
 		<xsd:annotation>
-			<xsd:documentation>Service related elements in frame.</xsd:documentation>
+			<xsd:documentation>TARIFF ZONE  related elements in frame.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
+			<xsd:element name="groupsOfTariffZones" type="groupsOfTariffZones_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>GROUPS OF TARIFF ZONEs in frame. +v2.0 </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>		
 			<xsd:element name="tariffZones" type="tariffZonesInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>TARIFF ZONEs in frame.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="groupsOfTariffZones" type="groupsOfTariffZonesInFrame_RelStructure" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>GROUPs of TARIFF ZONEs in frame.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_1/part1_frames/netex_siteFrame_version.xsd
+++ b/xsd/netex_part_1/part1_frames/netex_siteFrame_version.xsd
@@ -157,7 +157,7 @@ Rail transport, Roads and Road transport
 				<xsd:annotation>
 					<xsd:documentation>GROUPS of SITESs in frame. +v.0</xsd:documentation>
 				</xsd:annotation>
-			</xsd:element>		
+			</xsd:element>
 			<xsd:element name="groupsOfStopPlaces" type="groupsOfStopPlacesInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>GROUPS of STOP PLACEs in frame.</xsd:documentation>
@@ -221,7 +221,7 @@ Rail transport, Roads and Road transport
 				<xsd:annotation>
 					<xsd:documentation>GROUPS OF TARIFF ZONEs in frame. +v2.0 </xsd:documentation>
 				</xsd:annotation>
-			</xsd:element>		
+			</xsd:element>
 			<xsd:element name="tariffZones" type="tariffZonesInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>TARIFF ZONEs in frame.</xsd:documentation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_support.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_ifopt_site_support">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_ifopt_site_support">
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_address_support.xsd"/>
 	<!-- ======================================================================= -->
 	<xsd:annotation>
@@ -13,11 +13,14 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date><Modified>2011-02-05</Modified>Name Space changes
+				<Date>
+					<Modified>2011-02-05</Modified>Name Space changes
 				</Date>
-				<Date><Modified>2019-03-25</Modified>Fix #39 by Skinkie from 2019.01.07  Fix typo on ServiceSiteRefStructure 
+				<Date>
+					<Modified>2019-03-25</Modified>Fix #39 by Skinkie from 2019.01.07  Fix typo on ServiceSiteRefStructure 
 				</Date>
-				<Date><Modified>2020-20-05</Modified>New Modes Fix: add  sportsm transport, government  and culturalAttraction to SiteType enumeration					  
+				<Date>
+					<Modified>2020-20-05</Modified>New Modes Fix: add  sportsm transport, government  and culturalAttraction to SiteType enumeration					  
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -58,10 +61,37 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEX: SITE idenifier types.</xsd:documentation>
+		<xsd:documentation>NeTEX: SITE identifier types.</xsd:documentation>
 	</xsd:annotation>
-	<xsd:simpleType name="SiteElementIdType">
+	<!-- ==  GROUP OF SITEs ============================================== -->
+	<xsd:element name="GroupOfSitesRef" type="GroupOfSitesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
 		<xsd:annotation>
+			<xsd:documentation>Reference to a GROUP OF SITEs.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="GroupOfSitesRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a GROUP OF SITEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="GroupOfEntitiesRefStructure">
+				<xsd:attribute name="ref" type="GroupOfSitesIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a GROUP OF SITEs.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="GroupOfSitesIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a GROUP OF SITEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="GroupOfEntitiesIdType"/>
+	</xsd:simpleType>
+	<!-- ===== SITE========================================================== -->	
+	<xsd:simpleType name="SiteElementIdType">
+		<xsd:annotation>		
 			<xsd:documentation>Identifier for a SITE ELEMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="AddressablePlaceIdType"/>
@@ -123,7 +153,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<!-- ======================================================================= -->
+	<!-- ============= SERVICE ========================================================== -->
 	<xsd:simpleType name="ServiceSiteIdType">
 		<xsd:annotation>
 			<xsd:documentation>Identifier for a SERVICE SITE.</xsd:documentation>
@@ -149,7 +179,7 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<!-- ======================================================================= -->
+	<!-- ============= SITE COMPONENT ========================================================== -->
 	<xsd:simpleType name="SiteComponentIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a SITE COMPONENT.</xsd:documentation>
@@ -175,7 +205,7 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<!-- ======================================================================= -->
+	<!-- =========== LEVEL ============================================================ -->
 	<xsd:simpleType name="LevelIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a LEVEL.</xsd:documentation>
@@ -201,7 +231,71 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<!-- ======================================================================= -->
+	<!-- ===== SITE STRUCTURE======================================================== -->
+	<xsd:simpleType name="SiteStructureIdType">
+		<xsd:annotation>
+			<xsd:documentation>Identifier for a SITE STRUCTURE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SiteStructureRef" type="SiteStructureRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SITE STRUCTURE.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SiteStructureRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a SITE STRUCTURE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="SiteStructureIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SITE STRUCTURE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="siteStructureRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a collection of one or more SITE STRUCTUREs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="SiteStructureRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ====== LEVEL ======================================================== -->
+	<xsd:simpleType name="LevelInStructureIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a LEVEL IN  STRUCTURE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="LevelInStructureRef" type="LevelInStructureRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to LEVEL of a LEVEL IN  STRUCTURE.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="LevelInStructureRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a LEVEL IN  STRUCTURE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="LevelInStructureIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a LEVEL IN STRUCTURE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ===== ENTRANCE ===================================================== -->
 	<xsd:simpleType name="EntranceIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of ENTRANCE.</xsd:documentation>
@@ -221,7 +315,7 @@ Rail transport, Roads and Road transport
 			<xsd:restriction base="SiteComponentRefStructure">
 				<xsd:attribute name="ref" type="EntranceIdType" use="required">
 					<xsd:annotation>
-						<xsd:documentation>Identifier of a PLACE.</xsd:documentation>
+						<xsd:documentation>Identifier of an ENTRANCE.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:restriction>
@@ -239,7 +333,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<!-- ======================================================================= -->
+	<!-- ========= VEHICLE ENTRANCE ============================================================== -->
 	<xsd:simpleType name="VehicleEntranceIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a VEHICLE ENTRANCE.</xsd:documentation>
@@ -259,13 +353,13 @@ Rail transport, Roads and Road transport
 			<xsd:restriction base="EntranceRefStructure">
 				<xsd:attribute name="ref" type="VehicleEntranceIdType" use="required">
 					<xsd:annotation>
-						<xsd:documentation>Identifier of a PLACE.</xsd:documentation>
+						<xsd:documentation>Identifier of a VEHICLE ENTRANCE.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<!-- ======================================================================= -->
+	<!-- ============ ACCESS ZONE =========================================================== -->
 	<xsd:simpleType name="AccessZoneIdType">
 		<xsd:annotation>
 			<xsd:documentation>Identifier for an ACCESS ZONE.</xsd:documentation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_support.xsd
@@ -13,14 +13,11 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date>
-					<Modified>2011-02-05</Modified>Name Space changes
+				<Date><Modified>2011-02-05</Modified>Name Space changes
 				</Date>
-				<Date>
-					<Modified>2019-03-25</Modified>Fix #39 by Skinkie from 2019.01.07  Fix typo on ServiceSiteRefStructure 
+				<Date><Modified>2019-03-25</Modified>Fix #39 by Skinkie from 2019.01.07  Fix typo on ServiceSiteRefStructure 
 				</Date>
-				<Date>
-					<Modified>2020-20-05</Modified>New Modes Fix: add  sportsm transport, government  and culturalAttraction to SiteType enumeration					  
+				<Date><Modified>2020-20-05</Modified>New Modes Fix: add  sportsm transport, government  and culturalAttraction to SiteType enumeration					  
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -89,9 +86,9 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<!-- ===== SITE========================================================== -->	
+	<!-- ===== SITE========================================================== -->
 	<xsd:simpleType name="SiteElementIdType">
-		<xsd:annotation>		
+		<xsd:annotation>
 			<xsd:documentation>Identifier for a SITE ELEMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="AddressablePlaceIdType"/>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_ifopt_site_version">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_ifopt_site_version">
 	<xsd:include schemaLocation="netex_ifopt_site_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_equipmentPlace_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_genericFramework/netex_accessibility/netex_acsb_accessibility.xsd"/>
@@ -8,6 +8,7 @@
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_address_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_facility_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_topographicPlace_version.xsd"/>
+	<xsd:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="../../gml/gmlBasic2d-extract-v3_2_1-.xsd"/>	
 	<xsd:include schemaLocation="netex_ifopt_checkConstraint_version.xsd"/>
 	<xsd:include schemaLocation="netex_ifopt_equipmentAll.xsd"/>
 	<!-- ======================================================================= -->
@@ -23,9 +24,11 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date><Modified>2011-02-05</Modified>Name Space changes 
+				<Date>
+					<Modified>2011-02-05</Modified>Name Space changes 
 				</Date>
-				<Date><Modified>2020-10-10</Modified>New Modes : Add PRESENTATGION To Site ELement
+				<Date>
+					<Modified>2020-10-10</Modified>New Modes : Add PRESENTATGION To Site ELement
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -43,7 +46,7 @@
 					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
 				</Relation>
 				<Rights>Unclassified
- <Copyright>CEN, Crown Copyright 2009-2020</Copyright>
+ <Copyright>CEN, Crown Copyright 2009-2023</Copyright>
 				</Rights>
 				<Source>
 					<ul>
@@ -68,6 +71,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: SITE types.</xsd:documentation>
 	</xsd:annotation>
+	<!-- ======================================================================= -->	
 	<xsd:element name="SiteElement" type="SiteElement_VersionStructure" abstract="true" substitutionGroup="Place">
 		<xsd:annotation>
 			<xsd:documentation>A physical PLACE to which passengers may go. May have ACCESSIBILITY ASSESMENT and other properties to describe it.</xsd:documentation>
@@ -188,7 +192,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ======================================================================= -->
+	<!-- ==============SITE========================================================= -->
 	<xsd:element name="Site" type="Site_VersionStructure" abstract="true" substitutionGroup="SiteElement">
 		<xsd:annotation>
 			<xsd:documentation>A type of PLACE, such as a STOP PLACE, POINT OF INTEREST or ADDRESS, to which passengers may wish to travel.</xsd:documentation>
@@ -254,7 +258,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="entrances" type="siteEntrances_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Entrances to and within SITE.</xsd:documentation>
+					<xsd:documentation>ENTRANCEs  to and within SITE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="siteStructures" type="siteStructures_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>SITE STRUCTUREs within SITE. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="AllEquipmentGroup"/>
@@ -282,7 +291,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ======================================================================= -->
+	<!-- ============SITE COMPONENT =========================================================== -->
 	<xsd:element name="SiteComponent" type="SiteComponent_VersionStructure" abstract="true" substitutionGroup="SiteElement">
 		<xsd:annotation>
 			<xsd:documentation>An element of a SITE describing part of its structure. SITE COMPONENTs share common properties for accessibility and other features.</xsd:documentation>
@@ -434,7 +443,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ======================================================================= -->
+	<!-- ============ VEHICLE ENTRANCE =========================================================== -->
 	<xsd:complexType name="vehicleEntrances_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a list of VEHICLE ENTRANCEs.</xsd:documentation>
@@ -517,7 +526,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ====Level=========================================================== -->
+	<!-- ==== LEVEL =========================================================== -->
 	<xsd:complexType name="levels_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a list of LEVELs.</xsd:documentation>
@@ -618,7 +627,207 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="SiteRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ======================================================================= -->
+	<!-- ===  GROUP OF SITES =================================================== -->
+	<xsd:complexType name="groupsOfSites_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for list of  GROUP OF SITES.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="GroupOfSites" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="GroupOfSites" abstract="false" substitutionGroup="GroupOfEntities">
+		<xsd:annotation>
+			<xsd:documentation>A grouping of SITEs which will be commonly referenced for a specific purpose. +v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="GroupOfSites_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="GroupOfEntitiesGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="GroupOfSitesGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="GroupOfSitesIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="GroupOfSites_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for GROUP OF SITES.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="GroupOfEntities_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="GroupOfSitesGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="GroupOfSitesGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for GROUP OF SITES.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:group ref="GroupOfSitesSpatialGroup"/>
+			<xsd:element name="alternativeNames" type="alternativeNames_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Alternative names.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="PublicCode" type="ExternalObjectRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Public code for GROUP OF SITES.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="members" type="siteRefs_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>SITEs in a GROUP OF SITEs</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="GroupOfSitesSpatialGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for GROUP OF SITES.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Centroid" type="SimplePoint_VersionStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Centre Coordinates of ZONE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="gml:Polygon" minOccurs="0"/>
+			<xsd:element name="projections" type="projections_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Projections of SITE  onto another layer.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ===== SITE  STRUCTURE =============================================== -->
+	<xsd:complexType name="siteStructures_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for list of SITE STRUCTURES.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="SiteStructure" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SiteStructure" type="SiteStructure_VersionStructure" abstract="false" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A building or a separate part thereof within a SITE. +v2.0
+</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SiteStructure_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SITE STRUCTURE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DataManagedObjectStructure">
+				<xsd:sequence>
+					<xsd:group ref="SiteStructureGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SiteStructureGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements of a SITE STRUCTURE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of GROUP OF ENTITies.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Description" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Further Description of a GROUP OF ENTITies.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="SiteRef" minOccurs="0"/>
+			<xsd:element name="levelsInStructure" type="levelsInStructure_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>LEVELs found within SITe.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====== LEVEL IN STRUCTURE ============================================== -->
+	<xsd:complexType name="levelsInStructure_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of ENTRANCEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="LevelInStructure" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="LevelInStructure" type="LevelInStructure_VersionStructure" abstract="false" substitutionGroup="VersionedChild">
+		<xsd:annotation>
+			<xsd:documentation>A LEVEL that is accessible in a SITE STRUCTURE with its relative lateral order in that SITE STRUCTURE counted from the bottom and upwards. +V2.0
+</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="LevelInStructure_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for LEVEL IN STRUCTURE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="LevelInStructureGroup"/>
+				</xsd:sequence>
+				<xsd:attribute name="order" type="xsd:positiveInteger">
+					<xsd:annotation>
+						<xsd:documentation>Order of LEVEL IN STRUCTURE within SITE STRUCTURE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="LevelInStructureGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements of a LEVEL IN STRUCTURE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="FloorLabel" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Label associated with LEVEL within SITE STRUCTURE. </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of Level in SITE STRUCTURE</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="LevelRef"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ===== ACCESS ZONES ======================================================= -->
 	<xsd:complexType name="accessZones_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a list of ACCESS ZONEs.</xsd:documentation>
@@ -697,7 +906,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ======================================================================= -->
+	<!-- ============== SERVICE SITE ========================================================= -->
 	<xsd:element name="ServiceSite" substitutionGroup="Site">
 		<xsd:annotation>
 			<xsd:documentation>A sub-type of SITE which is of specific interest for the operator (e.g. where a joint service or a joint fee is proposed).</xsd:documentation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
@@ -609,7 +609,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="RelativeLevelOrder" type="xsd:integer" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Order of LEVELs. The level numbers are not absolute, but only give a relative order within the SITE. 0 should be the ground floor, even when it is often difficult to determine which one that is in a complex structure. Complex buildings can be modelled with multiple SITEs and referenced by SiteRef.</xsd:documentation>
+					<xsd:documentation>Primary relative order of LEVELs for SITE. -1, 0 +1 +2, etc,  0 should be the ground floor. Negative numbers can be used to indicate levels below ground level.  Note that in a complex site alternative setes of level indicators may exist. E.g. Level 1 in one   building part may be   ground level in another; in this case SITE STRUCTUREs and LEVELs IN STRUCTURE can be used to represent the alternative numbering sets.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="AccessibilityAssessment" type="AccessibilityAssessment_VersionedChildStructure" minOccurs="0">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
@@ -8,7 +8,7 @@
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_address_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_facility_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_topographicPlace_version.xsd"/>
-	<xsd:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="../../gml/gmlBasic2d-extract-v3_2_1-.xsd"/>	
+	<xsd:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="../../gml/gmlBasic2d-extract-v3_2_1-.xsd"/>
 	<xsd:include schemaLocation="netex_ifopt_checkConstraint_version.xsd"/>
 	<xsd:include schemaLocation="netex_ifopt_equipmentAll.xsd"/>
 	<!-- ======================================================================= -->
@@ -24,11 +24,9 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date>
-					<Modified>2011-02-05</Modified>Name Space changes 
+				<Date><Modified>2011-02-05</Modified>Name Space changes 
 				</Date>
-				<Date>
-					<Modified>2020-10-10</Modified>New Modes : Add PRESENTATGION To Site ELement
+				<Date><Modified>2020-10-10</Modified>New Modes : Add PRESENTATGION To Site ELement
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -71,7 +69,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: SITE types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ======================================================================= -->	
+	<!-- ======================================================================= -->
 	<xsd:element name="SiteElement" type="SiteElement_VersionStructure" abstract="true" substitutionGroup="Place">
 		<xsd:annotation>
 			<xsd:documentation>A physical PLACE to which passengers may go. May have ACCESSIBILITY ASSESMENT and other properties to describe it.</xsd:documentation>

--- a/xsd/netex_part_1/part1_ifopt/tmp0000.xsd
+++ b/xsd/netex_part_1/part1_ifopt/tmp0000.xsd
@@ -1,0 +1,553 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 2007 03 23 Add repeating name -->
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_ifopt_path_version">
+	<xsd:include schemaLocation="netex_ifopt_path_support.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_site_version.xsd"/>
+	<!-- ============================================== -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>V1.0 Nicholas Knowles</Contributor>
+				<Contributor>Roger Slevin [Roger.Slevin@dft.gsi.gov.uk]</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>Created as W3C .xsd schema by Nicholas Knowles. as 1.0 XML schema </Creator>
+				<Date>
+					<Created>2006-08-10</Created>
+				</Date>
+				<Date>
+					<Modified>2006-09-21</Modified>
+				</Date>
+				<Date>
+					<Modified>2007-03-22</Modified>
+				</Date>
+				<Date>
+					<Modified>2019-03-25</Modified>FR49 CD #65  Accessibility changes
+					 CD add new attributes to PathLink : Width, FlooringType,  RightSideBorder,  LeftSideBordert, TiltAngle, CodedTilt, TactileWarningStrip,  TactileGuidingStrip	
+					 NK Review: Reorder so as to place like elements toigether, add sub Groups to organize  
+ 				</Date>
+				<Date>
+					<Modified>2019-03-28</Modified>FR49 CD #65  Accessibility changes
+					 NJSK Doc rewviewe 
+					 Revise name of ___PathLink___   ___Width___ to ___MinimumWidth__, add enw attribute ___MinimumHeight___
+					 Revise name of  ___PathLink___  new attribute ___CodedTilt___ to ___TiltType___ to be consistent 				
+ 				    Also add new attributes ___MaximumGradient___ and MaximumGradientType___ to  ___PathLink___   	
+ 				</Date>
+				<Description>
+					<Title>NeTEx Network Exchange - PATH types.</Title>
+					<p>
+					</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_Ifopt_path_version.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>CEN TC278 SG6 and Department for Transport, Great Minster House, 76 Marsham Street, London SW1P 4DR</Publisher>
+				<Relation>
+					<Requires>http://www.netex.org.uk/schemas/1.0/ifopt/netex_ifopt_xxxxx.xsd</Requires>
+				</Relation>
+				<Rights>Unclassified
+					 <Copyright>CEN, Crown Copyright 2009-2019</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Evolved from NaPTAN, SIRI and other schemas.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange (IFOPT subset) - STOP PLACE Schema Place . </Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>IFOPT STOP PLACE Model.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:group name="PathPropertiesGroup">
+		<xsd:annotation>
+			<xsd:documentation>Common elements of a PATH.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:group ref="PathNavigationGroup"/>
+			<xsd:group ref="PathDescriptionGroup"/>
+			<xsd:element name="MaximumFlowPerMinute" type="xsd:nonNegativeInteger" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Maximum number of passengers who can traverse PATH LINK per minute.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="PathNavigationGroup">
+		<xsd:annotation>
+			<xsd:documentation>Common Navigation elements of a PATH.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Towards" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Direction heading to show for PATH LINK when travelling  in its FROM / TO sense.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Back" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Direction heading to show for PATH LINK when travelling  in its TO / FROM sense.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="NumberOfSteps" type="xsd:nonNegativeInteger" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Number of steps to take PATH LINK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="MinimumHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Minimum Height of PATH LINK. +v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="MinimumWidth" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Minimum Width of PATH LINK. +v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="AllowedUse" type="PathDirectionEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Allowed direction of use: one way or two way. Default is two way.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Transition" type="TransitionEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether PATH LINK is up down or level in from to direction.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Gradient" type="xsd:integer" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Maximum gradient in degrees  (in the direction of the PATH LINK way). +v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="GradientType" type="GradientEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Coded value of the maximum gradient.+v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="TiltAngle" type="xsd:integer" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Maximum Tilt angle in degrees between -20 and 20 (in the direction of the PATH LINK way). +v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="TiltType" type="TiltTypeEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Coded value of the maximum  tilt.  See allowed va;ues. +v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="PathDescriptionGroup">
+		<xsd:annotation>
+			<xsd:documentation>Common Description elements of a PATH.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="AccessFeatureType" type="AccessFeatureEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Type of physical feature of PATH LINK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="PassageType" type="PassageTypeEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Type of passage feature of PATH LINK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="FlooringType" type="FlooringTypeEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Type of flooring of the walking surface. +v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="RightSideBorder" type="BorderTypeEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Type of border on the right side (in the direction of the PATH LINK).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="LeftSideBorder" type="BorderTypeEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Type of border on the left side (in the direction of the PATH LINK). +v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="TactileWarningStrip" type="TactileWarningStripEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Nature of the  tactile warning strips (in the direction of the PATH LINK). +v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="TactileGuidingStrip" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Indicates whether there are guiding strips. +v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:element name="PathLink" substitutionGroup="Link">
+		<xsd:annotation>
+			<xsd:documentation>A link between any two PLACEs (That is STOP PLACEs, ACCESS SPACEs or QUAYs, BOARDING POSITIONs, POINTs OF INTEREST etc or PATH JUNCTIONs) that represents a step in a possible route for pedestrians, cyclists or other out of vehicle passengers within or between a PLACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="PathLink_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LinkGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="PathLinkGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="PathLinkIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="PathLink_VersionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for a PATH LINK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="Link_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="PathLinkGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="PathLinkGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements of a PATH LINK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="From" type="PathLinkEndStructure">
+				<xsd:annotation>
+					<xsd:documentation>Origin end of PATH LINK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="To" type="PathLinkEndStructure">
+				<xsd:annotation>
+					<xsd:documentation>Destination end of PATH LINK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Description" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Description of PATH LINK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:group ref="PathLinkElementGroup"/>
+			<xsd:group ref="PathPropertiesGroup"/>
+			<xsd:group ref="LinkDurationGroup"/>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="LinkDurationGroup">
+		<xsd:annotation>
+			<xsd:documentation>Duration properties of a LINK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="TransferDuration" type="TransferDurationStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Timings for the transfer.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:complexType name="PathLinkEndStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a PATH LINK ENd.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="PlaceRef" type="PlaceRefStructure">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a PLACE, including QUAY, ACCESS SPACE, BOARDING POSITION or other node of a SITE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="LevelRef" type="LevelRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a LEVEL on which SITE COMPONENT is found.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="EntranceRef" type="EntranceRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to an ENTRANCE of a PLACE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:group name="PathLinkElementGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements of a PATH SITE ELEMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:choice minOccurs="0">
+				<xsd:element ref="AccessibilityAssessmentRef"/>
+				<xsd:element ref="AccessibilityAssessment" minOccurs="0" maxOccurs="1"/>
+			</xsd:choice>
+			<xsd:element name="AccessModes" type="AccessModeListOfEnumerations" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Allowed MODEs to use in component.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:group ref="SiteElementPropertiesGroup"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="sitePathLinks_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of SITE PATH LINKs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="PathLinkRef"/>
+					<xsd:element ref="SitePathLink">
+						<xsd:annotation>
+							<xsd:documentation>PATH LINK for a SITE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SitePathLink" substitutionGroup="Link">
+		<xsd:annotation>
+			<xsd:documentation>A PATH LINK between two nodes that are SITE components, i.e. within a STOP PLACE or POINT OF INTEREST.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SitePathLink_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LinkGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="PathLinkGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SiteComponentGroup"/>
+							<xsd:group ref="SitePathLinkGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="PathLinkIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SitePathLink_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SITE PATH LINK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="PathLink_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="SiteComponentGroup"/>
+					<xsd:group ref="SitePathLinkGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SitePathLinkGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements of a SITE PATH LINK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Label" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Additional public label for the SITE PATH LINK</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<!-- ======================================================================= -->
+	<xsd:complexType name="pathJunctions_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of PATH JUNCTIONs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="PathJunctionRef"/>
+					<xsd:element ref="PathJunction">
+						<xsd:annotation>
+							<xsd:documentation>PATH JUNCTION for a SITE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="PathJunction" substitutionGroup="Point">
+		<xsd:annotation>
+			<xsd:documentation>A designated point, inside or outside of a STOP PLACE or POINT OF INTEREST, at which two or more PATH LINKs may connect or branch.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="PathJunction_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="PointGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="PathJunctionGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="PathJunctionIdType" use="optional"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="PathJunction_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a PATH LINK VIEW.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="Point_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="PathJunctionGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="PathJunctionGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements of a PATH JUNCTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="ParentZoneRef" type="ZoneRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Parent ZONE that contains this PATH JUNCTION.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:group ref="SiteElementPropertiesGroup">
+				<xsd:annotation>
+					<xsd:documentation>Elements of a SITE ELEMENTs.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:group>
+			<xsd:element name="Label" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Additional Label of PATH JUNCTION.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="SiteComponentRef" type="SiteComponentRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>PATH JUNCTION is within the referenced SITE COMPONENT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:element name="PathLinkView" substitutionGroup="DerivedView">
+		<xsd:annotation>
+			<xsd:documentation>A VIEW of a PATH LINK used to select items for presentation.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="PathLink_DerivedViewStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:element name="HideLink" type="xsd:boolean" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Whether link should be hidden in the PATH LINK VIEW.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="HideDestination" type="xsd:boolean" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Whether destination of PATH LINK should be hidden.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="ShowEntranceSeparately" type="xsd:boolean" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Whether ENTRANCE on beginning of PATH LINK should be shown as separate step in view.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="ShowExitSeparately" type="xsd:boolean" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Whether exit at end of PATH LINK should be shown as separate step in view.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="ShowHeadingSeparately" type="xsd:boolean" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Whether Heading element should be shown as separate step in view e.g. turn left right.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="PathLinkIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of Object of which this is a view.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="PathLink_DerivedViewStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a PATH LINK VIEW.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DerivedViewStructure">
+				<xsd:sequence>
+					<xsd:element name="HideLink" type="xsd:boolean" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Whether link should be hidden in the PATH LINK VIEW.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="HideDestination" type="xsd:boolean" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Whether destination of PATH LINK should be hidden.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ShowEntranceSeparately" type="xsd:boolean" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Whether ENTRANCE on beginning of PATH LINK should be shown as separate step in view.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ShowExitSeparately" type="xsd:boolean" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Whether exit at end of PATH LINK should be shown as separate step in view.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ShowHeadingSeparately" type="xsd:boolean" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Whether Heading element should be shown as separate step in view e.g. turn left right.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/xsd/netex_part_1/part1_ifopt/tmp0000.xsd
+++ b/xsd/netex_part_1/part1_ifopt/tmp0000.xsd
@@ -22,13 +22,11 @@
 				<Date>
 					<Modified>2007-03-22</Modified>
 				</Date>
-				<Date>
-					<Modified>2019-03-25</Modified>FR49 CD #65  Accessibility changes
+				<Date><Modified>2019-03-25</Modified>FR49 CD #65  Accessibility changes
 					 CD add new attributes to PathLink : Width, FlooringType,  RightSideBorder,  LeftSideBordert, TiltAngle, CodedTilt, TactileWarningStrip,  TactileGuidingStrip	
 					 NK Review: Reorder so as to place like elements toigether, add sub Groups to organize  
  				</Date>
-				<Date>
-					<Modified>2019-03-28</Modified>FR49 CD #65  Accessibility changes
+				<Date><Modified>2019-03-28</Modified>FR49 CD #65  Accessibility changes
 					 NJSK Doc rewviewe 
 					 Revise name of ___PathLink___   ___Width___ to ___MinimumWidth__, add enw attribute ___MinimumHeight___
 					 Revise name of  ___PathLink___  new attribute ___CodedTilt___ to ___TiltType___ to be consistent 				

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
@@ -4,8 +4,7 @@
 	<xsd:include schemaLocation="netex_stopAssignment_support.xsd"/>
 	<xsd:include schemaLocation="netex_servicePattern_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_trainElement_version.xsd"/>
-	<xsd:include schemaLocation="../../netex_part_2/part2_journeyTimes/netex_deckEntranceAlignment_version.xsd"/> 
-	
+	<xsd:include schemaLocation="../../netex_part_2/part2_journeyTimes/netex_deckEntranceAlignment_version.xsd"/>
 	<!-- ======================================================================= -->
 	<xsd:annotation>
 		<xsd:appinfo>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_stopAssignment_version">
+<xsd:schema xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_stopAssignment_version">
 	<xsd:include schemaLocation="../part1_ifopt/netex_ifopt_stopPlace_version.xsd"/>
 	<xsd:include schemaLocation="netex_stopAssignment_support.xsd"/>
 	<xsd:include schemaLocation="netex_servicePattern_version.xsd"/>
-	<xsd:include schemaLocation="../../netex_framework/netex_genericFramework/netex_assignment_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_trainElement_version.xsd"/>
+	<xsd:include schemaLocation="../../netex_part_2/part2_journeyTimes/netex_deckEntranceAlignment_version.xsd"/> 
+	
 	<!-- ======================================================================= -->
 	<xsd:annotation>
 		<xsd:appinfo>
@@ -131,7 +132,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:choice minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Reference or inline declaration of SCHEDULED STOP POINT which is being assigned  </xsd:documentation>
+					<xsd:documentation>Reference or inline declaration of SCHEDULED STOP POINT which is being assigned.</xsd:documentation>
 				</xsd:annotation>
 				<xsd:element ref="ScheduledStopPointRef"/>
 				<xsd:element ref="ScheduledStopPoint"/>
@@ -189,7 +190,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:choice minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>STOP PLACE to which SCHEDULED STOP POINT is to be  assigned.</xsd:documentation>
+					<xsd:documentation>STOP PLACE to which SCHEDULED STOP POINT is to be assigned.</xsd:documentation>
 				</xsd:annotation>
 				<xsd:element ref="StopPlaceRef"/>
 				<xsd:element ref="StopPlace"/>
@@ -203,7 +204,7 @@ Rail transport, Roads and Road transport
 			</xsd:choice>
 			<xsd:choice minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>BOARDING POSITION to which SCHEDULED STOP POINT is to be  assigned.</xsd:documentation>
+					<xsd:documentation>BOARDING POSITION to which SCHEDULED STOP POINT is to be assigned.</xsd:documentation>
 				</xsd:annotation>
 				<xsd:element ref="BoardingPositionRef"/>
 				<xsd:element ref="BoardingPosition"/>
@@ -360,7 +361,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="EntranceToVehicle" type="MultilingualString" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>A specific ENTRANCE to the VEHICLE. E.g. Front, rear.</xsd:documentation>
+					<xsd:documentation>Text description of A specific ENTRANCE to the VEHICLE. E.g. Front, rear.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="deckEntranceAssignments" type="deckEntranceAssignments_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Explicit assignment of a DECK ENTRANCE to a BOARDING POSITION</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
+++ b/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_timetableFrame_version">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_timetableFrame_version">
 	<xsd:include schemaLocation="netex_timetableFrame_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_trainElement_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_frames/netex_serviceCalendarFrame_version.xsd"/>
 	<xsd:include schemaLocation="../part2_journeyTimes/netex_datedVehicleJourney_version.xsd"/>
+	<xsd:include schemaLocation="../part2_journeyTimes/netex_deckPlanAssignment_version.xsd"/>	
 	<xsd:annotation>
 		<xsd:appinfo>
 			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
@@ -109,7 +110,7 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="TimetablePropertiesGroup"/>
 			<xsd:group ref="TimetableDefaultsGroup">
 				<xsd:annotation>
-					<xsd:documentation>Default  properties of elements in TIMETABLE FRAME. Use these values on child elements if not specified on individual elements.</xsd:documentation>
+					<xsd:documentation>Default properties of elements in TIMETABLE FRAME. Use these values on child elements if not specified on individual elements.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
 			<xsd:group ref="TimeDemandTypeInFrameGroup"/>
@@ -122,7 +123,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="TimetableDefaultsGroup">
 		<xsd:annotation>
-			<xsd:documentation>Default  properties of elements in TIMETABLE FRAME. Use these values if not specified on individual elements.</xsd:documentation>
+			<xsd:documentation>Default properties of elements in TIMETABLE FRAME. Use these values if not specified on individual elements.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="NetworkView" minOccurs="0"/>
@@ -179,7 +180,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="frequencyGroups" type="frequencyGroupsInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>FREQUENCY GROUPs  In frame. Can be used to template VEHICLE JOURNEYs.</xsd:documentation>
+					<xsd:documentation>FREQUENCY GROUPs In frame. Can be used to template VEHICLE JOURNEYs.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="groupsOfServices" type="groupsOfServicesInFrame_RelStructure" minOccurs="0">
@@ -194,17 +195,22 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="journeyPartCouples" type="journeyPartCouplesInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>JOURNEY COUPLINGs  in frame.</xsd:documentation>
+					<xsd:documentation>JOURNEY COUPLINGs in frame.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="coupledJourneys" type="coupledJourneysInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>JOURNEY COUPLINGs  in frame.</xsd:documentation>
+					<xsd:documentation>COUPLED JOURNEYs in frame.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="serviceFacilitySets" type="serviceFacilitySetsInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>SERVICE FACILITies  in frame.</xsd:documentation>
+					<xsd:documentation>SERVICE FACILITies in frame.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="deckPlanAssignments" type="deckPlanAssignments_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DECK PLAN ASSIGNMENTs in frame.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="typesOfService" type="typesOfServiceInFrame_RelStructure" minOccurs="0">

--- a/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
+++ b/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
@@ -14,13 +14,16 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date><Modified>2017-05-09</Modified>  Add Header
+				<Date>
+					<Modified>2017-05-09</Modified>  Add Header
 				</Date>
-				<Date><Modified>2019-03-25</Modified>CR 51 CD Add VehicleJourneyStop Assignment.
+				<Date>
+					<Modified>2019-03-25</Modified>CR 51 CD Add VehicleJourneyStop Assignment.
 							NJSK Review make vehicleJourneyStopAssignmentsInFrame_RelStructure lower camel case consistent with NeTEx conventions. 
 							Also correct some documentation comments
 				</Date>
-				<Date><Modified>2020-10-08</Modified>New Modes: Widen VehicleType to TransportType
+				<Date>
+					<Modified>2020-10-08</Modified>New Modes: Widen VehicleType to TransportType
 				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines TIMETABLE FRAME types.</p>

--- a/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
+++ b/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
@@ -4,7 +4,7 @@
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_trainElement_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_frames/netex_serviceCalendarFrame_version.xsd"/>
 	<xsd:include schemaLocation="../part2_journeyTimes/netex_datedVehicleJourney_version.xsd"/>
-	<xsd:include schemaLocation="../part2_journeyTimes/netex_deckPlanAssignment_version.xsd"/>	
+	<xsd:include schemaLocation="../part2_journeyTimes/netex_deckPlanAssignment_version.xsd"/>
 	<xsd:annotation>
 		<xsd:appinfo>
 			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
@@ -15,16 +15,13 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
-				<Date>
-					<Modified>2017-05-09</Modified>  Add Header
+				<Date><Modified>2017-05-09</Modified>  Add Header
 				</Date>
-				<Date>
-					<Modified>2019-03-25</Modified>CR 51 CD Add VehicleJourneyStop Assignment.
+				<Date><Modified>2019-03-25</Modified>CR 51 CD Add VehicleJourneyStop Assignment.
 							NJSK Review make vehicleJourneyStopAssignmentsInFrame_RelStructure lower camel case consistent with NeTEx conventions. 
 							Also correct some documentation comments
 				</Date>
-				<Date>
-					<Modified>2020-10-08</Modified>New Modes: Widen VehicleType to TransportType
+				<Date><Modified>2020-10-08</Modified>New Modes: Widen VehicleType to TransportType
 				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines TIMETABLE FRAME types.</p>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_all_objects_part2_journeyTimes.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_all_objects_part2_journeyTimes.xsd
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_all_objects_part2_journeyTimes">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_all_objects_part2_journeyTimes"> 
 	<!-- ===Dependencies ======================================= -->
 	<xsd:include schemaLocation="netex_journey_version.xsd"/>
 	<xsd:include schemaLocation="netex_journeyDesignator_support.xsd"/>
 	<xsd:include schemaLocation="netex_call_version.xsd"/>
 	<xsd:include schemaLocation="netex_call_support.xsd"/>
 	<xsd:include schemaLocation="netex_coupledJourney_support.xsd"/>
-	<xsd:include schemaLocation="netex_coupledJourney_version.xsd"/>
+	<xsd:include schemaLocation="netex_coupledJourney_version.xsd"/> 
+	<xsd:include schemaLocation="netex_deckEntranceAlignment_support.xsd"/>
+	<xsd:include schemaLocation="netex_deckEntranceAlignment_version.xsd"/>
+	<xsd:include schemaLocation="netex_deckPlanAssignment_support.xsd"/>
+	<xsd:include schemaLocation="netex_deckPlanAssignment_version.xsd"/> 
 	<xsd:include schemaLocation="netex_flexibleService_support.xsd"/>
 	<xsd:include schemaLocation="netex_flexibleService_version.xsd"/>
 	<xsd:include schemaLocation="netex_interchange_support.xsd"/>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_all_objects_part2_journeyTimes.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_all_objects_part2_journeyTimes.xsd
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_all_objects_part2_journeyTimes"> 
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_all_objects_part2_journeyTimes">
 	<!-- ===Dependencies ======================================= -->
 	<xsd:include schemaLocation="netex_journey_version.xsd"/>
 	<xsd:include schemaLocation="netex_journeyDesignator_support.xsd"/>
 	<xsd:include schemaLocation="netex_call_version.xsd"/>
 	<xsd:include schemaLocation="netex_call_support.xsd"/>
 	<xsd:include schemaLocation="netex_coupledJourney_support.xsd"/>
-	<xsd:include schemaLocation="netex_coupledJourney_version.xsd"/> 
+	<xsd:include schemaLocation="netex_coupledJourney_version.xsd"/>
 	<xsd:include schemaLocation="netex_deckEntranceAlignment_support.xsd"/>
 	<xsd:include schemaLocation="netex_deckEntranceAlignment_version.xsd"/>
 	<xsd:include schemaLocation="netex_deckPlanAssignment_support.xsd"/>
-	<xsd:include schemaLocation="netex_deckPlanAssignment_version.xsd"/> 
+	<xsd:include schemaLocation="netex_deckPlanAssignment_version.xsd"/>
 	<xsd:include schemaLocation="netex_flexibleService_support.xsd"/>
 	<xsd:include schemaLocation="netex_flexibleService_version.xsd"/>
 	<xsd:include schemaLocation="netex_interchange_support.xsd"/>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_deckEntranceAlignment_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_deckEntranceAlignment_support.xsd
@@ -13,8 +13,7 @@
 				<Date>
 					<Created>2023-02-12</Created>
 				</Date>
-				<Date>
-					<Modified>2023-02-12</Modified>
+				<Date><Modified>2023-02-12</Modified>
           Name Space changes
         </Date>
 				<Description>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_deckEntranceAlignment_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_deckEntranceAlignment_support.xsd
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_deckEntranceAlignment_support">
+	<!-- ======================================================================= -->
+	<xsd:include schemaLocation="../../netex_framework/netex_genericFramework/netex_assignment_support.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>V1.0 Nicholas Knowles</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for NeTEx version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-02-12</Created>
+				</Date>
+				<Date>
+					<Modified>2023-02-12</Modified>
+          Name Space changes
+        </Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the DECK ENTRANCE ALIGNMENT types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_deckEntranceAlignment_support.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>
+				<Relation>
+					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
+				</Relation>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright 2023-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel  standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx DECK ENTRANCE ALIGNMENT types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>DECK ENTRANCE ALIGNMENT identifier  types</xsd:documentation>
+	</xsd:annotation>
+	<!-- ==== DECK ENTRANCE ASSIGNMENT==================================================== -->
+	<xsd:complexType name="deckEntranceAssignmentRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DECK ENTRANCE ASSIGNMENTs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="deckEntranceAssignmentRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="deckEntranceAssignmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK ENTRANCE ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="AssignmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="deckEntranceAssignmentRef" type="deckEntranceAssignmentRefStructure" substitutionGroup="AssignmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK ENTRANCE ASSIGNMENT. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="deckEntranceAssignmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK ENTRANCE ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="AssignmentRefStructure">
+				<xsd:attribute name="ref" type="deckEntranceAssignmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK ENTRANCE ASSIGNMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_deckEntranceAlignment_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_deckEntranceAlignment_version.xsd
@@ -16,8 +16,7 @@
 				<Date>
 					<Created>2023-01-30</Created>
 				</Date>
-				<Date>
-					<Modified>2023-01-30</Modified>
+				<Date><Modified>2023-01-30</Modified>
           Name Space changes
         </Date>
 				<Description>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_deckEntranceAlignment_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_deckEntranceAlignment_version.xsd
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_deckEntranceAlignment_version">
+	<xsd:include schemaLocation="netex_deckEntranceAlignment_support.xsd"/>
+	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd"/>
+	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_trainElement_support.xsd"/>
+	<xsd:include schemaLocation="../../netex_framework/netex_genericFramework/netex_assignment_version.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>V1.0 Nicholas Knowles</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for NeTEx version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-01-30</Created>
+				</Date>
+				<Date>
+					<Modified>2023-01-30</Modified>
+          Name Space changes
+        </Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the DECK ENTRANCE ALIGNMENT types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_deckEntranceAlignment_version.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>
+				<Relation>
+					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
+				</Relation>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright  2022-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel,   standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx DECKENTRANCE ALIGNMENT types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>DECK ENTRANCE ALIGNMENT data types</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<!-- ==== DECK ENTRANCE ASSIGNMENT ==================================================== -->
+	<xsd:complexType name="deckEntranceAssignments_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for containment in frame of DECK ENTRANCE ASSIGNMENTs</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="DeckEntranceAssignment" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="DeckEntranceAssignment" substitutionGroup="Assignment_">
+		<xsd:annotation>
+			<xsd:documentation>The association of a DECK ENTRANCE of a VEHICLE's DECK PLAN  with a TRAIN and TRAIN COMPONENT and a specific STOP PLACE,  QUAY and possibly BOARDING POSITION.    NOTE: may indicate which side of VEHICLE door is. +v2.0
+</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DeckEntranceAssignment_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:sequence>
+								<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+							</xsd:sequence>
+							<xsd:sequence>
+								<xsd:group ref="DataManagedObjectGroup"/>
+							</xsd:sequence>
+							<xsd:sequence>
+								<xsd:group ref="AssignmentGroup"/>
+							</xsd:sequence>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckEntranceAssignmentGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="deckEntranceAssignmentIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of DECK ENTRANCE ASSIGNMENT.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DeckEntranceAssignment_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK ENTRANCE ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="Assignment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="DeckEntranceAssignmentGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckEntranceAssignmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK ENTRANCE ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="DeckEntranceRef"/>
+			<xsd:element ref="TrainComponentRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_support.xsd
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_deckPlanAssignment_support">
+	<!-- ======================================================================= -->
+	<xsd:include schemaLocation="../../netex_framework/netex_genericFramework/netex_assignment_support.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>V1.0 Nicholas Knowles</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for NeTEx version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-02-12</Created>
+				</Date>
+				<Date>
+					<Modified>2023-02-312</Modified>
+          Name Space changes
+        </Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the DECK PLAN ASSIGNMENT types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_deckPlanAssignment_support.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>
+				<Relation>
+					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
+				</Relation>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright 2023-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel  standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx DECK PLAN ASSIGNMENT types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>DECK PLAN ASSIGNMENT identifier  types</xsd:documentation>
+	</xsd:annotation>
+	<!-- ==== DECK PLAN ASSIGNMENT==================================================== -->
+	<xsd:complexType name="deckPlanAssignmentRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DECK PLAN ASSIGNMENTs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="DeckPlanAssignmentRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="DeckPlanAssignmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a DECK PLAN ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="AssignmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DeckPlanAssignmentRef" type="DeckPlanAssignmentRefStructure" substitutionGroup="AssignmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DECK PLAN ASSIGNMENT. +v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DeckPlanAssignmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DECK PLAN ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="AssignmentRefStructure">
+				<xsd:attribute name="ref" type="DeckPlanAssignmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DECK PLAN ASSIGNMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_support.xsd
@@ -13,8 +13,7 @@
 				<Date>
 					<Created>2023-02-12</Created>
 				</Date>
-				<Date>
-					<Modified>2023-02-312</Modified>
+				<Date><Modified>2023-02-312</Modified>
           Name Space changes
         </Date>
 				<Description>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_version.xsd
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_deckPlanAssignment_version">
+	<xsd:include schemaLocation="netex_deckPlanAssignment_support.xsd"/>
+	<xsd:include schemaLocation="netex_coupledJourney_support.xsd"/>
+	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd"/>
+	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd"/>
+	<xsd:include schemaLocation="../../netex_framework/netex_genericFramework/netex_assignment_version.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>V1.0 Nicholas Knowles</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for NeTEx version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles. mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2023-01-30</Created>
+				</Date>
+				<Date>
+					<Modified>2023-01-30</Modified>
+          Name Space changes
+        </Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the DECK PLAN ASSIGNMENT types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_deckPlanAssignment_version.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>
+				<Relation>
+					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
+				</Relation>
+				<Rights>
+          Unclassified
+          <Copyright>CEN, Crown Copyright  2022-2023</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel,   standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+            Air transport, Airports,
+            Ports and maritime transport, Ferries (marine),
+            Public transport, Bus services, Coach
+            services, Bus stops and stations,
+            Rail transport, Railway stations and track, Train services, Underground trains,
+            Business and industry, Transport, Air transport , Ports and maritime
+            transport, Public transport,
+            Rail transport, Roads and Road transport
+          </Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx DECK PLAN ASSIGNMENT types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>DECK PLAN ASSIGNMENT data types</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<!-- ==== DECK PLAN ASSIGNMENT ==================================================== -->
+	<xsd:complexType name="deckPlanAssignments_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for containment in frame of DECK PLAN ASSIGNMENTs</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="DeckPlanAssignment" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="DeckPlanAssignment" substitutionGroup="Assignment_">
+		<xsd:annotation>
+			<xsd:documentation>DECK PLAN ASSIGNMENT: The allocation of a DECK PLAN to  all or part of a specific VEHICLE JOURNEY  and /or VEHICLE  TYPE and/or TRAIN ELEMENT. +v2.0
+    </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DeckPlanAssignment_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:sequence>
+								<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+							</xsd:sequence>
+							<xsd:sequence>
+								<xsd:group ref="DataManagedObjectGroup"/>
+							</xsd:sequence>
+							<xsd:sequence>
+								<xsd:group ref="AssignmentGroup"/>
+							</xsd:sequence>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DeckPlanAssignmentGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DeckPlanAssignmentIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of DECK PLAN ASSIGNMENT.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DeckPlanAssignment_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a DECK PLAN ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="Assignment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="DeckPlanAssignmentGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeckPlanAssignmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a DECK PLAN ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="DeckPlanRef"/>
+			<xsd:element ref="TransportTypeRef" minOccurs="0"/>
+			<xsd:element ref="JourneyRef" minOccurs="0"/>
+			<xsd:element ref="JourneyPartRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_version.xsd
@@ -81,8 +81,7 @@
 	</xsd:complexType>
 	<xsd:element name="DeckPlanAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
-			<xsd:documentation>DECK PLAN ASSIGNMENT: The allocation of a DECK PLAN to  all or part of a specific VEHICLE JOURNEY  and /or VEHICLE  TYPE and/or TRAIN ELEMENT. +v2.0
-    </xsd:documentation>
+			<xsd:documentation>The allocation of a DECK PLAN to all or part of a specific VEHICLE JOURNEY and /or VEHICLE TYPE and/or TRAIN ELEMENT. +v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_version.xsd
@@ -17,8 +17,7 @@
 				<Date>
 					<Created>2023-01-30</Created>
 				</Date>
-				<Date>
-					<Modified>2023-01-30</Modified>
+				<Date><Modified>2023-01-30</Modified>
           Name Space changes
         </Date>
 				<Description>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_accessRightParameter_version">
+	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_modeOfOperation_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_serviceCalendar_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_vehicleSeating_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_trainElement_support.xsd"/>
@@ -8,8 +9,8 @@
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd"/>	
 	<!-- ====Network ========================================================= -->
 	<xsd:include schemaLocation="../../netex_part_1/part1_ifopt/netex_ifopt_pointOfInterest_support.xsd"/>
+	<xsd:include schemaLocation="../../netex_part_1/part1_ifopt/netex_ifopt_localService_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_part_1/part1_networkDescription/netex_line_support.xsd"/>
-	<xsd:include schemaLocation="../../netex_part_1/part1_tacticalPlanning/netex_servicePattern_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_part_1/part1_networkDescription/netex_route_support.xsd"/>
 	<!-- ====Timetables ========================================================= -->
 	<xsd:include schemaLocation="../../netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd"/>
@@ -18,6 +19,7 @@
 	<xsd:include schemaLocation="netex_qualityStructureFactor_support.xsd"/>
 	<xsd:include schemaLocation="netex_timeStructureFactor_support.xsd"/>
 	<xsd:include schemaLocation="netex_distanceMatrixElement_version.xsd"/>
+	<xsd:include schemaLocation="netex_usageParameterEligibility_support.xsd"/>
 	<xsd:include schemaLocation="netex_usageParametersAll_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd"/>
 	<xsd:include schemaLocation="netex_fareProduct_support.xsd"/>
@@ -37,7 +39,6 @@
 	<!-- ===ACCESS RIGHTS======================================================== -->
 	<xsd:include schemaLocation="netex_accessRightParameter_support.xsd"/>
 	<xsd:include schemaLocation="netex_usageParameter_version.xsd"/>
-	<xsd:include schemaLocation="netex_distanceMatrixElement_version.xsd"/>
 	<!-- ======================================================================= -->
 	<xsd:annotation>
 		<xsd:appinfo>
@@ -147,7 +148,7 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEx  ACCESS RIGHT ASSIGNMENT  types.</xsd:documentation>
+		<xsd:documentation>NeTEx ACCESS RIGHT ASSIGNMENT types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
 	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
@@ -456,7 +457,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>SITE validity parametersfor ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<!-- <xsd:element ref="GroupOfSitesRef"/> -->		
+			<xsd:element ref="GroupOfSitesRef" minOccurs="0"/>
 			<xsd:element ref="SiteElementRef" minOccurs="0"/>
 			<xsd:element ref="LevelRef" minOccurs="0"/>			
 			<xsd:element ref="PointOfInterestClassificationRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -6,7 +6,7 @@
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_trainElement_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_topographicPlace_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd"/>
-	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd"/>	
+	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd"/>
 	<!-- ====Network ========================================================= -->
 	<xsd:include schemaLocation="../../netex_part_1/part1_ifopt/netex_ifopt_pointOfInterest_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_part_1/part1_ifopt/netex_ifopt_localService_support.xsd"/>
@@ -26,7 +26,7 @@
 	<xsd:include schemaLocation="netex_salesDistribution_support.xsd"/>
 	<xsd:include schemaLocation="netex_salesOfferPackageEntitlement_support.xsd"/>
 	<xsd:include schemaLocation="netex_salesOfferPackage_support.xsd"/>
-	<xsd:include schemaLocation="../part3_salesTransactions/netex_mediumApplication_support.xsd"/>	
+	<xsd:include schemaLocation="../part3_salesTransactions/netex_mediumApplication_support.xsd"/>
 	<xsd:include schemaLocation="netex_typeOfTravelDocument_support.xsd"/>
 	<!-- ====New Modes ========================================================= -->
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_nm_fleetEquipment_support.xsd"/>
@@ -357,7 +357,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="ValidityConditionRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ==== SCOPING VALIDITY PARAMETER ASSIGNMENT=================================================== -->	
+	<!-- ==== SCOPING VALIDITY PARAMETER ASSIGNMENT=================================================== -->
 	<xsd:complexType name="validityParameters_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>One to many Relationship for scoping validity parameters.</xsd:documentation>
@@ -459,7 +459,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element ref="GroupOfSitesRef" minOccurs="0"/>
 			<xsd:element ref="SiteElementRef" minOccurs="0"/>
-			<xsd:element ref="LevelRef" minOccurs="0"/>			
+			<xsd:element ref="LevelRef" minOccurs="0"/>
 			<xsd:element ref="PointOfInterestClassificationRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
@@ -591,7 +591,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="LocatableSpotRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfLocatableSpotRef" minOccurs="0"/>
 		</xsd:sequence>
-	</xsd:group>	
+	</xsd:group>
 	<xsd:group name="ClassOfUseValidityParametersGroup">
 		<xsd:annotation>
 			<xsd:documentation>CLASS OF USE validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
@@ -632,7 +632,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfFareStructureElementRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfTariffRef" minOccurs="0"/>
-			<xsd:element ref="TariffRef" minOccurs="0"/>			
+			<xsd:element ref="TariffRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="ProductValidityParametersGroup">
@@ -646,7 +646,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfFareProductRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfUsageParameterRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfConcessionRef" minOccurs="0"/>
-			<xsd:element ref="TypeOfProofRef" minOccurs="0"/>			
+			<xsd:element ref="TypeOfProofRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="SalesOfferValidityParametersGroup">
@@ -657,7 +657,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfSalesOfferPackageRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfTravelDocumentRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfMachineReadabilityRef" minOccurs="0"/>
-			<xsd:element ref="TypeOfMediumAccessDeviceRef" minOccurs="0"/>			
+			<xsd:element ref="TypeOfMediumAccessDeviceRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="DistributionParametersGroup">

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2.2" id="netex_accessRightParameter_version">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_accessRightParameter_version">
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_serviceCalendar_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_vehicleSeating_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_trainElement_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_topographicPlace_support.xsd"/>
+	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd"/>
+	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd"/>	
 	<!-- ====Network ========================================================= -->
 	<xsd:include schemaLocation="../../netex_part_1/part1_ifopt/netex_ifopt_pointOfInterest_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_part_1/part1_networkDescription/netex_line_support.xsd"/>
@@ -22,6 +24,7 @@
 	<xsd:include schemaLocation="netex_salesDistribution_support.xsd"/>
 	<xsd:include schemaLocation="netex_salesOfferPackageEntitlement_support.xsd"/>
 	<xsd:include schemaLocation="netex_salesOfferPackage_support.xsd"/>
+	<xsd:include schemaLocation="../part3_salesTransactions/netex_mediumApplication_support.xsd"/>	
 	<xsd:include schemaLocation="netex_typeOfTravelDocument_support.xsd"/>
 	<!-- ====New Modes ========================================================= -->
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_nm_fleetEquipment_support.xsd"/>
@@ -121,7 +124,7 @@
 					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
 				</Relation>
 				<Rights>Unclassified
-					 <Copyright>CEN, Crown Copyright 2009-2021</Copyright>
+					 <Copyright>CEN, Crown Copyright 2009-2023</Copyright>
 				</Rights>
 				<Source>
 					<ul>
@@ -325,7 +328,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ====VALIDITY PARAMETER ASSIGNMENT=================================================== -->
+	<!-- ==== TEMPORAL VALIDITY PARAMETER ASSIGNMENT================================== -->
 	<xsd:complexType name="temporalValidityParameters_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>One to many Relationship for temporal validity parameters.</xsd:documentation>
@@ -343,15 +346,17 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Temporal validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
+			<!-- <xsd:element ref="ServiceCalendarRef" minOccurs="0"/> 		was in the commit, but caused problems! NK pls check -->
 			<xsd:element ref="DayTypeRef" minOccurs="0"/>
-			<xsd:element ref="TimebandRef" minOccurs="0"/>
 			<xsd:element ref="GroupOfTimebandsRef" minOccurs="0"/>
+			<!-- <xsd:element ref="TimebandRef" minOccurs="0"/>			was in the commit, but caused problems! NK pls check -->
 			<xsd:element ref="OperatingDayRef" minOccurs="0"/>
 			<xsd:element ref="OperatingPeriodRef" minOccurs="0"/>
 			<xsd:element ref="ServiceCalendarRef" minOccurs="0"/>
 			<xsd:element ref="ValidityConditionRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
+	<!-- ==== SCOPING VALIDITY PARAMETER ASSIGNMENT=================================================== -->	
 	<xsd:complexType name="validityParameters_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>One to many Relationship for scoping validity parameters.</xsd:documentation>
@@ -376,7 +381,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Network validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
-			<xsd:group ref="RouteValidityParametersGroup">
+			<xsd:group ref="RoutingValidityParametersGroup">
 				<xsd:annotation>
 					<xsd:documentation>Route validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
 				</xsd:annotation>
@@ -451,7 +456,9 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>SITE validity parametersfor ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
+			<!-- <xsd:element ref="GroupOfSitesRef"/> -->		
 			<xsd:element ref="SiteElementRef" minOccurs="0"/>
+			<xsd:element ref="LevelRef" minOccurs="0"/>			
 			<xsd:element ref="PointOfInterestClassificationRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
@@ -479,7 +486,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="VehicleMeetingPlaceRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:group name="RouteValidityParametersGroup">
+	<xsd:group name="RoutingValidityParametersGroup">
 		<xsd:annotation>
 			<xsd:documentation>ROUTE validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -561,15 +568,29 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="SeatingValidityParametersGroup">
 		<xsd:annotation>
-			<xsd:documentation>Seating validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
+			<xsd:documentation>Seating validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.  NB PAssengerSeatRef is DEPRECATED </xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="TrainElementRef" minOccurs="0"/>
 			<xsd:element ref="TrainComponentLabelAssignmentRef" minOccurs="0"/>
+			<xsd:element ref="DeckPlanRef" minOccurs="0"/>
+			<xsd:element ref="DeckSpaceRef" minOccurs="0"/>
+			<xsd:group ref="SpotValidityParametersGroup"/>
 			<xsd:element ref="PassengerSeatRef" minOccurs="0"/>
 			<xsd:element ref="VehicleRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
+	<xsd:group name="SpotValidityParametersGroup">
+		<xsd:annotation>
+			<xsd:documentation>Seating validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.  NB PAssengerSeatRef is DEPRECATED </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="SpotColumnRef" minOccurs="0"/>
+			<xsd:element ref="SpotRowRef" minOccurs="0"/>
+			<xsd:element ref="LocatableSpotRef" minOccurs="0"/>
+			<xsd:element ref="TypeOfLocatableSpotRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>	
 	<xsd:group name="ClassOfUseValidityParametersGroup">
 		<xsd:annotation>
 			<xsd:documentation>CLASS OF USE validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
@@ -610,6 +631,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfFareStructureElementRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfTariffRef" minOccurs="0"/>
+			<xsd:element ref="TariffRef" minOccurs="0"/>			
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="ProductValidityParametersGroup">
@@ -623,6 +645,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfFareProductRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfUsageParameterRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfConcessionRef" minOccurs="0"/>
+			<xsd:element ref="TypeOfProofRef" minOccurs="0"/>			
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="SalesOfferValidityParametersGroup">
@@ -633,6 +656,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfSalesOfferPackageRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfTravelDocumentRef" minOccurs="0"/>
 			<xsd:element ref="TypeOfMachineReadabilityRef" minOccurs="0"/>
+			<xsd:element ref="TypeOfMediumAccessDeviceRef" minOccurs="0"/>			
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="DistributionParametersGroup">


### PR DESCRIPTION
redo of #571  #574  and #575 

Pay attention there is something that is not working. I had to comment two lines out from #574. 
![image](https://github.com/NeTEx-CEN/NeTEx/assets/24227470/6665be3d-d6ff-4f6a-ad62-10bcb5fa4968)
in xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd

A deep check by @Aurige  and @nick-knowles  is necessary

I did not recheck  #415  , #414, #413 and #412 but just closed them.

575 contained 
fa43f0f
0eddb08
29ee965
532c9b

574 contained 
"4247f2b
3b2cac2"
0eddb08
29ee965
532c9b

571 contained
0eddb08
29ee965
532c9be




























































