### PR TITLE
Add properties to describe the height of a Lift

### DIFF
--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -156,6 +156,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Width of EQUIPMENT or entrance to EQUIPMENT (e.g. Lift).</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="Height" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Height of EQUIPMENT or entrance to EQUIPMENT (e.g. Lift).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="DirectionOfUse" type="DirectionOfUseEnumeration" default="both" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Direction in which EQUIPMENT. can be used. Default is both.</xsd:documentation>
@@ -831,6 +836,11 @@ Rail transport, Roads and Road transport
 			<xsd:element name="InternalWidth" type="LengthType" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Internal width of lift.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="InternalHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Internal height of lift.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>


### PR DESCRIPTION
Hey everyone! At Deutsche Bahn, we (sometimes) have records on the height of our elevator cabins and doors, and figured it would be nice to include that data in our new NeTEx datasets (which we are currently working on).

I therefore created this PR, which simply clones the `Width` attributes used to describe a lift equipment's cabin and door width. If you'd prefer another approach or different names, I'll update the PR as needed 🙂