### PR TITLE
Labelling v2.0 changes, second series

### DIFF
--- a/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
@@ -114,9 +114,17 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="Reservation"/>
 			<xsd:enumeration value="EntityLegalOwnership"/>
 			<xsd:enumeration value="FareManagement"/>
-			<xsd:enumeration value="Financing"/>
+			<xsd:enumeration value="Financing">
+			<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="SecurityManagement"/>
-			<xsd:enumeration value="CustomerService"/>
+			<xsd:enumeration value="CustomerService">
+			<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="DataRegistrar"/>
 			<xsd:enumeration value="Tenant"/>
 			<xsd:enumeration value="FacilityManagement"/>
@@ -145,7 +153,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="distributes"/>
 			<xsd:enumeration value="secures"/>
 			<xsd:enumeration value="redistributes"/>
-			<xsd:enumeration value="supports"/>
+			<xsd:enumeration value="supports">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="owns"/>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>

--- a/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
@@ -115,13 +115,13 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="EntityLegalOwnership"/>
 			<xsd:enumeration value="FareManagement"/>
 			<xsd:enumeration value="Financing">
-			<xsd:annotation>
+				<xsd:annotation>
 					<xsd:documentation>+v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="SecurityManagement"/>
 			<xsd:enumeration value="CustomerService">
-			<xsd:annotation>
+				<xsd:annotation>
 					<xsd:documentation>+v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>

--- a/xsd/netex_framework/netex_responsibility/netex_validityCondition_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_validityCondition_support.xsd
@@ -121,17 +121,17 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="NAND">
 				<xsd:annotation>
-					<xsd:documentation>Successive elements are logically ANDed together; comparison must satisfy all specified values. The result is then negated.</xsd:documentation>
+					<xsd:documentation>Successive elements are logically ANDed together; comparison must satisfy all specified values. The result is then negated. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="NOR">
 				<xsd:annotation>
-					<xsd:documentation>Successive elements are logically ORed together; comparison must satisfy at least one specified value. The result is then negated.</xsd:documentation>
+					<xsd:documentation>Successive elements are logically ORed together; comparison must satisfy at least one specified value. The result is then negated. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="XNOR">
 				<xsd:annotation>
-					<xsd:documentation>Successive elements are logically ORed together; comparison must satisfy only one specified value. The result is then negated.</xsd:documentation>
+					<xsd:documentation>Successive elements are logically ORed together; comparison must satisfy only one specified value. The result is then negated. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 		</xsd:restriction>

--- a/xsd/netex_framework/netex_reusableComponents/netex_dayType_propertiesOfDay.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_dayType_propertiesOfDay.xsd
@@ -284,7 +284,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="TimeOfDayEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for TimeOfDay.</xsd:documentation>
+			<xsd:documentation>Allowed values for TimeOfDay. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="dawn"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_dayType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_dayType_version.xsd
@@ -292,7 +292,7 @@ Rail transport, Roads and Road transport
 				</xsd:element>
 				<xsd:element name="StartEvent" type="TimeOfDayEnumeration">
 					<xsd:annotation>
-						<xsd:documentation>Event marking start of timeband, e.,g  , dusk +V1.2.2 dawn</xsd:documentation>
+						<xsd:documentation>Event marking start of timeband, e.g., dusk, dawn. +v1.2.2</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
@@ -306,7 +306,7 @@ Rail transport, Roads and Road transport
 						</xsd:element>
 						<xsd:element name="EndEvent" type="TimeOfDayEnumeration" minOccurs="0">
 							<xsd:annotation>
-								<xsd:documentation>Event marking start of timeband, e.,g  dawn, dusk. +V1.2.2 dawn</xsd:documentation>
+								<xsd:documentation>Event marking end of timeband, e.g., dusk, dawn. +v1.2.2</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
 					</xsd:choice>

--- a/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
@@ -395,7 +395,11 @@ Rail transport, Roads and Road transport
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="female"/>
 			<xsd:enumeration value="male"/>
-			<xsd:enumeration value="unspecified"/>
+			<xsd:enumeration value="unspecified">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="HireFacilityEnumeration">
@@ -404,15 +408,31 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="unknown"/>
-			<xsd:enumeration value="scooterHire"/>
-			<xsd:enumeration value="vehicleHire"/>
+			<xsd:enumeration value="scooterHire">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="vehicleHire">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="carHire"/>
 			<xsd:enumeration value="motorCycleHire"/>
 			<xsd:enumeration value="cycleHire"/>
 			<xsd:enumeration value="taxi"/>
-			<xsd:enumeration value="boatHire"/>
+			<xsd:enumeration value="boatHire">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="recreationDeviceHire"/>
-			<xsd:enumeration value="other"/>
+			<xsd:enumeration value="other">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="LightingControlFacilityEnumeration">
@@ -440,8 +460,16 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="noBaggageStorage"/>
 			<xsd:enumeration value="baggageStorage"/>
 			<xsd:enumeration value="luggageRacks"/>
-			<xsd:enumeration value="skiRacks"/>
-			<xsd:enumeration value="skiRacksOnRear"/>
+			<xsd:enumeration value="skiRacks">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="skiRacksOnRear">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="extraLargeLuggageRacks"/>
 			<xsd:enumeration value="baggageVan"/>
 			<xsd:enumeration value="noCycles"/>
@@ -530,7 +558,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="noSmoking"/>
 			<xsd:enumeration value="familyArea"/>
 			<xsd:enumeration value="childfreeArea"/>
-			<xsd:enumeration value="animalsAllowed"/>
+			<xsd:enumeration value="animalsAllowed">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="noAnimals"/>
 			<xsd:enumeration value="breastfeedingFriendly"/>
 			<xsd:enumeration value="mobilePhoneUseZone"/>
@@ -557,17 +589,41 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="unknown"/>
-			<xsd:enumeration value="valetParking"/>
+			<xsd:enumeration value="valetParking">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="carWash"/>
-			<xsd:enumeration value="valetCarWash"/>
+			<xsd:enumeration value="valetCarWash">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="carValetClean"/>
 			<xsd:enumeration value="oilChange"/>
 			<xsd:enumeration value="engineWarming"/>
 			<xsd:enumeration value="petrol"/>
-			<xsd:enumeration value="batteryCare"/>
-			<xsd:enumeration value="recharging"/>
-			<xsd:enumeration value="tyreCheck"/>
-			<xsd:enumeration value="other"/>
+			<xsd:enumeration value="batteryCare">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="recharging">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="tyreCheck">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="other">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="MedicalFacilityEnumeration">

--- a/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_support.xsd
@@ -199,8 +199,16 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="other"/>
 			<xsd:enumeration value="phoneAtStop"/>
 			<xsd:enumeration value="text"/>
