### PR TITLE
Labelling v2.0 changes, first series

### DIFF
--- a/xsd/netex_framework/netex_frames/netex_resourceFrame_version.xsd
+++ b/xsd/netex_framework/netex_frames/netex_resourceFrame_version.xsd
@@ -27,6 +27,8 @@
 				</Date>
 				<Date><Modified>2023-02-02</Modified>Add DECK PLAN CHANGES.
 				</Date>
+				<Date><Modified>2023-11-06</Modified>Add contracts to RESOURCE FRAME.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines RESOURCE FRAME types.</p>
 				</Description>
@@ -146,7 +148,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="contracts" type="contractsInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>CONTRACTs used in frame +v2.0</xsd:documentation>
+					<xsd:documentation>CONTRACTs used in frame. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_genericFramework/netex_grouping_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_grouping_version.xsd
@@ -23,6 +23,8 @@
 				</Date>
 				<Date><Modified>2017-10-01</Modified>CR0006 Add infolinks to  GroupOfEntities so can have links on timetable etc.
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines GROUPING types.</p>
 				</Description>
@@ -117,7 +119,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="infoLinks" minOccurs="0">

--- a/xsd/netex_framework/netex_genericFramework/netex_organisation_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_organisation_version.xsd
@@ -29,6 +29,12 @@
 					<Modified>2020-11-06 New Modes (Norway): Add related organisations.
 								Add external Contact details</Modified>
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
+				<Date><Modified>2023-11-21</Modified>CR0545 Organisation: add VATNumber.
+				</Date>
+				<Date><Modified>2024-06-26</Modified>CR0594 Deprecate ExternalOperatorRef.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines ORGANISATION types.</p>
 				</Description>
@@ -208,7 +214,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="CompanyNumber" type="xsd:normalizedString" minOccurs="0">
@@ -218,12 +224,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="VATNumber" type="xsd:normalizedString" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Company registered tax number including Country prefix.</xsd:documentation>
+					<xsd:documentation>Company registered tax number including Country prefix. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ExternalOperatorRef" type="ExternalObjectRefStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>An alternative  code that uniquely identifies the OPERATOR. Specifically for use in AVMS systems. For VDV compatibility. DEPRECATED - use PrivateCode -v2.0</xsd:documentation>
+					<xsd:documentation>An alternative  code that uniquely identifies the OPERATOR. Specifically for use in AVMS systems. For VDV compatibility. DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -401,7 +407,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ContactDetails" type="ContactStructure" minOccurs="0">

--- a/xsd/netex_framework/netex_genericFramework/netex_place_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_place_version.xsd
@@ -20,8 +20,9 @@
 					<Modified>2011-02-05</Modified>
 					<!-- Name Space changes -->
 				</Date>
-				<Date><Modified>2017-12-05</Modified>cd Fix error in  type for Place- should be Place_versionStructure
-
+				<Date><Modified>2017-12-05</Modified>cd Fix error in type for Place - should be Place_versionStructure.
+				</Date>
+				<Date><Modified>2023-11-21</Modified>CR0545 Transfer: add TransferMode.
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -161,7 +162,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="TransferMode" type="AccessModeEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>If a special transfer mode is needed. ACCESS MODE enumeration is also used for the TransferMode.</xsd:documentation>
+					<xsd:documentation>If a special transfer mode is needed. ACCESS MODE enumeration is also used for the TransferMode. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_genericFramework/netex_pointAndLinkSequence_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_pointAndLinkSequence_version.xsd
@@ -21,6 +21,8 @@
 				</Date>
 				<Date><Modified>2010-11-30</Modified> Add projections, revise for revised Section Mode
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines POINT AND LINK SEQUENCE types.</p>
 				</Description>
@@ -103,7 +105,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="projections" type="projections_RelStructure" minOccurs="0">

--- a/xsd/netex_framework/netex_responsibility/netex_responsibilitySet_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibilitySet_support.xsd
@@ -10,6 +10,8 @@
 				<Date>
 					<Created>2010-09-04</Created>
 				</Date>
+				<Date><Modified>2023-11-06</Modified>CR0530 Add ContractTypeEnum, LegalStatusEnum.
+				</Date>
 				<Date><Modified>2024-03-01</Modified>Split off from responsibilyu_support, add CONTRACT
 				</Date>
 				<Description>
