### PR TITLE
LiftCallEquipment

### DIFF
--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -2155,6 +2155,27 @@ Correct COnstraints for PointOnRoute
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====LiftCallEquipment============================== -->
+		<!-- =====LiftCallEquipment unique========================== -->
+		<xsd:unique name="LiftCallEquipment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [LiftCallEquipment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:LiftCallEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====LiftCallEquipment Key ========================== -->
+		<xsd:keyref name="LiftCallEquipment_AnyKeyRef" refer="netex:LiftCallEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:LiftCallEquipmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="LiftCallEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:LiftCallEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
 		<!-- =====StaircaseEquipment============================== -->
 		<!-- =====StaircaseEquipment unique========================== -->
 		<xsd:unique name="StaircaseEquipment_UniqueBy_Id_Version">

--- a/xsd/NeTEx_publication_timetable.xsd
+++ b/xsd/NeTEx_publication_timetable.xsd
@@ -1683,7 +1683,7 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="Equipment_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:Equipment | .//netex:PlaceEquipment | .//netex:InstalledEquipment | .//netex:ActualVehicleEquipment | .//netex:TicketValidatorEquipment | .//netex:TicketingEquipment   | .//netex:SanitaryEquipment  | .//netex:PassengerSafetyEquipment | .//netex:RubbishDisposalEquipment    |.//netex:PassengerInformationEquipment   | .//netex:EntranceEquipment  | .//netex:LiftEquipment |  .//netex:EscalatorEquipment | .//netex:TravelatorEquipment | .//netex:StaircaseEquipment | .//netex:RampEquipment  | .//netex:RoughSurface  | .//netex:PlaceLighting|  .//netex:PlaceSign |  .//netex:PlaceSign | .//netex:HeadingSign  | .//netex:GeneralSign   |.//netex:WaitingRoomEquipment   | .//netex:ShelterEquipment  | .//netex:SeatingEquipment | .//netex:TrolleyStandEquipment      | .//netex:LuggageLockerEquipment  |  .//netex:CycleParkingEquipment    |.//netex:AccessVehicleEquipment    |.//netex:WheelchairVehicleEquipment"/>
+			<xsd:selector xpath=".//netex:Equipment | .//netex:PlaceEquipment | .//netex:InstalledEquipment | .//netex:ActualVehicleEquipment | .//netex:TicketValidatorEquipment | .//netex:TicketingEquipment   | .//netex:SanitaryEquipment  | .//netex:PassengerSafetyEquipment | .//netex:RubbishDisposalEquipment    |.//netex:PassengerInformationEquipment   | .//netex:EntranceEquipment  | .//netex:LiftEquipment | .//netex:LiftCallEquipment |  .//netex:EscalatorEquipment | .//netex:TravelatorEquipment | .//netex:StaircaseEquipment | .//netex:RampEquipment  | .//netex:RoughSurface  | .//netex:PlaceLighting|  .//netex:PlaceSign |  .//netex:PlaceSign | .//netex:HeadingSign  | .//netex:GeneralSign   |.//netex:WaitingRoomEquipment   | .//netex:ShelterEquipment  | .//netex:SeatingEquipment | .//netex:TrolleyStandEquipment      | .//netex:LuggageLockerEquipment  |  .//netex:CycleParkingEquipment    |.//netex:AccessVehicleEquipment    |.//netex:WheelchairVehicleEquipment"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
@@ -1778,7 +1778,7 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="AccessEquipment_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:EntranceEquipment | .//netex:LiftEquipment | .//netex:RampEquipment |.//netex:StaircaseEquipment   | .//netex:EscalatorEquipment  |  .//netex:TravelatorEquipment  | .//netex:RoughSurface | .//netex:PlaceLighting"/>
+			<xsd:selector xpath=".//netex:EntranceEquipment | .//netex:LiftEquipment | .//netex:LiftCallEquipment | .//netex:RampEquipment |.//netex:StaircaseEquipment   | .//netex:EscalatorEquipment  |  .//netex:TravelatorEquipment  | .//netex:RoughSurface | .//netex:PlaceLighting"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
@@ -1821,6 +1821,27 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 		</xsd:keyref>
 		<xsd:key name="LiftEquipment_AnyVersionedKey">
 			<xsd:selector xpath=".//netex:LiftEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
+		<!-- =====LiftCallEquipment============================== -->
+		<!-- =====LiftCallEquipment unique========================== -->
+		<xsd:unique name="LiftCallEquipment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [LiftCallEquipment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:LiftCallEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====LiftCallEquipment Key ========================== -->
+		<xsd:keyref name="LiftCallEquipment_AnyKeyRef" refer="netex:LiftCallEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:LiftCallEquipmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="LiftCallEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:LiftCallEquipment"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_support.xsd
@@ -187,7 +187,33 @@ Rail transport, Roads and Road transport
 			<xsd:restriction base="AccessEquipmentRefStructure">
 				<xsd:attribute name="ref" type="LiftEquipmentIdType" use="required">
 					<xsd:annotation>