-			<xsd:enumeration value="mobileApp"/>
-			<xsd:enumeration value="atOffice"/>
+			<xsd:enumeration value="mobileApp">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="atOffice">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="none"/>
 		</xsd:restriction>
 	</xsd:simpleType>
@@ -621,16 +629,20 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Purchase and payment.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
-			<xsd:enumeration value="blockFullAmountOnCard"/>
+			<xsd:enumeration value="blockFullAmountOnCard">
+				<xsd:annotation>
+					<xsd:documentation>The full amount is blocked on card against customer’s credit limit but not charged.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="deposit">
 				<xsd:annotation>
-					<xsd:documentation>Purchase with deferred  payment.</xsd:documentation>
+					<xsd:documentation>Purchase with deferred payment.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="none"/>
 			<xsd:enumeration value="other">
 				<xsd:annotation>
-					<xsd:documentation>Reervation but not necessarily payment</xsd:documentation>
+					<xsd:documentation>Reservation but not necessarily payment.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 		</xsd:restriction>

--- a/xsd/netex_framework/netex_reusableComponents/netex_submode_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_submode_version.xsd
@@ -487,7 +487,7 @@ Local train adapted for running in mountain railway lines.</xsd:documentation>
 			<xsd:enumeration value="railTaxi"/>
 			<xsd:enumeration value="bikeTaxi">
 				<xsd:annotation>
-					<xsd:documentation>Bike taxi (other than cycleRickshaw, +v1.2.2). </xsd:documentation>
+					<xsd:documentation>Bike taxi (other than cycleRickshaw, +v1.2.2).</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="blackCab"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_submode_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_submode_version.xsd
@@ -94,7 +94,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:element name="TransportSubmode" type="TransportSubmodeStructure">
 		<xsd:annotation>
-			<xsd:documentation>A submode of a Public Transport MODE. </xsd:documentation>
+			<xsd:documentation>A submode of a public or private TRANSPORT MODE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="TransportSubmodeStructure">
@@ -137,7 +137,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="WaterSubmode"/>
 			<xsd:element ref="SnowAndIceSubmode">
 				<xsd:annotation>
-					<xsd:documentation>Extra: Snow and Ice Submode. +v1.1s</xsd:documentation>
+					<xsd:documentation>Extra: Snow and Ice Submode. +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:choice>
@@ -472,18 +472,46 @@ Local train adapted for running in mountain railway lines.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="unknown"/>
-			<xsd:enumeration value="undefined"/>
+			<xsd:enumeration value="undefined">
+				<xsd:annotation>
+					<xsd:documentation>Undefined / other than any of the available types.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="communalTaxi"/>
-			<xsd:enumeration value="charterTaxi"/>
+			<xsd:enumeration value="charterTaxi">
+				<xsd:annotation>
+					<xsd:documentation>+v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="waterTaxi"/>
 			<xsd:enumeration value="railTaxi"/>
-			<xsd:enumeration value="bikeTaxi"/>
+			<xsd:enumeration value="bikeTaxi">
+				<xsd:annotation>
+					<xsd:documentation>Bike taxi (other than cycleRickshaw, +v1.2.2). </xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="blackCab"/>
 			<xsd:enumeration value="miniCab"/>
-			<xsd:enumeration value="appTaxi"/>
-			<xsd:enumeration value="fiacre"/>
-			<xsd:enumeration value="rickshaw"/>
-			<xsd:enumeration value="cycleRickshaw"/>
+			<xsd:enumeration value="appTaxi">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="fiacre">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="rickshaw">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cycleRickshaw">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="allTaxiServices"/>
 		</xsd:restriction>
 	</xsd:simpleType>
@@ -502,56 +530,60 @@ Local train adapted for running in mountain railway lines.</xsd:documentation>
 			<xsd:enumeration value="undefined"/>
 			<xsd:enumeration value="hireScooter">
 				<xsd:annotation>
-					<xsd:documentation>	Rental scooter (Small wheeled  low platform  vehicles, - includes push scooters, electric scooters, skateboards,  Sedgeways, etc). +v1.2.2</xsd:documentation>
+					<xsd:documentation>Rental scooter (small wheeled low platform vehicles - includes push scooters, electric scooters, skateboards, Segways, etc). +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="hireCycle">
 				<xsd:annotation>
-					<xsd:documentation>Rental cycle  (Bicycle, tandem, tricycle, pedal or electric ; use SimpleVehicleType / VehicleCategory  to specify exact model. Includes pedal cycles, electric bikes, hybrids, etc). +v1.2.2</xsd:documentation>
+					<xsd:documentation>Rental cycle (bicycle, tandem, tricycle, pedal or electric; use SimpleVehicleType / VehicleCategory to specify exact model. Includes pedal cycles, electric bikes, hybrids, etc). +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="hireMotorbike">
 				<xsd:annotation>