@@ -111,7 +113,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:simpleType name="ContractTypeEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for TYPE OF CONTRACT.</xsd:documentation>
+			<xsd:documentation>Allowed values for TYPE OF CONTRACT. +v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="formal"/>
@@ -123,7 +125,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="LegalStatusEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for Legal Status of a CONTRACT.</xsd:documentation>
+			<xsd:documentation>Allowed values for Legal Status of a CONTRACT. +v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="binding"/>

--- a/xsd/netex_framework/netex_responsibility/netex_responsibilitySet_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibilitySet_version.xsd
@@ -26,6 +26,10 @@
 				<Date>
 					<Modified>2020-08-12 Issue 104 Add ResponsibilityRoles to RESOURCE FRAME</Modified>
 				</Date>
+				<Date><Modified>2023-11-06</Modified>CR0530 Add Contract, AssociatedContract in ResponsibilityRoleAssignment.
+				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines data administration base types.</p>
 				</Description>
@@ -158,7 +162,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="roles" type="responsibilityRoleAssignments_RelStructure" minOccurs="0">
@@ -302,7 +306,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Administrative area to which this RESPONSIBILITY SET is assigned.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="AssociatedContract" type="ContractRef_RelStructure" minOccurs="0"/>
+			<xsd:element name="AssociatedContract" type="ContractRef_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Associated CONTRACT. +v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:complexType name="responsibilityRoleAssignments_RelStructure">

--- a/xsd/netex_framework/netex_responsibility/netex_responsibility_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibility_version.xsd
@@ -23,6 +23,8 @@
 				<Date>
 					<Modified>2017-11-11 Fix allow version of dereived view id</Modified>
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Add privateCodes.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines RESPONSIBILITY types.</p>
 				</Description>
@@ -224,7 +226,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="privateCodes" type="PrivateCodesStructure">
 		<xsd:annotation>
-			<xsd:documentation>A list of private codes that uniquely identifiy the element. May be used for inter-operating with other (legacy) systems.</xsd:documentation>
+			<xsd:documentation>A list of private codes that uniquely identifiy the element. May be used for inter-operating with other (legacy) systems. +v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:unique name="PrivateCodeType">
 			<xsd:annotation>

--- a/xsd/netex_framework/netex_responsibility/netex_typeOfValue_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_typeOfValue_version.xsd
@@ -20,6 +20,8 @@
 				<Date>
 					<Modified>217-03-27   Change to use responsibility  1.1 with AlternativeText</Modified>
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines TYPE OF VALUE types.</p>
 				</Description>
@@ -145,7 +147,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_responsibility/netex_validityCondition_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_validityCondition_version.xsd
@@ -18,6 +18,8 @@
 				<Date>
 					<Modified>217-03-27   Change to use responsibility  1.1 with AlternativeText</Modified>
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines Time base types.</p>
 				</Description>
@@ -237,7 +239,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_dayType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_dayType_version.xsd
@@ -22,6 +22,8 @@
 				</Date>
 				<Date><Modified>2021-07-07</Modified>NewModesAdd TimeOfDayEnumeration with dawn, dusk 
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines DAY TYPE types </p>
 				</Description>
@@ -176,7 +178,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="DaySpanGroup">

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipment_version.xsd
@@ -22,6 +22,8 @@
 				</Date>
 				<Date><Modified>2019-04-05</Modified>Add back missing infolinks
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines EQUIPMENT base types.</p>
 				</Description>
@@ -127,7 +129,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="PublicCode" type="PublicCodeStructure" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_equipmentEnergy_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_equipmentEnergy_support.xsd
@@ -16,6 +16,8 @@
 				</Date>
 				<Date><Modified>2021-09-02</Modified>New Modes: Add Battery and TypeOfBatteryChemistry, PlugType, etc.
 				</Date>
+				<Date><Modified>2023-11-21</Modified>CR0545 CouplingTypeEnumeration: deprecated pantographAbove.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines ENERGY EQUIPMENT types for Place access.</p>
 				</Description>
@@ -216,7 +218,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="plug"/>
 			<xsd:enumeration value="pantographAbove">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED. Will be panthograph.</xsd:documentation>
+					<xsd:documentation>DEPRECATED. Will be panthograph. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="pantograph"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_notice_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_notice_version.xsd
@@ -18,6 +18,8 @@
 				<Date>
 					<Modified>2017-03-24  CR004 Add Short name</Modified>
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines common NOTICE identifier  types.</p>
 				</Description>
