### PR TITLE
Site Entrance qualifier

### DIFF
--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_support.xsd
@@ -336,6 +336,28 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>
+	<xsd:simpleType name="EntrancePurposeEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for entrance purpose.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="main"/>
+			<xsd:enumeration value="side"/>
+			<xsd:enumeration value="back"/>
+			<xsd:enumeration value="secondary">
+				<xsd:annotation>
+					<xsd:documentation>Indirect access, e.g., via a shop or restaurant.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="withinStopPlace">
+				<xsd:annotation>
+					<xsd:documentation>An ENTRANCE for which IsExternal is false.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="emergencyOnly"/>
+			<xsd:enumeration value="other"/>
+		</xsd:restriction>
+	</xsd:simpleType>
 	<xsd:simpleType name="AccessSpaceTypeEnumeration">
 		<xsd:annotation>
 			<xsd:documentation>Allowed values for ACCESS SPACE TYPEs.</xsd:documentation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
@@ -387,7 +387,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="EntranceType" type="EntranceEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Classification of ENTRANCE. Use EQUIPMENT element to describe in further detail.</xsd:documentation>
+					<xsd:documentation>Classification of ENTRANCE. Use EntrancePurpose and EQUIPMENT elements to describe in further detail.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="EntrancePurpose" type="EntrancePurposeEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Classification of ENTRANCE regarding its purpose (e.g., main entrance, side entrance, etc.).</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="IsExternal" type="xsd:boolean" default="true" minOccurs="0">


### PR DESCRIPTION
Intended to resolve issue #556.

Note that entrances can only be qualified as emergency exits if they are normally closed. If emergency routes needed to be described, a different mechanism would be required. 

