### PR TITLE
TAP TSI Example validation

### DIFF
--- a/examples/standards/tap_tsi/B1_NRT/Netex_tap_tsi_B1-1080.xml
+++ b/examples/standards/tap_tsi/B1_NRT/Netex_tap_tsi_B1-1080.xml
@@ -59108,7 +59108,8 @@ This example provides an example of encodeing TAP TSI  NRT  fares in NeTEx XML
 								</ValidBetween>
 							</validityConditions>
 							<Name lang="de">Online Ticket nicht gueltig</Name>
-							<TypeOfNoticeRef version="any" ref="M"/> <!--All ref="TCVM" replaced by ref="M" since ther is no TypeOfNotice with if="TCVM" - v2.0-->
+							<TypeOfNoticeRef version="any" ref="M"/>
+							<!--All ref="TCVM" replaced by ref="M" since ther is no TypeOfNotice with if="TCVM" - v2.0-->
 							<variants>
 								<DeliveryVariant order="1">
 									<VariantText lang="fr">billets online pas valide </VariantText>

--- a/examples/standards/tap_tsi/B1_NRT/Netex_tap_tsi_B1-1080.xml
+++ b/examples/standards/tap_tsi/B1_NRT/Netex_tap_tsi_B1-1080.xml
@@ -59108,7 +59108,7 @@ This example provides an example of encodeing TAP TSI  NRT  fares in NeTEx XML
 								</ValidBetween>
 							</validityConditions>
 							<Name lang="de">Online Ticket nicht gueltig</Name>
-							<TypeOfNoticeRef version="any" ref="TCVM"/>
+							<TypeOfNoticeRef version="any" ref="M"/> <!--All ref="TCVM" replaced by ref="M" since ther is no TypeOfNotice with if="TCVM" - v2.0-->
 							<variants>
 								<DeliveryVariant order="1">
 									<VariantText lang="fr">billets online pas valide </VariantText>
@@ -59129,7 +59129,7 @@ This example provides an example of encodeing TAP TSI  NRT  fares in NeTEx XML
 								</ValidBetween>
 							</validityConditions>
 							<Name lang="de">Für die Busstrecke Nürnberg - Praha gelten die gesetzlichen Vorschriften der jeweiligen Länder für die Personen- beförderung auf der Straße.</Name>
-							<TypeOfNoticeRef version="any" ref="TCVM"/>
+							<TypeOfNoticeRef version="any" ref="M"/>
 							<variants>
 								<DeliveryVariant order="1">
 									<VariantText lang="fr">Pour les lignes de bus Nürnberg - Praha, les dispositions légales de chaque pays pour le transport de voyageurs sur la route s'appliquent. </VariantText>
@@ -59150,7 +59150,7 @@ This example provides an example of encodeing TAP TSI  NRT  fares in NeTEx XML
 								</ValidBetween>
 							</validityConditions>
 							<Name lang="de">Kinder von 6 bis inklusive 11 Jahren Die Mitnahme von Reisegepäck ist nicht möglich. RAILPLUS nicht zugelassen</Name>
-							<TypeOfNoticeRef version="any" ref="TCVM"/>
+							<TypeOfNoticeRef version="any" ref="M"/>
 							<variants>
 								<DeliveryVariant order="1">
 									<VariantText lang="fr">Les enfants âgés de 6 à 11 ans inclus L'emport de bagages n'est pas possible. RAILplus pas autorisé </VariantText>
@@ -59171,7 +59171,7 @@ This example provides an example of encodeing TAP TSI  NRT  fares in NeTEx XML
 								</ValidBetween>
 							</validityConditions>
 							<Name lang="de">Kinder von 4 bis inklusive 14 Jahren Reservierungspflicht Servicetelefon +49 461 864 602 verkehrt voraussichtlich von April bis Oktober</Name>
-							<TypeOfNoticeRef version="any" ref="TCVM"/>
+							<TypeOfNoticeRef version="any" ref="M"/>
 							<variants>
 								<DeliveryVariant order="1">
 									<VariantText lang="fr">Les enfants âgés de 4 à 14 ans inclus Réservation obligatoire téléphone de service  +49 461 864 602 ne circule qu'à partir d'avril jusqu'au octobre </VariantText>
@@ -59192,7 +59192,7 @@ This example provides an example of encodeing TAP TSI  NRT  fares in NeTEx XML
 								</ValidBetween>
 							</validityConditions>
 							<Name lang="de">Kinder von 4 bis inklusive 14 Jahren RAILPLUS nicht zugelassen</Name>