-						<xsd:documentation>Identifier of a TICKETING EQUIPMENT.</xsd:documentation>
+						<xsd:documentation>Identifier of a LIFT EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="LiftCallEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a LIFT call EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="AccessEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="LiftCallEquipmentRef" type="AccessEquipmentRefStructure" substitutionGroup="AccessEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of an LIFT call EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="LiftCallEquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an LIFT call EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="AccessEquipmentRefStructure">
+				<xsd:attribute name="ref" type="LiftCallEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a LIFT call EQUIPMENT.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:restriction>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -1015,7 +1015,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="GroundMarkAlignedWithButton" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Indicates a tactile marker on floor under the buttons (or aligned with) +v1.1 .</xsd:documentation>
+					<xsd:documentation>Indicates a tactile marker on floor under the buttons (or aligned with). +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="AudioAnnouncements" type="xsd:boolean" minOccurs="0">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -99,6 +99,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="EntranceEquipment"/>
 			<xsd:element ref="StaircaseEquipment"/>
 			<xsd:element ref="LiftEquipment"/>
+			<xsd:element ref="LiftCallEquipment"/>
 			<xsd:element ref="EscalatorEquipment"/>
 			<xsd:element ref="TravelatorEquipment"/>
 			<xsd:element ref="RampEquipment"/>
@@ -116,6 +117,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="EntranceEquipment" minOccurs="0"/>
 			<xsd:element ref="EscalatorEquipment" minOccurs="0"/>
 			<xsd:element ref="LiftEquipment" minOccurs="0"/>
+			<xsd:element ref="LiftCallEquipment" minOccurs="0"/>
 			<xsd:element ref="PlaceLighting" minOccurs="0"/>
 			<xsd:element ref="QueueingEquipment" minOccurs="0"/>
 			<xsd:element ref="RampEquipment" minOccurs="0"/>
@@ -942,9 +944,93 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Indicates buttons height (in centimeter)</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="GroundMarkalignedWithButton" type="xsd:boolean" minOccurs="0">
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:element name="LiftCallEquipment" substitutionGroup="AccessEquipment">
+		<xsd:annotation>
+			<xsd:documentation>Specialisation of PLACE ACCESS EQUIPMENT for calling LIFTs (provides specific characteristics that may differ from floor to floor like button height, door, etc.).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="LiftCallEquipment_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EquipmentGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AccessEquipmentGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for an ACCESS EQUIPMENT.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LiftCallEquipmentGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for calling a LIFT that are specific to a floor /.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="LiftCallEquipmentIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="LiftCallEquipment_VersionStructure" abstract="false">
+		<xsd:complexContent>
+			<xsd:extension base="AccessEquipment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="LiftCallEquipmentGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="LiftCallEquipmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for LIFT call EQUIPMENT type.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="CallButtonHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Indicates a tactile marker on floor under the buttons (or aligned with).</xsd:documentation>
+					<xsd:documentation>Height of call button from ground.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="RaisedButtons" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether buttons are raised.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="BrailleButtons" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether buttons have braille.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="GroundMarkAlignedWithButton" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a tactile marker on floor under the buttons (or aligned with) +v1.1 .</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="AudioAnnouncements" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether LIFT has AudioAnnouncements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="MagneticInductionLoop" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Indicates existence of a magnetic induction loop. +v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="DoorOrientation" type="CompassBearing8Enumeration" minOccurs="0" maxOccurs="2">
+				<xsd:annotation>
+					<xsd:documentation>The direction from which to approach the door(s).</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -974,7 +974,7 @@ Rail transport, Roads and Road transport
 						<xsd:sequence>
 							<xsd:group ref="LiftCallEquipmentGroup">
 								<xsd:annotation>
-									<xsd:documentation>Elements for calling a LIFT that are specific to a floor /.</xsd:documentation>
+									<xsd:documentation>Elements for calling a LIFT that are specific to a floor.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:group>
 						</xsd:sequence>


### PR DESCRIPTION
Proposal for issue #535. Added a `LiftCallEquipment` as proposed by @nick-knowles and included a `DoorOrientation` based on the compass octagon idea from @Joostb61 - this is an alternative to the `OtherDoorsEnumeration` from #555. 

I did not include VisualIndicator (intended by Nick for the hearing impaired, I guess) because it isn't clear (to me at least) what needs to be indicated (current floor, arrival of cabin, call acknowledge, visibility of cabin) and the default case of a visibly opening door seems sufficient to me. 

I removed `GroundMarkalignedWithButton` in LiftEquipment since we already have `GroundMarkAlignedWithButton`.