@@ -168,7 +170,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfNoticeRef" minOccurs="0"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_version.xsd
@@ -18,6 +18,8 @@
 				</Date>
 				<Date><Modified>2020-08-09</Modified>Issues #107 Fix UIcOperatingPeriod 
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines  SERVICE CALENDAR    types.</p>
 				</Description>
@@ -335,7 +337,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="DaySpanGroup"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_version.xsd
@@ -33,6 +33,8 @@
 				<Date><Modified>2020-11-27</Modified>NewModes: Drop  PublicTransportOperator,   alternativeTransportOperator.
 						  Revis TransportAdministrativeZone to apply to list of all mdo0es rather than just vehicle modes.
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines  NetEX:TRANSPORT  ORGANISATION    types.</p>
 				</Description>
@@ -504,7 +506,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="OrganisationPartRef" minOccurs="0"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -42,6 +42,10 @@
 				</Date>
 				<Date><Modified>2023-01-30</Modified>TM CR: Enhancement Add Accepted Driver Permit
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
+				<Date><Modified>2023-11-21</Modified>CR0545 Add AcceptedDriverPermit.
+				</Date>
 				<Date><Modified>2024-02-07</Modified>Fix - allow default DEck Plan or TRANSPORT TYPE, move VehiclesInFramegroup her
 				</Date>
 				<Description>
@@ -482,7 +486,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="acceptedDriverPermits" type="acceptedDriverPermits_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Required permit to operate the vehicle.</xsd:documentation>
+					<xsd:documentation>Required permit to operate the vehicle. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -502,7 +506,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:element name="AcceptedDriverPermit" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation>Accepted TYPE OF DRIVER PERMIT for a given SIMPLE VEHICLE TYPE. +V2.0</xsd:documentation>
+			<xsd:documentation>Accepted TYPE OF DRIVER PERMIT for a given SIMPLE VEHICLE TYPE. +v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -1144,7 +1148,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Private code of the vehicle.</xsd:documentation>
+					<xsd:documentation>Private code of the vehicle. DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
@@ -26,6 +26,8 @@
 				</Date>
 				<Date><Modified>2017-06-13</Modified>Issue #125 Add Multimodal to QuayType  enums
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines STOP PLACE base types.</p>
 				</Description>
@@ -326,7 +328,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element ref="PrivateCode">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="IdentifierType" type="xsd:normalizedString" minOccurs="0">

--- a/xsd/netex_part_1/part1_networkDescription/netex_activation_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_activation_version.xsd
@@ -20,6 +20,8 @@
 					<Modified>2011-02-05</Modified>
 					<!-- Name Space changes -->
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the ACTIVATION types.</p>
@@ -257,7 +259,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfActivationRef" minOccurs="0"/>

--- a/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
@@ -52,6 +52,8 @@
 				<Date>
 					<Modified>2020-10-05 New modes - add MODE of OPERATION to LINE.</Modified>
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Date>
 					<Modified>2023-12-14 #391 Fix linesInDirection to also allow Allowed line diretcion ref. Remove commented out code</Modified>
 				</Date>
@@ -370,7 +372,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ExternalLineRef" type="ExternalObjectRefStructure" minOccurs="0">
@@ -722,7 +724,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_passengerInformationEquipment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_passengerInformationEquipment_version.xsd
@@ -26,6 +26,8 @@
 				</Date>
 				<Date><Modified>2019-04-15</Modified>Add missing element from TypeofPassengerInformationEquipment
 				</Date>
+				<Date><Modified>2023-11-21</Modified>CR0545 PassengerInformationEquipment: added PassengerInformationEquipmentList.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines PASSENGER INFORMATION EQUIPMENT  types.</p>
 				</Description>
@@ -243,7 +245,7 @@ LOGICAL DISPLAY corresponds to a SIRI STOP MONITORING point.</xsd:documentation>
 			<xsd:element ref="SiteComponentRef" minOccurs="0"/>
 			<xsd:element name="PassengerInformationEquipmentList" type="PassengerInformationEquipmentListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>List of PASSENGER INFORMATION Equipments.</xsd:documentation>
+					<xsd:documentation>List of PASSENGER INFORMATION Equipments. +2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfPassengerInformationEquipmentRef" minOccurs="0"/>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
@@ -43,6 +43,8 @@
 				<Date><Modified>2019-03-01</Modified>Comment SBB20
 				     	Extension of ConnectionEnd (submode and transportOrganisation)
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Date><Modified>2023-12-18</Modified>FIX: revise the  #525 implementation of BOOKING ARRANGEMENT and SERVICE BOOKING ARRANGEMENT,
 				</Date>
 				<Description>