-					<xsd:documentation>Rental motorcycle (moped, velo, motorbike, quadbike, etc  ; use SimpleVehicleType / VehicleCategory  to specify exact model.  </xsd:documentation>
+					<xsd:documentation>Rental motorcycle (moped, velo, motorbike, quadbike, etc  ; use SimpleVehicleType / VehicleCategory  to specify exact model. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="hireCar">
 				<xsd:annotation>
-					<xsd:documentation>Rental car - Includes all sizes (Small, mini, medium, large, etc)</xsd:documentation>
+					<xsd:documentation>Rental car - includes all sizes (small, mini, medium, large, etc.).</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="hireVan">
 				<xsd:annotation>
-					<xsd:documentation>Rental van - Includes all categories of small to large minivan, minibus and transporter.</xsd:documentation>
+					<xsd:documentation>Rental van - includes all categories of small to large minivan, minibus and transporter.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ownScooter">
 				<xsd:annotation>
-					<xsd:documentation>Own scooter (Small wheeled  low platform  vehicles, - includes push scooters, electric scooters, skateboards,  Sedgeways, etc). +v1.2.2</xsd:documentation>
+					<xsd:documentation>Own scooter (small wheeled  low platform  vehicles - includes push scooters, electric scooters, skateboards, Segways, etc.). +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ownCycle">
 				<xsd:annotation>
-					<xsd:documentation>Own cycle (Bicycle, tandem, tricile, pedal or electric ; use SimpleVehicleType / VehicleCategory to specify exact model. Includes push scooters, electric scooters, skateboards,  Sedgeways, etc). +v1.2.2</xsd:documentation>
+					<xsd:documentation>Own cycle (bicycle, tandem, tricile, pedal or electric; use SimpleVehicleType / VehicleCategory to specify exact model. Includes push scooters, electric scooters, skateboards, Segways, etc.). +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ownMotorbike">
 				<xsd:annotation>
-					<xsd:documentation>Own motorcycle (moped, velo, motorbike, quadbike, etc  ; use SimpleVehicleType / VehicleCategory  to specify exact model.  +v1.2.2</xsd:documentation>
+					<xsd:documentation>Own motorcycle (moped, velo, motorbike, quadbike, etc.; use SimpleVehicleType / VehicleCategory  to specify exact model. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ownCar">
 				<xsd:annotation>
-					<xsd:documentation>OWn car. Includes all sizes (Small, mini, medium, large, etc) +v1.2.2</xsd:documentation>
+					<xsd:documentation>Own car. Includes all sizes (small, mini, medium, large, etc.). +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ownVan">
 				<xsd:annotation>
-					<xsd:documentation>Own van - Includes all categories of small to large minivan, minibus and transporter.+v1.2.2</xsd:documentation>
+					<xsd:documentation>Own van - includes all categories of small to large minivan, minibus and transporter. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="allHireVehicles"/>
-			<xsd:enumeration value="allVehicles"/>
+			<xsd:enumeration value="allVehicles">
+				<xsd:annotation>
+					<xsd:documentation>Hire and own vehicles. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<!-- ======================================================================= -->

--- a/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
@@ -137,7 +137,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>VEHICLE MODELs in frame.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="vehicleEquipmentProfiles" type="vehicleEquipmenProfilesInFrame_RelStructure" minOccurs="0">
+			<xsd:element name="vehicleEquipmentProfiles" type="vehicleEquipmentProfilesInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>VEHICLE EQUIPMENT PROFILEs in frame.</xsd:documentation>
 				</xsd:annotation>
@@ -149,7 +149,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:complexType name="vehicleEquipmenProfilesInFrame_RelStructure">
+	<xsd:complexType name="vehicleEquipmentProfilesInFrame_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for containment in frame of VEHICLE EQUIPMENT PROFILEs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
@@ -503,7 +503,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="cycle"/>
 			<xsd:enumeration value="pedalCycle">
 				<xsd:annotation>
-					<xsd:documentation></xsd:documentation>
+					<xsd:documentation/>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="eCycle"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
@@ -501,7 +501,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="scooter"/>
 			<xsd:enumeration value="eScooter"/>
 			<xsd:enumeration value="cycle"/>
-			<xsd:enumeration value="pedalCycle"/>
+			<xsd:enumeration value="pedalCycle">
+				<xsd:annotation>
+					<xsd:documentation></xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="eCycle"/>
 			<xsd:enumeration value="tricycle"/>
 			<xsd:enumeration value="tandem"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -1201,7 +1201,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="Description" type="MultilingualString" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Description of VEHICLE EQUIPMENT PROFILE.</xsd:documentation>
+					<xsd:documentation>Description of VEHICLE EQUIPMENT PROFILE. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="EquipmentRef" minOccurs="0"/>
@@ -1215,7 +1215,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Manufacturer VEHICLE MODEL.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="TypeOfEquipmentRef" minOccurs="0"/>
+			<xsd:element ref="TypeOfEquipmentRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>TYPE of EQUIPMENT. +v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="PurposeOfEquipmentProfileRef" minOccurs="0"/>
 			<xsd:element name="vehicleEquipmentProfileMembers" type="vehicleEquipmentProfileMembers_RelStructure" minOccurs="0">
 				<xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentParking_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentParking_support.xsd
@@ -102,7 +102,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="railings"/>
 			<xsd:enumeration value="cycleScheme">
 				<xsd:annotation>
-					<xsd:documentation></xsd:documentation>
+					<xsd:documentation/>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="lockers">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentParking_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentParking_support.xsd
@@ -93,12 +93,28 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="racks"/>
-			<xsd:enumeration value="docks"/>
+			<xsd:enumeration value="docks">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="bars"/>
 			<xsd:enumeration value="railings"/>
-			<xsd:enumeration value="cycleScheme"/>
-			<xsd:enumeration value="lockers"/>
-			<xsd:enumeration value="freestanding"/>
+			<xsd:enumeration value="cycleScheme">
+				<xsd:annotation>
+					<xsd:documentation></xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="lockers">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="freestanding">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>
@@ -130,7 +146,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:simpleType name="LockingMechanismEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed value for LOCKING MECHANISM</xsd:documentation>
+			<xsd:documentation>Allowed value for LOCKING MECHANISM. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="none"/>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_support.xsd
@@ -374,10 +374,14 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="roadside"/>
 			<xsd:enumeration value="undefined"/>
 			<xsd:enumeration value="other"/>
-			<xsd:enumeration value="onPavement"/>
+			<xsd:enumeration value="onPavement">
+				<xsd:annotation>
+						<xsd:documentation>Car park at ground level. +v1.2.2</xsd:documentation>
+					</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="cycleHire">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED 1.2.2 Use onPavement instead</xsd:documentation>
+					<xsd:documentation>DEPRECATED - use onPavement instead. -v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 		</xsd:restriction>
@@ -421,8 +425,16 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="payAtMachineOnFootPriorToExit"/>
 			<xsd:enumeration value="payByPrepaidToken"/>
 			<xsd:enumeration value="payByMobileDevice"/>
-			<xsd:enumeration value="payByPlate"/>
-			<xsd:enumeration value="prepayForPermit"/>
+			<xsd:enumeration value="payByPlate">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="prepayForPermit">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="undefined"/>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
@@ -458,9 +470,17 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Allowed values for PARKING VEHICLE types.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="cycle"/>
+			<xsd:enumeration value="cycle">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="pedalCycle"/>
-			<xsd:enumeration value="eCycle"/>
+			<xsd:enumeration value="eCycle">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="moped"/>
 			<xsd:enumeration value="motorcycle"/>
 			<xsd:enumeration value="motorcycleWithSidecar"/>
@@ -468,8 +488,16 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="twoWheeledVehicle"/>
 			<xsd:enumeration value="threeWheeledVehicle"/>
 			<xsd:enumeration value="car"/>
-			<xsd:enumeration value="microCar"/>
-			<xsd:enumeration value="miniCar"/>
+			<xsd:enumeration value="microCar">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="miniCar">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="smallCar"/>
 			<xsd:enumeration value="passengerCar"/>
 			<xsd:enumeration value="largeCar"/>
@@ -479,10 +507,18 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="carWithTrailer"/>
 			<xsd:enumeration value="carWithCaravan"/>
 			<xsd:enumeration value="minibus"/>
-			<xsd:enumeration value="minivan"/>
+			<xsd:enumeration value="minivan">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="bus"/>
 			<xsd:enumeration value="van"/>
-			<xsd:enumeration value="transporter"/>
+			<xsd:enumeration value="transporter">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="largeVan"/>
 			<xsd:enumeration value="highSidedVehicle"/>
 			<xsd:enumeration value="lightGoodsVehicle"/>
@@ -495,7 +531,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="vehicleWithTrailer"/>
 			<xsd:enumeration value="lightGoodsVehicleWithTrailer"/>
 			<xsd:enumeration value="heavyGoodsVehicleWithTrailer"/>
-			<xsd:enumeration value="snowmobile"/>
+			<xsd:enumeration value="snowmobile">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="undefined"/>
 			<xsd:enumeration value="other"/>
 			<xsd:enumeration value="allPassengerVehicles"/>
@@ -510,20 +550,48 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="allUsers"/>
 			<xsd:enumeration value="staff"/>
 			<xsd:enumeration value="visitors"/>
-			<xsd:enumeration value="customers"/>
-			<xsd:enumeration value="guests"/>
+			<xsd:enumeration value="customers">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="guests">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="registeredDisabled"/>
-			<xsd:enumeration value="impairedMobility"/>
+			<xsd:enumeration value="impairedMobility">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="registered"/>
 			<xsd:enumeration value="rental"/>
 			<xsd:enumeration value="doctors"/>
 			<xsd:enumeration value="residentsWithPermits"/>
 			<xsd:enumeration value="reservationHolders"/>
 			<xsd:enumeration value="emergencyServices"/>
-			<xsd:enumeration value="taxi"/>
-			<xsd:enumeration value="vehicleSharing"/>
-			<xsd:enumeration value="women"/>
-			<xsd:enumeration value="families"/>
+			<xsd:enumeration value="taxi">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="vehicleSharing">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="women">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="families">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="other"/>
 			<xsd:enumeration value="all"/>
 		</xsd:restriction>
@@ -536,7 +604,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="BayGeometryEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for PARKING Geometry.</xsd:documentation>
+			<xsd:documentation>Allowed values for PARKING Geometry. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="unspecified"/>
@@ -549,7 +617,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="ParkingVisibilityEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for PARKING Visibility</xsd:documentation>
+			<xsd:documentation>Allowed values for PARKING Visibility. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="unmarked"/>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_support.xsd
@@ -376,8 +376,8 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="other"/>
 			<xsd:enumeration value="onPavement">
 				<xsd:annotation>
-						<xsd:documentation>Car park at ground level. +v1.2.2</xsd:documentation>
-					</xsd:annotation>
+					<xsd:documentation>Car park at ground level. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="cycleHire">
 				<xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_version.xsd
@@ -193,7 +193,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Type of PARKING.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="TypeOfParkingRef" minOccurs="0"/>
+			<xsd:element ref="TypeOfParkingRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a TYPE OF PARKING. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="ParkingVehicleTypes" type="ParkingVehicleListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Types of Vehicle allowed in PARKING.</xsd:documentation>
@@ -447,10 +451,14 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements of a PARKING ENTRANCE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="ModeOfOperationRef" minOccurs="0"/>
+			<xsd:element ref="ModeOfOperationRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to MODE of OPERATION. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="areas" type="parkingAreaRefs_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>PARKING AREAs to which ENtrance gives access appky +v1.1.</xsd:documentation>
+					<xsd:documentation>PARKING AREAs to which ENTRANCE gives access. +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -627,7 +635,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="ParkingPropertiesDetailsGroup">
 		<xsd:annotation>
-			<xsd:documentation>EClassifying lements of a PARKING PROPERTies.</xsd:documentation>
+			<xsd:documentation>Classifying elements of a PARKING PROPERTies.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="ParkingStayList" type="ParkingStayListOfEnumerations" minOccurs="0">
@@ -728,7 +736,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Type of vehicle that PARKING allows.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="TransportTypeRef" minOccurs="0"/>
+			<xsd:element ref="TransportTypeRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a TRANSPORT TYPE. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="ParkingStayType" type="ParkingStayEnumeration" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Type of Stay allowed in PARKING.</xsd:documentation>
@@ -1022,10 +1034,14 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements of a PARKING BAY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="ParkingAreaRef" minOccurs="0"/>
+			<xsd:element ref="ParkingAreaRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="ParkingUserTypes" type="ParkingUserListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Type of users: disabled, all etc.</xsd:documentation>
+					<xsd:documentation>Type of users: disabled, all etc. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ParkingVehicleType" type="ParkingVehicleEnumeration" minOccurs="0">
@@ -1033,8 +1049,16 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Type of vehicle in PARKING BAY.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="TransportTypeRef" minOccurs="0"/>
-			<xsd:group ref="ParkingPropertiesDetailsGroup"/>
+			<xsd:element ref="TransportTypeRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:group ref="ParkingPropertiesDetailsGroup">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:group>
 			<xsd:element name="Length" type="LengthType" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Length of PARKING BAY.</xsd:documentation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_support.xsd
@@ -429,11 +429,31 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="works"/>
 			<xsd:enumeration value="office"/>
 			<xsd:enumeration value="militaryBase"/>
-			<xsd:enumeration value="retail"/>
-			<xsd:enumeration value="transport"/>
-			<xsd:enumeration value="sports"/>
-			<xsd:enumeration value="government"/>
-			<xsd:enumeration value="culturalAttraction"/>
+			<xsd:enumeration value="retail">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="transport">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="sports">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="government">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="culturalAttraction">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>

--- a/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
@@ -251,7 +251,11 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TransportSubmode" minOccurs="0"/>
-			<xsd:element ref="ModeOfOperationRef" minOccurs="0"/>
+			<xsd:element ref="ModeOfOperationRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="GroupOfLinesType" type="GroupOfLinesTypeEnumeration" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Classification of GROUP OF LINES. +v1.1</xsd:documentation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_networkRestriction_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_networkRestriction_version.xsd
@@ -308,7 +308,11 @@ Rail transport, Roads and ROAD transport
 			<xsd:documentation>Elements for a MANOEUVRE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="TransportTypeRef" minOccurs="0"/>
+			<xsd:element ref="TransportTypeRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_routingConstraint_support.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_routingConstraint_support.xsd
@@ -148,14 +148,46 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Allowed values for zone use.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="forbiddenZone"/>
-			<xsd:enumeration value="cannotBoardAndAlightInSameZone"/>
-			<xsd:enumeration value="cannotBoardInZone"/>
-			<xsd:enumeration value="cannotAlightInZone"/>
-			<xsd:enumeration value="mustBoardInZone"/>
-			<xsd:enumeration value="mustAlightInZone"/>
-			<xsd:enumeration value="passThroughUseOnly"/>
-			<xsd:enumeration value="other"/>
+			<xsd:enumeration value="forbiddenZone">
+				<xsd:annotation>
+					<xsd:documentation>Zone may not be entered. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cannotBoardAndAlightInSameZone">
+				<xsd:annotation>
+					<xsd:documentation>Cannot board and alight within the same zone.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cannotBoardInZone">
+				<xsd:annotation>
+					<xsd:documentation>May not board in zone. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cannotAlightInZone">
+				<xsd:annotation>
+					<xsd:documentation>May not alight in zone. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="mustBoardInZone">
+				<xsd:annotation>
+					<xsd:documentation>Must board in Zone. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="mustAlightInZone">
+				<xsd:annotation>
+					<xsd:documentation>Must alight in zone. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="passThroughUseOnly">
+				<xsd:annotation>
+					<xsd:documentation>May only pass through zone. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="other">
+				<xsd:annotation>
+					<xsd:documentation>Other rule.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 </xsd:schema>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -387,8 +387,16 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Scoping validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:group ref="ModeValidityParametersGroup"/>
-			<xsd:group ref="OrganisationValidityParametersGroup"/>
+			<xsd:group ref="ModeValidityParametersGroup">
+				<xsd:annotation>
+					<xsd:documentation>MODE related validity parameters for assignment. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:group>
+			<xsd:group ref="OrganisationValidityParametersGroup">
+				<xsd:annotation>
+					<xsd:documentation>ORGANISATION related validity parameters for assignment.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:group>
 			<xsd:group ref="NetworkValidityParametersGroup">
 				<xsd:annotation>
 					<xsd:documentation>Network validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
@@ -409,18 +417,18 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="ModeValidityParametersGroup">
 		<xsd:annotation>
-			<xsd:documentation>MODE validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
+			<xsd:documentation>MODE validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:choice>
 				<xsd:element name="VehicleModes" type="VehicleModeListOfEnumerations" minOccurs="0">
 					<xsd:annotation>
-						<xsd:documentation>Vehicle Modes to which ACCESS RIGHTs  apply. DEPRECATED - keep for backwards capability</xsd:documentation>
+						<xsd:documentation>VEHICLE MODEs to which ACCESS RIGHTs apply. DEPRECATED - keep for backwards compatibility. -v1.2.2</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="TransportModes" type="AllModesListOfEnumerations" minOccurs="0">
 					<xsd:annotation>
-						<xsd:documentation>Any mode to which Mode validity parameters apply +v1.2.2</xsd:documentation>
+						<xsd:documentation>Any MODE to which mode validity parameters apply. +v1.2.2</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
@@ -430,7 +438,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="OrganisationValidityParametersGroup">
 		<xsd:annotation>
-			<xsd:documentation>ORGANISATION validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
+			<xsd:documentation>ORGANISATION validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT. Revised v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="GroupOfOperatorsRef" minOccurs="0"/>
@@ -461,7 +469,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Site validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
-			<xsd:element ref="MobilityServiceConstraintZoneRef" minOccurs="0"/>
+			<xsd:element ref="MobilityServiceConstraintZoneRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to an MOBILITY SERVICE CONSTRAINT ZONE. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="SiteValidityParametersGroup">
@@ -517,7 +529,11 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="BorderPointRef" minOccurs="0"/>
 			<xsd:element ref="SeriesConstraintRef" minOccurs="0"/>
 			<xsd:element ref="ServiceJourneyPatternRef" minOccurs="0"/>
-			<xsd:element ref="SingleJourneyPathRef" minOccurs="0"/>
+			<xsd:element ref="SingleJourneyPathRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a SINGLE JOURNEY PATH. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="TransferRestrictionRef" minOccurs="0"/>
 			<xsd:element ref="RoutingConstraintZoneRef" minOccurs="0"/>
 			<xsd:element ref="ServiceExclusionRef" minOccurs="0"/>
@@ -537,8 +553,16 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfProductCategoryRef" minOccurs="0"/>
 			<xsd:group ref="ConventionalServiceValidityParametersGroup"/>
 			<xsd:group ref="AlternativeServiceValidityParametersGroup"/>
-			<xsd:element ref="TransportTypeRef" minOccurs="0"/>
-			<xsd:element ref="VehicleModelRef" minOccurs="0"/>
+			<xsd:element ref="TransportTypeRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>TRANSPORT TYPE to which assignment is made. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="VehicleModelRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>VEHICLE MODEL to which assignment is made. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="TypeOfServiceRef" minOccurs="0"/>
 			<xsd:group ref="EquipmentValidityParametersGroup">
 				<xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_version.xsd
@@ -310,12 +310,12 @@ Rail transport, Roads and Road transport
 				</xsd:choice>
 				<xsd:element name="StartMeetingPointRef" type="PointRefStructure">
 					<xsd:annotation>
-						<xsd:documentation>Start MeetingPoint for  Cell of  DISTANCE MATRIX.</xsd:documentation>
+						<xsd:documentation>Start MeetingPoint for cell of DISTANCE MATRIX. +v1.2.2</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="FromFareSectionRef" type="FareSectionRefStructure" minOccurs="0">
 					<xsd:annotation>
-						<xsd:documentation>FARE SECTION at which  element begins.</xsd:documentation>
+						<xsd:documentation>FARE SECTION at which element begins.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="FromFarePointInPatternRef" type="FarePointInPatternRefStructure" minOccurs="0">
@@ -351,12 +351,12 @@ Rail transport, Roads and Road transport
 				</xsd:choice>
 				<xsd:element name="EndMeetingPointRef" type="PointRefStructure">
 					<xsd:annotation>
-						<xsd:documentation>ENd MeetingPoint for  Cell of  DISTANCE MATRIX.</xsd:documentation>
+						<xsd:documentation>End MeetingPoint for cell of DISTANCE MATRIX.+v1.2.2</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ToFareSectionRef" type="FareSectionRefStructure" minOccurs="0">
 					<xsd:annotation>
-						<xsd:documentation>FARE SECTION at which  element ends.</xsd:documentation>
+						<xsd:documentation>FARE SECTION at which element ends.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ToFarePointInPatternRef" type="FarePointInPatternRefStructure" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_support.xsd
@@ -98,13 +98,17 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="pointToPointFare"/>
 			<xsd:enumeration value="pointToPointDistanceFare"/>
 			<xsd:enumeration value="stageFare"/>
-			<xsd:enumeration value="penaltyFare"/>
+			<xsd:enumeration value="penaltyFare">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="VehicleCollectionEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for  VEHICLE RENTAL COLLECTION</xsd:documentation>
+			<xsd:documentation>Allowed values for  VEHICLE RENTAL COLLECTION. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="onSite"/>

--- a/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
@@ -259,12 +259,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="RequiresDeposit" type="xsd:boolean" default="true" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Requires a deposit +v1.2.2</xsd:documentation>
+					<xsd:documentation>Requires a deposit. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="NoCashPayment" type="xsd:boolean" default="true" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Cash payment not accepted +v1.2.2</xsd:documentation>
+					<xsd:documentation>Cash payment not accepted. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -330,12 +330,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="LikeForLikeRefuelling" type="xsd:boolean" default="true" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Refuelling Policy +v1.2.2</xsd:documentation>
+					<xsd:documentation>Refuelling policy. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="VehicleCollection" type="VehicleCollectionEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Vehicle collection process +v1.2.2</xsd:documentation>
+					<xsd:documentation>Vehicle collection process. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_fareProduct_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareProduct_support.xsd
@@ -646,14 +646,22 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="beforeTravel"/>
 			<xsd:enumeration value="onStartOfTravel"/>
 			<xsd:enumeration value="beforeEndOfTravel"/>
-			<xsd:enumeration value="beforeTravelThenAdjustAtEndOfTravel"/>
+			<xsd:enumeration value="beforeTravelThenAdjustAtEndOfTravel">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="onStartThenAdjustAtEndOfTravel"/>
 			<xsd:enumeration value="onStarThenAdjustAtEndOfFareDay">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED TYPO</xsd:documentation>
+					<xsd:documentation>DEPRECATED TYPO. -v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
-			<xsd:enumeration value="onStartThenAdjustAtEndOfFareDay"/>
+			<xsd:enumeration value="onStartThenAdjustAtEndOfFareDay">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="onStartThenAdjustAtEndOfChargePeriod"/>
 			<xsd:enumeration value="atEndOfTravel"/>
 			<xsd:enumeration value="atEndOfFareDay"/>

--- a/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
@@ -598,7 +598,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="CellPriceableReferencesGroup">
 		<xsd:annotation>
-			<xsd:documentation>PriceableElements for a CELL.Group.</xsd:documentation>
+			<xsd:documentation>PriceableElements for a CELL group.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="PriceableObjectRef" minOccurs="0" maxOccurs="unbounded"/>
@@ -607,25 +607,25 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="CellSpecificsGroup">
 		<xsd:annotation>
-			<xsd:documentation>Aspects of a fare structure element for a CELL.Group.</xsd:documentation>
+			<xsd:documentation>Aspects of a fare structure element for a CELL group.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:group ref="CellSpecificRoutingGroup">
 				<xsd:annotation>
-					<xsd:documentation>Routing Aspects of a fare structure element for a CELL.Group.</xsd:documentation>
+					<xsd:documentation>Routing aspects of a fare structure element for a CELL group.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
 			<xsd:group ref="CellSpecificNetworkGroup"/>
 			<xsd:group ref="CellSpecificServiceGroup">
 				<xsd:annotation>
-					<xsd:documentation>Service Aspects of a fare structure element for a CELL.Group.</xsd:documentation>
+					<xsd:documentation>Service aspects of a fare structure element for a CELL group.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
 			<xsd:group ref="CellSpecificTransportTypeGroup"/>
 			<xsd:group ref="CellSpecificEquipmentGroup"/>
 			<xsd:group ref="CellSpecificDistributionGroup">
 				<xsd:annotation>
-					<xsd:documentation>Distribution Aspects of a fare structure element for a CELL.Group.</xsd:documentation>
+					<xsd:documentation>Distribution aspects of a fare structure element for a CELL group.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
 		</xsd:sequence>
@@ -635,12 +635,24 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Network Aspects of a fare structure element for a CELL.Group.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="TransportOrganisationRef" minOccurs="0"/>
+			<xsd:element ref="TransportOrganisationRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>A TRANSPORT ORGANISATION for which the CELL provides a price. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="GroupOfLinesRef" minOccurs="0"/>
 			<xsd:element ref="LineRef" minOccurs="0"/>
 			<xsd:element ref="SiteRef" minOccurs="0"/>
-			<xsd:element ref="VehicleMeetingPlaceRef" minOccurs="0"/>
-			<xsd:element ref="TypeOfParkingRef" minOccurs="0"/>
+			<xsd:element ref="VehicleMeetingPlaceRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>A VEHICLE MEETING PLACE for which the CELL provides a price. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="TypeOfParkingRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>A TYPE of PARKING for which the CELL provides a price. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="TariffZoneRef" minOccurs="0"/>
 			<xsd:element ref="FareSectionRef" minOccurs="0"/>
 		</xsd:sequence>
@@ -672,16 +684,24 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfServiceRef" minOccurs="0"/>
 			<xsd:choice minOccurs="0">
 				<xsd:element ref="ServiceJourneyRef"/>
-				<xsd:element ref="SingleJourneyRef"/>
+				<xsd:element ref="SingleJourneyRef">
+					<xsd:annotation>
+						<xsd:documentation>A SINGLE JOURNEY for which the CELL provides a price. +v1.2.2</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
 				<xsd:element ref="TrainNumberRef"/>
 				<xsd:element ref="GroupOfServicesRef"/>
-				<xsd:element ref="GroupOfSingleJourneysRef"/>
+				<xsd:element ref="GroupOfSingleJourneysRef">
+					<xsd:annotation>
+						<xsd:documentation>A GROUP of SINGLE JOURNEYs for which the CELL provides a price. +v1.2.2</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
 			</xsd:choice>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="CellSpecificTransportTypeGroup">
 		<xsd:annotation>
-			<xsd:documentation>Equipment Aspects of a fare structure element for a CELL.Group +v1.2.2</xsd:documentation>
+			<xsd:documentation>TRANSPORT TYPE aspects of a fare structure element for a CELL group. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="TransportTypeRef" minOccurs="0"/>
@@ -691,7 +711,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="CellSpecificEquipmentGroup">
 		<xsd:annotation>
-			<xsd:documentation>Equipment Aspects of a fare structure element for a CELL.Group +v1.2.2</xsd:documentation>
+			<xsd:documentation>EQUIPMENT aspects of a fare structure element for a CELL group. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="EquipmentRef" minOccurs="0"/>
@@ -699,7 +719,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="CellSpecificDistributionGroup">
 		<xsd:annotation>
-			<xsd:documentation>Distribution Aspects of a fare structure element for a CELL.Group.</xsd:documentation>
+			<xsd:documentation>Distribution aspects of a fare structure element for a CELL group.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="TypeOfFareProductRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_fares/netex_salesDistribution_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesDistribution_support.xsd
@@ -274,7 +274,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="exchange"/>
 			<xsd:enumeration value="refund"/>
 			<xsd:enumeration value="inform"/>
-			<xsd:enumeration value="book"/>
+			<xsd:enumeration value="book">
+				<xsd:annotation>
+					<xsd:documentation>Distributor may do a booking for the product. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="private"/>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>

--- a/xsd/netex_part_3/part3_fares/netex_typeOfTravelDocument_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_typeOfTravelDocument_support.xsd
@@ -137,7 +137,7 @@ Rail transport, Roads and Road transport
 	<!-- ====Enums  DOCUMENT.================================================== -->
 	<xsd:simpleType name="MediaTypeEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for ResellType.</xsd:documentation>
+			<xsd:documentation>Allowed values for MediaType.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="none"/>
@@ -147,7 +147,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="selfPrintPaperTicket"/>
 			<xsd:enumeration value="smartCard"/>
 			<xsd:enumeration value="mobileApp"/>
-			<xsd:enumeration value="licencePlate"/>
+			<xsd:enumeration value="licencePlate">
+				<xsd:annotation>
+					<xsd:documentation>Travel document is licence plate. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="card"/>
 			<xsd:enumeration value="mms"/>
 			<xsd:enumeration value="sms"/>
@@ -156,14 +160,18 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="MachineReadableEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for ResellType.</xsd:documentation>
+			<xsd:documentation>Allowed values for MachineReadable.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="none"/>
 			<xsd:enumeration value="magneticStrip"/>
 			<xsd:enumeration value="chip"/>
 			<xsd:enumeration value="ocr"/>
-			<xsd:enumeration value="apnr"/>
+			<xsd:enumeration value="apnr">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="barCode"/>
 			<xsd:enumeration value="qrCode"/>
 			<xsd:enumeration value="shotCode"/>
@@ -173,7 +181,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="MachineReadableListOfEnumerations">
 		<xsd:annotation>
-			<xsd:documentation>List of Machine readable Types.</xsd:documentation>
+			<xsd:documentation>List of machine readable types.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:list itemType="MachineReadableEnumeration"/>
 	</xsd:simpleType>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterBooking_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterBooking_version.xsd
@@ -167,7 +167,7 @@ Rail transport, Roads and Road transport
 	<!-- ====BOOKING POLICY=================================================== -->
 	<xsd:element name="BookingPolicy" abstract="true" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
-			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer.</xsd:documentation>
+			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -213,7 +213,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="BookingMethods" type="BookingMethodListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Booking methods allowed</xsd:documentation>
+					<xsd:documentation>Booking methods allowed. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -411,7 +411,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="BookingDepositRefundable" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether a booking deposit is refunded on cancellation.</xsd:documentation>
+					<xsd:documentation>Whether a booking deposit is refunded on cancellation. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_support.xsd
@@ -148,7 +148,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="DepositPolicyEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for  Deposit  Policy. +v1.1.2</xsd:documentation>
+			<xsd:documentation>Allowed values for DepositPolicy. +v1.1.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="none">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
@@ -654,7 +654,7 @@ Rail transport, Roads and Road transport
 	<!-- ==== TYPE OF PROOF REQUIRED ========================================================== -->
 	<xsd:element name="TypeOfProof" abstract="false" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
-			<xsd:documentation>Type of Proff of identity required. +v1.2.2</xsd:documentation>
+			<xsd:documentation>TYPE of PROOF of identity required. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
@@ -378,7 +378,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="useOfMobileDevice"/>
 			<xsd:enumeration value="automaticByTime"/>
 			<xsd:enumeration value="automaticByProximity"/>
-			<xsd:enumeration value="accessCode"/>
+			<xsd:enumeration value="accessCode">
+				<xsd:annotation>
+					<xsd:documentation>Activation by entering a code. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>

--- a/xsd/netex_part_3/part3_frames/netex_salesTransactionFrame_version.xsd
+++ b/xsd/netex_part_3/part3_frames/netex_salesTransactionFrame_version.xsd
@@ -143,7 +143,11 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:group ref="RetailConsortiumInFrameGroup"/>
 			<xsd:group ref="FareContractsInFrameGroup"/>
-			<xsd:group ref="MediumAccessDevicesInFrameGroup"/>
+			<xsd:group ref="MediumAccessDevicesInFrameGroup">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:group>
 			<xsd:group ref="SecurityListsInFrameGroup"/>
 			<xsd:group ref="SalesTransactionInFrameGroup"/>
 			<xsd:group ref="TravelDocumentsInFrameGroup"/>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPaymentMeans_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPaymentMeans_version.xsd
@@ -80,7 +80,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:element name="CustomerPaymentMeans" abstract="false" substitutionGroup="VersionedChild">
 		<xsd:annotation>
-			<xsd:documentation>A registered means with which a TRANSPORT CUSTOMER wishes to make payments for a CUSTOMER ACCOUNT, e.g. by nominated EMV card, </xsd:documentation>
+			<xsd:documentation>A registered means with which a TRANSPORT CUSTOMER wishes to make payments for a CUSTOMER ACCOUNT, e.g. by nominated EMV card. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -957,10 +957,26 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements for a CUSTOMER PURCHASE PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="IndividualTravellerRef" minOccurs="0"/>
-			<xsd:element ref="VehiclePoolingDriverInfoRef" minOccurs="0"/>
-			<xsd:element ref="TripRef" minOccurs="0"/>
-			<xsd:element ref="TripLegRef" minOccurs="0"/>
+			<xsd:element ref="IndividualTravellerRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="VehiclePoolingDriverInfoRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="TripRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="TripLegRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 </xsd:schema>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_support.xsd
@@ -118,10 +118,18 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="unused"/>
-			<xsd:enumeration value="unverified"/>
+			<xsd:enumeration value="unverified">
+				<xsd:annotation>
+					<xsd:documentation>Not yet verified. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="active"/>
 			<xsd:enumeration value="dormant"/>
-			<xsd:enumeration value="suspended"/>
+			<xsd:enumeration value="suspended">
+				<xsd:annotation>
+					<xsd:documentation>Temporarily disabled.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="archived"/>
 			<xsd:enumeration value="closed"/>
 		</xsd:restriction>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
@@ -295,12 +295,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="Phone" type="TelephoneContactStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Phone number. (Usually personal  mobile phone). </xsd:documentation>
+					<xsd:documentation>Phone number (usually personal mobile phone.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="PhoneVerified" type="xsd:dateTime" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Phone of CUSTOMER last verified +v1.2.2</xsd:documentation>
+					<xsd:documentation>Phone of CUSTOMER last verified. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="PostalAddress" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_travelSpecificationSummary_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_travelSpecificationSummary_version.xsd
@@ -112,7 +112,11 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:group ref="TravelSpecificationSummaryEndPointPlaceGroup"/>
 			<xsd:element ref="ScheduledStopPointView" minOccurs="0"/>
-			<xsd:element ref="VehicleMeetingPointRef" minOccurs="0"/>
+			<xsd:element ref="VehicleMeetingPointRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="QuayRef" minOccurs="0"/>
 			<xsd:element ref="BoardingPositionRef" minOccurs="0"/>
 			<xsd:element ref="TariffZoneRef" minOccurs="0" maxOccurs="unbounded"/>
@@ -124,7 +128,11 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="TopographicPlaceView" minOccurs="0"/>
-			<xsd:element ref="SiteRef" minOccurs="0"/>
+			<xsd:element ref="SiteRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="AddressRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
@@ -135,7 +143,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="Start" type="xsd:dateTime" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Start timw for trip or pass.</xsd:documentation>
+					<xsd:documentation>Start time for trip or pass.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="End" type="xsd:dateTime" minOccurs="0">

--- a/xsd/netex_part_5/part5_fm/netex_nm_accessCredentialsAssignment_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_accessCredentialsAssignment_version.xsd
@@ -68,7 +68,7 @@ Rail transport, Roads and Road transport
 	<xsd:element name="ServiceAccessCode" abstract="false" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Code to access a service, can be numerical code, barcode, flashcode, etc.
- +V1.2.2</xsd:documentation>
+ +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_5/part5_fm/netex_nm_usageParameterRental_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_usageParameterRental_version.xsd
@@ -61,7 +61,7 @@ Rail transport, Roads and Road transport
 	<!-- ==== RENTAL PENALTY POLICY USER PARAMETER ================================================ -->
 	<xsd:element name="RentalPenaltyPolicy" abstract="false" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
-			<xsd:documentation>Policy regarding different aspects of RENTAL service penalty charges, for example loss of vehicle.</xsd:documentation>
+			<xsd:documentation>Policy regarding different aspects of RENTAL service penalty charges, for example loss of vehicle. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_5/part5_frames/netex_nm_mobilityJourneyFrame_version.xsd
+++ b/xsd/netex_part_5/part5_frames/netex_nm_mobilityJourneyFrame_version.xsd
@@ -91,7 +91,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="MobilityJourneyFrame" abstract="false" substitutionGroup="CommonFrame">
 		<xsd:annotation>
-			<xsd:documentation>A coherent set of MOBILITY JOURNEY data to which the same frame VALIDITY CONDITIONs have been assigned.</xsd:documentation>
+			<xsd:documentation>A coherent set of MOBILITY JOURNEY data to which the same frame VALIDITY CONDITIONs have been assigned. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -169,7 +169,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="vehicleAccessCredentials" type="vehicleAccessCredentialAssignments_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>VEHICLE MEETING POINTs in frame.</xsd:documentation>
+					<xsd:documentation>VEHICLE ACCESS CREDENTIALs in frame.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -182,7 +182,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="parkingLogEntries" type="parkingLogEntriesInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>VEHICLE MEETING POINTs in frame.</xsd:documentation>
+					<xsd:documentation>PARKING LOG ENTRies in frame.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_5/part5_frames/netex_nm_mobilityServiceFrame_version.xsd
+++ b/xsd/netex_part_5/part5_frames/netex_nm_mobilityServiceFrame_version.xsd
@@ -204,7 +204,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="vehicleMeetingPlaces" type="vehicleMeetingPlaces_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>VEHICLE MEETIN.G PLACES  in frame.</xsd:documentation>
+					<xsd:documentation>VEHICLE MEETING PLACES in frame.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="vehicleMeetingPlaceAssignments" type="vehicleServicePlaceAssignments_RelStructure" minOccurs="0">

--- a/xsd/netex_part_5/part5_nd/netex_nm_mobilityServiceConstraintZone_support.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_mobilityServiceConstraintZone_support.xsd
@@ -137,7 +137,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:simpleType name="TransportZoneUseEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for Zone Use.</xsd:documentation>
+			<xsd:documentation>Allowed values for Zone Use. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="allUsesAllowed"/>
@@ -160,7 +160,7 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:simpleType name="ZoneRuleApplicabilityEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for Zone Rule APplicability.</xsd:documentation>
+			<xsd:documentation>Allowed values for ZONE rule applicability. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="inside"/>

--- a/xsd/netex_part_5/part5_nd/netex_nm_mobilityServiceConstraintZone_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_mobilityServiceConstraintZone_version.xsd
@@ -151,7 +151,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:element name="VehicleTypeZoneRestriction" abstract="false" substitutionGroup="VersionedChild">
 		<xsd:annotation>
-			<xsd:documentation> A POINT where passengers can board or alight from vehicles.  +v1.2.2</xsd:documentation>
+			<xsd:documentation>Restriction on use of a MOBILITY SERVICE CONSTRAINT ZONE for a specific TRANSPORT TYPE. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPlace_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPlace_version.xsd
@@ -78,7 +78,7 @@ Rail transport, Roads and Road transport
 	</xsd:element>
 	<xsd:element name="VehicleMeetingPlace" abstract="false" substitutionGroup="Place">
 		<xsd:annotation>
-			<xsd:documentation>A place where  vehicles/passengers meet to change mode of transportation, for boarding, alighting, pick-up, drop-off, etc.  +v1.2.2
+			<xsd:documentation>A place where vehicles/passengers meet to change mode of transportation, for boarding, alighting, pick-up, drop-off, etc.  +v1.2.2
 </xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
@@ -336,7 +336,7 @@ Rail transport, Roads and Road transport
 	<!-- ==== VEHICLE SHARING PARKING BAY  ============================================================ -->
 	<xsd:element name="VehicleSharingParkingBay" abstract="false" substitutionGroup="ParkingBay_">
 		<xsd:annotation>
-			<xsd:documentation>A spot in the PARKING AREA dedicated to vehicle sharing or rental. 	+v1.2.2</xsd:documentation>
+			<xsd:documentation>A spot in the PARKING AREA dedicated to vehicle sharing or rental.	+v1.2.2</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_5/part5_sj/netex_nm_singleJourneyService_version.xsd
+++ b/xsd/netex_part_5/part5_sj/netex_nm_singleJourneyService_version.xsd
@@ -132,23 +132,23 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="DepartureDayOffset" type="DayOffsetType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Departure Time Day Offset</xsd:documentation>
+					<xsd:documentation>Departure Time Day Offset.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="OperatingDayRef" minOccurs="0"/>
 			<xsd:element name="datedPassingTimes" type="targetPassingTimes_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DATED PASSING TIMEsfor SINGLE JOURNEY</xsd:documentation>
+					<xsd:documentation>DATED PASSING TIMEsfor SINGLE JOURNEY.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="meetingPointAssignments" type="vehicleMeetingPointAssignments_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>MEETING POINT ASSIGNMENTS for SINGLE JOURNEY</xsd:documentation>
+					<xsd:documentation>MEETING POINT ASSIGNMENTS for SINGLE JOURNEY.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="VehiclePoolingDriverInfoRef" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Possible relation to a VEHICLE POOLING DRIVER, as defined in Transmodel</xsd:documentation>
+					<xsd:documentation>Possible relation to a VEHICLE POOLING DRIVER, as defined in Transmodel.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>


### PR DESCRIPTION
Second series following #762. They are about the changes from PR #305 (new modes) for which I updated the documentation where missing and added *+v1.2.2* labels. This was quite an epic undertaking because over 150 files were concerned. 