### PR TITLE
Review of the CHARGING PLAN

### DIFF
--- a/xsd/netex_part_2/part2_vehicleService/netex_vehicleRechargingPlan_version.xsd
+++ b/xsd/netex_part_2/part2_vehicleService/netex_vehicleRechargingPlan_version.xsd
@@ -5,6 +5,7 @@
 	<xsd:include schemaLocation="../part2_journeyTimes/netex_coupledJourney_support.xsd"/>
 	<xsd:include schemaLocation="../part2_journeyTimes/netex_vehicleJourney_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_responsibility/netex_responsibility_version.xsd"/>
+	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_vehicle_version.xsd"/>
 	<!-- ======================================================================= -->
 	<xsd:annotation>
 		<xsd:appinfo>
@@ -140,7 +141,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="RechargingProcessType" type="RechargingProcessEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Description of RECHARGING PLAN.</xsd:documentation>
+					<xsd:documentation>Type of recharching process</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="TotalChargeEnergy" type="WattHoursType" minOccurs="0">
@@ -216,8 +217,16 @@ Rail transport, Roads and Road transport
 							<xsd:group ref="RechargingDurationGroup"/>
 							<xsd:element ref="JourneyRef" minOccurs="0"/>
 							<xsd:element ref="PointInJourneyPatternRef" minOccurs="0"/>
-							<xsd:element ref="VehicleTypeRef" minOccurs="0"/>
-							<xsd:element ref="VehicleRef" minOccurs="0"/>
+							<xsd:element name="vehicleTypes" type="vehicleTypeRefs_RelStructure" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>TYPES OF VEHICLE possibly compatible with this recharging plan and step.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="vehicles" type="vehicleRefs_RelStructure" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>VEHICLEs possibly compatible with this recharging plan and step.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
 						</xsd:sequence>
 					</xsd:sequence>
 					<xsd:attribute name="id" type="RechargingStepIdType"/>
@@ -264,8 +273,16 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="RechargingDurationGroup"/>
 			<xsd:element ref="JourneyRef" minOccurs="0"/>
 			<xsd:element ref="PointInJourneyPatternRef" minOccurs="0"/>
-			<xsd:element ref="VehicleTypeRef" minOccurs="0"/>
-			<xsd:element ref="VehicleRef" minOccurs="0"/>
+			<xsd:element name="vehicleTypes" type="vehicleTypeRefs_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>TYPES OF VEHICLE possibly compatible with this recharging plan and step.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vehicles" type="vehicleRefs_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>VEHICLEs possibly compatible with this recharging plan and step.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="RechargingDurationGroup">


### PR DESCRIPTION
Review of the CHARGING PLAN's NeTEx implementation References to VEHICLE and VEHICLE TYPE has been updated to VEHICLEs and VEHICLE TYPEs (multiple possible). Furthermore, this is a small extension to Transmodel (or a more direct access, avoiding the need to walk through the object hierarchy). It's fine an useful to me, but probably need double check.