### PR TITLE
changing QuayTaype for "on street"

### DIFF
--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
@@ -405,14 +405,24 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="multimodal"/>
 			<xsd:enumeration value="busOnStreetBoarding">
 				<xsd:annotation>
-					<xsd:documentation>Bus stop directly on street. This means people waiting to board will literally be standing on the street.</xsd:documentation>
+					<xsd:documentation>Depreciated in favor of busStopWithinRoadwayBoarding.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
+			<xsd:enumeration value="busStopWithinRoadwayBoarding">
+				<xsd:annotation>
+					<xsd:documentation>Bus stop directly on street. This means people waiting to board will literally be standing on the street. The usual elements of a stop (pole, bank, information) usually are present at the road side. Often there are marking on the floor and sometimes also traffic lights stopping the traffic for boarding and alighting.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>			
 			<xsd:enumeration value="tramOnStreetBoarding">
 				<xsd:annotation>
-					<xsd:documentation>Tram stop directly on street. This means people waiting to board will literally be standing on the street.</xsd:documentation>
+					<xsd:documentation>Depreciated in favor of tramStopWithinRoadwayBoarding.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
+			<xsd:enumeration value="tramStopWithinRoadwayBoarding">
+				<xsd:annotation>
+					<xsd:documentation>Tram stop directly on street. This means people waiting to board will literally be standing on the street. The usual elements of a stop (pole, bank, information) usually are present at the road side. Often there are marking on the floor and sometimes also traffic lights stopping the traffic for boarding and alighting.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>			
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>


### PR DESCRIPTION
Comment from Nick:
Thanks for the image
Apologies but I am not in the EPIAP group so I have missed prior discussion - but my naive interpretation from the name having not seen the the discussion (which would be typical for others and new users) I think shows there is a problem.
So it is not "busOnStreetBoarding" boarding - as all busStops are "On street" by definition - but "busStopWithInRoadwayBoarding" ... so at the very least the name is highly misleading in that it fails to make the pertinent distinction from a normal bus stop which is also on a street - and so and will probably be wrongly used by naive users for their normal regular "pavement boarding " stops.
Are such bus stops also marked by a pole or other indicator at the side? How do passengers know the bus or tram will stop in the vicinity? If that is the case then the in road boarding aspect sounds much more like the Transmodel / NeTex model concept of a QUAY + BOARDING POSITION, attached to a STOP PLACE (rather than being a property of theSTOP PLACE itself) , and what you are describing is an additional classification of either the QUAY type (QuayType = BusStopInRoad ?) or BOARDING POSITION ( BoardingPositionType = positionInRoadwayAtBusStop ?_ ) . . Remember, for buses one typically has a single STOP PLACE representing both directions e.g. "Town Hall", with two separate QUAYs e.g. "Eastbound Town Hall" and "Westbound TownHall", representing the QUAYs ( ie poles / bus shelters) either side of the street , and if needed, one or more BOARDING POSITIONs indicating the locations for the passenger to stand to board the bus.
See the existing classifications
[image.png (view on web)](https://eur01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FNeTEx-CEN%2FNeTEx%2Fassets%2F1826507%2F1917265a-35dc-47aa-a263-bf927e9aec58&data=05%7C02%7Cmatthias.guenter%40sbb.ch%7Ccf8a1227f55f4115342108dc0341399d%7C2cda5d11f0ac46b3967daf1b2e1bd01a%7C0%7C0%7C638388825873901972%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=jKC1O91wTt0Sb2ZPdGON8lsfZq4%2ByorFdwoKRd7qWXc%3D&reserved=0)
By introducing a separate stop type for certain specific combinations of QUAY and BOARDING POSITION type you are arguably hacking the system - and if one starts mixing up what are meant to be orthogonal concepts you soon have a combinatorial explosion and spaghetti.
Anyway, to resolve this at the very least there need to be better comments in the XML for the enums to explain the difference between on street and on street boarding. Personally I would prefer one either renamed the stop concept to something like inRoadway boarding, or better still made it a classification of either the QUAY the BOARDING POSITION rather than the STOP PLACE, This would allow you to specify precise coordinates for the points to stand either side in the road according to direction to enter the vehicle - which presumably still applies to in street boarding
It may also be useful to stand back and ask the so what why do you want to distinguish such stops - presumably the use case is to flag stops that are not suitable for disabled access. Doesn't an accessibility assessment do this more clearly?


Clarification from my side:
* We are talking QUAY TYPE. So that is correct.
* I updated the definitions
* I depreciated the values.