@@ -317,7 +319,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ExternalStopPointRef" type="ExternalObjectRefStructure" minOccurs="0">

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
@@ -25,6 +25,8 @@
 				</Date>
 				<Date><Modified>2017-06-03</Modified>CR0051 CD Allow reference to JOURNEY PATTERN on DYNAMIC STOP ASSIGNMENT.
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Date><Modified>2023-12-12</Modified>Add DECK ENTRANCE ASSIGNMENT
 				</Date>
 				<Date><Modified>2024-02-08</Modified>Add Directional attributes as per MS suggestions:  ArrivesForwards, DpeartsForwards  ArrivesFrom, Left DepartsToRight .  corrected name of passengerBoardingPositionAssignments
@@ -132,7 +134,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:choice minOccurs="0">

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_timeDemandType_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_timeDemandType_version.xsd
@@ -22,6 +22,8 @@
 					<Modified>2011-02-05</Modified>
 					<!-- Name Space changes -->
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the TIME DEMAND TYPE types.</p>
@@ -175,7 +177,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfTimeDemandTypeRef" minOccurs="0"/>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
@@ -27,6 +27,8 @@
 				</Date>
 				<Date><Modified>2019-04-12</Modified>NJSK Fix: Add missing FrompPointInPattern and ToPointInPattern  element that are in doc
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the INTERCHANGE. types.</p>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_journey_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_journey_version.xsd
@@ -32,6 +32,8 @@
 				<Date><Modified>2019-03-26</Modified>NL-27 CD #58 Add default  TypeOfProductCategory and TypeOfService to Line:
 					Move TypeOfProductCategory amnd TypeOfService from netex_journey_version  to  Framework reusable components netex_travelRights_version  so they are visible from part 1			 
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange JOURNEY types.</p>
 				</Description>

--- a/xsd/netex_part_2/part2_vehicleService/netex_vehicleService_version.xsd
+++ b/xsd/netex_part_2/part2_vehicleService/netex_vehicleService_version.xsd
@@ -25,6 +25,8 @@
 				</Date>
 				<Date><Modified>2017-012-05</Modified> Correct DayOffsetType  on Course of COurnet
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the VEHICLE SERVICE types.</p>
@@ -208,7 +210,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -779,7 +781,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="PreparationDuration" type="xsd:duration" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
@@ -40,6 +40,8 @@
 						Add  FarePrice AmountWithResultsGroup and refactor  FarePriceAmount groups to be clearer
 					   Also  revise PriceRuleStepResult:  add AdjustmentAmount, AdjustmentUnits .  RoundingRef, RoundingStepRef, and   NARRATIVE text element 
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the FARE PRICE   types.</p>
@@ -264,7 +266,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="StartDate" type="xsd:date" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
@@ -39,6 +39,8 @@
 					Add new atrribute   ProductType to     AmountOfPriceUnitFareProduct with values  tripCarnet, passCarnet, unitCoupons, other., 																					     </Date>
 				<Date><Modified>2020-12-12</Modified>NEWMdoes - allow any type of ORGANMISATION to own product 
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the FARE PRODUCT types.</p>
@@ -177,7 +179,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="InfoUrl" type="xsd:anyURI" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_fareSeries_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareSeries_version.xsd
@@ -18,6 +18,8 @@
 				</Date>
 				<Date><Modified>2011-02-05</Modified>Name Space changes 
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Date><Modified>2023-12-09</Modified>Add Zone in Series 
 				</Date>
 				<Date><Modified>2023-12-09</Modified>SeriesConstraint Issue #33: Fix unbounded error on SeriesCOnstraint/JourneyPatterns
@@ -184,7 +186,7 @@
 		<xsd:sequence>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="Itinerary" type="MultilingualString" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_fareStructureElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareStructureElement_version.xsd
@@ -27,6 +27,8 @@
 				</Date>
 				<Date><Modified>2020-10-12</Modified>NewModes add LocalService and MobilityService to Tariff applicability 
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the FARE STRUCTURE ELEMENT types.</p>
@@ -164,7 +166,7 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="TariffDescriptionGroup"/>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="TariffOrganisationGroup" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_fares/netex_fareStructure_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareStructure_version.xsd
@@ -21,6 +21,8 @@
 				</Date>
 				<Date><Modified>2019-03-11</Modified>UK-74 Add new TypeOfFareStructureFactor
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the FARE STRUCTURE types.</p>
@@ -188,7 +190,7 @@ Rail transport, Roads and Road transport
 						<xsd:sequence>
 							<xsd:element ref="PrivateCode" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+									<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>