-							<TypeOfNoticeRef version="any" ref="TCVM"/>
+							<TypeOfNoticeRef version="any" ref="M"/>
 							<variants>
 								<DeliveryVariant order="1">
 									<VariantText lang="fr">Les enfants âgés de 4 à 14 ans inclusRAILplus pas autorisé </VariantText>
@@ -59213,7 +59213,7 @@ This example provides an example of encodeing TAP TSI  NRT  fares in NeTEx XML
 								</ValidBetween>
 							</validityConditions>
 							<Name lang="de">keine Kinderermäßigung RAILPLUS nicht zugelassen</Name>
-							<TypeOfNoticeRef version="any" ref="TCVM"/>
+							<TypeOfNoticeRef version="any" ref="M"/>
 							<variants>
 								<DeliveryVariant order="1">
 									<VariantText lang="fr">Pas de réduction pour les enfantsRAILplus pas autorisé </VariantText>

--- a/examples/standards/tap_tsi/B1_NRT/Netex_tap_tsi_B1.xml
+++ b/examples/standards/tap_tsi/B1_NRT/Netex_tap_tsi_B1.xml
@@ -303,7 +303,7 @@ V1.1 Extensively revised with improved ids and use of tarifffs.
 					<!--  === TARIFFS  ===  -->
 					<tariffs>
 						<Tariff id="tap:NRT_Standard" version="1.0">
-							<ValidBetween id="tap:Tariff01" version="1.0">
+							<ValidBetween id="tap:Tariff02" version="1.0"> <!--ID changed from id="tap:Tariff01" to id="tap:Tariff02" since it has to be unique - v2.0-->
 								<FromDate>2011-01-01T00:00:00Z</FromDate>
 								<ToDate>2014-01-01T00:00:00Z</ToDate>
 							</ValidBetween>

--- a/examples/standards/tap_tsi/B1_NRT/Netex_tap_tsi_B1.xml
+++ b/examples/standards/tap_tsi/B1_NRT/Netex_tap_tsi_B1.xml
@@ -303,7 +303,8 @@ V1.1 Extensively revised with improved ids and use of tarifffs.
 					<!--  === TARIFFS  ===  -->
 					<tariffs>
 						<Tariff id="tap:NRT_Standard" version="1.0">
-							<ValidBetween id="tap:Tariff02" version="1.0"> <!--ID changed from id="tap:Tariff01" to id="tap:Tariff02" since it has to be unique - v2.0-->
+							<ValidBetween id="tap:Tariff02" version="1.0">
+								<!--ID changed from id="tap:Tariff01" to id="tap:Tariff02" since it has to be unique - v2.0-->
 								<FromDate>2011-01-01T00:00:00Z</FromDate>
 								<ToDate>2014-01-01T00:00:00Z</ToDate>
 							</ValidBetween>

--- a/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
@@ -108,7 +108,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="lessor"/>
 			<xsd:enumeration value="dataRegistrar"/>
 			<xsd:enumeration value="other"/>
-<!--			DEPRECATED VALUES from v2.0 -->
+			<!--			DEPRECATED VALUES from v2.0 -->
 			<xsd:enumeration value="Planning"/>
 			<xsd:enumeration value="Operation"/>
 			<xsd:enumeration value="Control"/>

--- a/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
@@ -108,6 +108,22 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="lessor"/>
 			<xsd:enumeration value="dataRegistrar"/>
 			<xsd:enumeration value="other"/>
+<!--			DEPRECATED VALUES from v2.0 -->
+			<xsd:enumeration value="Planning"/>
+			<xsd:enumeration value="Operation"/>
+			<xsd:enumeration value="Control"/>
+			<xsd:enumeration value="Reservation"/>
+			<xsd:enumeration value="EntityLegalOwnership"/>
+			<xsd:enumeration value="FareManagement"/>
+			<xsd:enumeration value="Financing"/>
+			<xsd:enumeration value="SecurityManagement"/>
+			<xsd:enumeration value="CustomerService"/>
+			<xsd:enumeration value="DataRegistrar"/>
+			<xsd:enumeration value="Tenant"/>
+			<xsd:enumeration value="FacilityManagement"/>
+			<xsd:enumeration value="Lessor"/>
+			<xsd:enumeration value="DataRegistrar"/>
+			<xsd:enumeration value="Other"/>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="StakeholderRoleTypeListOfEnumerations">


### PR DESCRIPTION
There were some real errors in some examples that were not catched before (reused ID, bad references...), and also a missed deprecation on enumeration values. Correcting these seems to solve the TAP TSI example validation issues.

Should solve https://github.com/NeTEx-CEN/NeTEx/pull/743
