### PR TITLE
Remove unusual places for JourneyPatternViews

### DIFF
--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPattern_version.xsd
@@ -84,10 +84,9 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element ref="JourneyPattern_"/>
-					<xsd:element ref="JourneyPatternView"/>
-				</xsd:choice>
+				<xsd:sequence>
+					<xsd:element ref="JourneyPattern_" maxOccurs="unbounded"/>
+				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
@@ -164,10 +164,9 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element ref="ServicePattern"/>
-					<xsd:element ref="JourneyPatternView"/>
-				</xsd:choice>
+				<xsd:sequence>
+					<xsd:element ref="ServicePattern" maxOccurs="unbounded"/>
+				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>


### PR DESCRIPTION
I cannot think of any argument why one would like to have a JourneyPattern**View** inside `journeyPatternsInFrame`. Over either an explicit JourneyPattern, which follows the same content.
```
<journeyPatterns>
  <JourneyPatternView>
  </JourneyPatternView>
</journeyPatterns>
```

Neither I do understand why a JourneyPattern**View** should be part of `servicePatternsInFrame`.

Proposed to remove in master, since no (poor) example exists for this practise.