@@ -221,7 +223,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_fares/netex_geographicStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_geographicStructureFactor_version.xsd
@@ -23,6 +23,8 @@
 				</Date>
 				<Date><Modified>2013-02-013</Modified>Fixe toadd TYPE OF FARE STRCUTURE  FACTOR and TYPE FO INTERVAL
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the GEOGRAPHCIAL STRUCTURE FACTOR types.</p>
@@ -293,7 +295,7 @@ Rail transport, Roads and Road transport
 						<xsd:sequence>
 							<xsd:element ref="PrivateCode" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+									<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_fares/netex_qualityStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_qualityStructureFactor_version.xsd
@@ -26,6 +26,8 @@
 				<Date><Modified>2019-03-11</Modified>EURA-72 Add arrivalTtime to TimeAtAstop and indicate into / out of / through constraint.. 
 					 Also Make Start Time at STop Optional
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the QUALIY STRUCTURE FACTOR types.</p>
@@ -119,7 +121,7 @@ Rail transport, Roads and Road transport
 						<xsd:sequence>
 							<xsd:element ref="PrivateCode" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+									<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>
@@ -266,7 +268,7 @@ Rail transport, Roads and Road transport
 						<xsd:sequence>
 							<xsd:element ref="PrivateCode" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+									<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>
@@ -357,7 +359,7 @@ Rail transport, Roads and Road transport
 						<xsd:sequence>
 							<xsd:element ref="PrivateCode" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+									<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
@@ -31,6 +31,8 @@
 				</Date>
 				<Date><Modified>2019-03-10</Modified>EURA-78 Allow more than one refernece a  GroupsOfSalesOfferPackageRef  from  SalesOfferPackage (ie make relationship many to many)
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the SALES OFFER PACKAGE types.</p>
@@ -212,7 +214,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="SalesOfferPackageCommonGroup"/>

--- a/xsd/netex_part_3/part3_fares/netex_timeStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_timeStructureFactor_version.xsd
@@ -21,6 +21,8 @@
 				</Date>
 				<Date><Modified>2011-03-12</Modified>NORWAY-105 Add MinimumDuration to TimeInterval.
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the TIME STRUCTURE FACTOR types.</p>
@@ -303,7 +305,7 @@ Rail transport, Roads and Road transport
 						<xsd:sequence>
 							<xsd:element ref="PrivateCode" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+									<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_parkingTariff/netex_parkingTariff_version.xsd
+++ b/xsd/netex_part_3/part3_parkingTariff/netex_parkingTariff_version.xsd
@@ -25,6 +25,8 @@
 				</Date>
 				<Date><Modified>2020-10-08</Modified>New Modes: Widen VehicleType to TransportType
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines PARKING TARIFF elements</p>
 				</Description>
@@ -235,7 +237,7 @@ Rail transport, Roads and Road transport
 						<xsd:sequence>
 							<xsd:element ref="PrivateCode" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+									<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -52,6 +52,8 @@
 				</Date>
 				<Date><Modified>2021-05-14</Modified>NewModes - Add TravellerInfo and DRiverPoolInfo to CUSTOMER PUCRHASE PACHAGE ASSIGNMENT
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Date><Modified>2023-12-15</Modified> Customer Purchase Package to hold Package History
 				</Date>
 				<Date><Modified>2023-12-18</Modified>Factor out Paymount amount to FARE DEBIT PACKAGE
@@ -534,7 +536,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="SalesOfferPackageRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_travelDocument_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_travelDocument_version.xsd
@@ -30,6 +30,8 @@
 				</Date>
 				<Date><Modified>2019-03-127</Modified>UK-57 Add new attribute  MarkedAs to TravelDocument
 				</Date>
+				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the fare TRAVEL DOCUMENT types.</p>
@@ -155,7 +157,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="PrivateCode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - use privateCodes</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfTravelDocumentRef" minOccurs="0"/>


### PR DESCRIPTION
This PR responds to issue #636 with a first series of *+v2.0* labels. Documentation already reflects the proposed changes. This first series should completely cover pages 1-255 in part 1 of the documentation. 

Please review my comment for *PrivateCode* in *VehicleCodeGroup*.