### PR TITLE
`TactileWriting` attribute for all handrails

### DIFF
--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -833,6 +833,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Height of lower handrail from floor.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="TactileWriting" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the presence of signage that can be read tactilely (in Braille for example) on the handrail.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="LiftDimensionsGroup">
@@ -1168,6 +1173,11 @@ Rail transport, Roads and Road transport
 			<xsd:element name="LowerHandrailHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Height of any additional lower handrail.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="TactileWriting" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the presence of signage that can be read tactilely (in Braille for example) on the handrail.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="TactileGuidanceStrips" type="xsd:boolean" minOccurs="0">


### PR DESCRIPTION
Hey everyone! #555 introduced a `TactileWriting` attribute to `StairGroup`, indicating if the handrail includes a tactile sign. IMO it makes sense to also include that attribute for other equipments which have a handrail, specifically `Ramp` and `Lift`.

Maybe it would make sense to move all handrail-specific attributes to a separate group, to make sure that they are always in sync. But that's probably out of scope for this small MR 😄.