### PR TITLE
Labelling v2.0 changes, third series

### DIFF
--- a/xsd/netex_framework/netex_frames/netex_resourceFrame_version.xsd
+++ b/xsd/netex_framework/netex_frames/netex_resourceFrame_version.xsd
@@ -138,7 +138,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="responsibilityRoles" type="responsibilityRolesInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>RESPONSIBILITY Roles used in frame.</xsd:documentation>
+					<xsd:documentation>RESPONSIBILITY roles used in frame. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="responsibilitySets" type="responsibilitySetsInFrame_RelStructure" minOccurs="0">

--- a/xsd/netex_framework/netex_genericFramework/netex_accessibility/netex_acsb_limitations.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_accessibility/netex_acsb_limitations.xsd
@@ -137,7 +137,7 @@ Rail transport, Roads and Road transport
 	</xsd:element>
 	<xsd:element name="StairFreeAccess" type="LimitationStatusEnumeration" default="unknown">
 		<xsd:annotation>
-			<xsd:documentation>Whether a PLACE has stair free access, in comparison with step free access one single step in the route is allowed.</xsd:documentation>
+			<xsd:documentation>Whether a PLACE has stair free access, in comparison with step free access one single step in the route is allowed. +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:element name="EscalatorFreeAccess" type="LimitationStatusEnumeration" default="unknown">

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
@@ -127,7 +127,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:choice minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Use gml:MultiSurface if the Zone contains multiple non-continuous areas, e.g. a coastline with islands.</xsd:documentation>
+					<xsd:documentation>Use gml:MultiSurface if the Zone contains multiple non-continuous areas, e.g. a coastline with islands. +v2.0</xsd:documentation>
 				</xsd:annotation>
 				<xsd:element ref="gml:Polygon"/>
 				<xsd:element ref="gml:MultiSurface"/>
@@ -253,7 +253,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="PublicCode" type="PublicCodeStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Public identifier code of TARIFF ZONE.</xsd:documentation>
+					<xsd:documentation>Public identifier code of TARIFF ZONE. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_responsibility/netex_relationship_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_relationship_support.xsd
@@ -114,7 +114,7 @@ Rail transport, Roads and Road transport
 				</xsd:attribute>
 				<xsd:attribute name="uri" type="xsd:anyURI" use="optional">
 					<xsd:annotation>
-						<xsd:documentation>Location of the external entity.</xsd:documentation>
+						<xsd:documentation>Location of the external entity. +v2.0</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -78,7 +78,7 @@
 		<xsd:sequence>
 			<xsd:element name="deckPlans" type="deckPlans_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>A List OF DECK PLANs</xsd:documentation>
+					<xsd:documentation>A List OF DECK PLANs. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_environment_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_environment_support.xsd
@@ -153,7 +153,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="FlooringStatus" type="FlooringStatusEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Status of the flooring.</xsd:documentation>
+					<xsd:documentation>Status of the flooring. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="RightSideBorder" type="BorderTypeEnumeration" minOccurs="0">
@@ -173,7 +173,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="TactileWarningStripContrast" type="xsd:boolean" minOccurs="0" default="true">
 				<xsd:annotation>
-					<xsd:documentation>Indicates whether the color of the possible warning strip is sufficiently contrasted with the color of the floor.</xsd:documentation>
+					<xsd:documentation>Indicates whether the color of the possible warning strip is sufficiently contrasted with the color of the floor. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="TactileGuidingStrip" type="xsd:boolean" minOccurs="0">
@@ -183,7 +183,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="TactileGuidingStripStatus" type="TactileGuidingStripStatusEnumeration" minOccurs="0" default="goodAndContrasted">
 				<xsd:annotation>
-					<xsd:documentation>Provides additional details on possible guiding strip.</xsd:documentation>
+					<xsd:documentation>Provides additional details on possible guiding strip. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -224,7 +224,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="BearingCapacity" type="WeightType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Maximum weight that the EQUIPMENT can bear.</xsd:documentation>
+					<xsd:documentation>Maximum weight that the EQUIPMENT can bear. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="NumberOfSteps" type="xsd:nonNegativeInteger" minOccurs="0">
@@ -239,12 +239,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="EquipmentLength" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Length of the EQUIPMENT be it hoist or ramp. When fully extended and only the part outside the VEHICLE.</xsd:documentation>
+					<xsd:documentation>Length of the EQUIPMENT be it hoist or ramp. When fully extended and only the part outside the VEHICLE. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="EquipmentWidth" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Width of the EQUIPMENT be it hoist or ramp. When fully extended and only the part outside the VEHICLE.</xsd:documentation>
+					<xsd:documentation>Width of the EQUIPMENT be it hoist or ramp. When fully extended and only the part outside the VEHICLE. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="GapToPlatform" type="LengthType" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
@@ -686,9 +686,21 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="networkStatus"/>
 			<xsd:enumeration value="realTimeDisruptions"/>
 			<xsd:enumeration value="realTimeDepartures"/>
-			<xsd:enumeration value="stationMap"/>
-			<xsd:enumeration value="acousticStationMap"/>
-			<xsd:enumeration value="tactileStationMap"/>
+			<xsd:enumeration value="stationMap">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="acousticStationMap">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="tactileStationMap">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>

--- a/xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_support.xsd
@@ -348,7 +348,11 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="ownCar"/>
-			<xsd:enumeration value="privateLift"/>
+			<xsd:enumeration value="privateLift">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<!-- ======================================================================= -->

--- a/xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_version.xsd
@@ -43,12 +43,12 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="openModes" type="openModesRelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>OPEN MODES in FRAME</xsd:documentation>
+					<xsd:documentation>OPEN MODES in FRAME. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="modesOfOperation" type="modesOfOperationRelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>MODES OF OPERATION in frame.</xsd:documentation>
+					<xsd:documentation>MODES OF OPERATION in frame. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_mode_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_mode_support.xsd
@@ -88,9 +88,21 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="shuttle"/>
 			<xsd:enumeration value="ski"/>
 			<xsd:enumeration value="skate"/>
-			<xsd:enumeration value="motorcycle"/>
-			<xsd:enumeration value="scooter"/>
-			<xsd:enumeration value="wheelchair"/>
+			<xsd:enumeration value="motorcycle">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="scooter">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="wheelchair">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="AccessModeListOfEnumerations">

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_fleetEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_fleetEquipment_version.xsd
@@ -68,8 +68,16 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
-					<xsd:element ref="CarModelProfile"/>
-					<xsd:element ref="CycleModelProfile"/>
+					<xsd:element ref="CarModelProfile">
+						<xsd:annotation>
+							<xsd:documentation>+v1.2.2</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element ref="CycleModelProfile">
+						<xsd:annotation>
+							<xsd:documentation>+v1.2.2</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_version.xsd
@@ -267,7 +267,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MaximumBookingPeriod" type="xsd:duration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Maximum interval in advance of departure day or time that Service may be ordered. +V1.2..2</xsd:documentation>
+					<xsd:documentation>Maximum interval in advance of departure day or time that Service may be ordered. +V1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="BookingUrl" type="InfoLinkStructure" minOccurs="0">
@@ -333,7 +333,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MaximumBookingPeriod" type="xsd:duration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Maximum interval in advance of departure day or time that a service may be ordered. +V1.2..2</xsd:documentation>
+					<xsd:documentation>Maximum interval in advance of departure day or time that a service may be ordered. +V1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="BookingUrl" type="InfoLinkStructure" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_submode_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_submode_version.xsd
@@ -207,7 +207,7 @@ Service mode</xsd:documentation>
 			</xsd:enumeration>
 			<xsd:enumeration value="largeVehicleTransportRailService">
 				<xsd:annotation>
-					<xsd:documentation>carTransportRailService that allows for bigger vehicles than normal cars (e.g. truck, bus).</xsd:documentation>
+					<xsd:documentation>carTransportRailService that allows for bigger vehicles than normal cars (e.g. truck, bus). +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="touristRailway">
@@ -432,7 +432,7 @@ Local train adapted for running in mountain railway lines.</xsd:documentation>
 			<xsd:enumeration value="dragLift"/>
 			<xsd:enumeration value="paternoster">
 				<xsd:annotation>
-					<xsd:documentation>A paternoster lift is a vertical passenger lift which consists of a chain of open compartments that passengers step into as it passes.</xsd:documentation>
+					<xsd:documentation>A paternoster lift is a vertical passenger lift which consists of a chain of open compartments that passengers step into as it passes. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="telecabinLink">

--- a/xsd/netex_framework/netex_reusableComponents/netex_topographicPlace_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_topographicPlace_support.xsd
@@ -64,9 +64,21 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Allowed values for classifying TOPOGRAPHIC PLACEs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
-			<xsd:enumeration value="continent"/>
-			<xsd:enumeration value="interregion"/>
-			<xsd:enumeration value="country"/>
+			<xsd:enumeration value="continent">
+				<xsd:annotation>
+					<xsd:documentation>+v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="interregion">
+				<xsd:annotation>
+					<xsd:documentation>+v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="country">
+				<xsd:annotation>
+					<xsd:documentation>+v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="principality"/>
 			<xsd:enumeration value="state"/>
 			<xsd:enumeration value="province">
@@ -83,7 +95,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Locality is a city.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
-			<xsd:enumeration value="municipality"/>
+			<xsd:enumeration value="municipality">
+				<xsd:annotation>
+					<xsd:documentation>+v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="quarter"/>
 			<xsd:enumeration value="suburb">
 				<xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_trainElement_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_trainElement_support.xsd
@@ -182,7 +182,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="carriage"/>
 			<xsd:enumeration value="engine"/>
 			<xsd:enumeration value="carTransporter"/>
-			<xsd:enumeration value="largeVehicleTransporter"/>
+			<xsd:enumeration value="largeVehicleTransporter">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="sleeperCarriage"/>
 			<xsd:enumeration value="luggageVan"/>
 			<xsd:enumeration value="restaurantCarriage"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
@@ -157,7 +157,11 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="VehicleEquipmentProfile"/>
-					<xsd:element ref="RechargingEquipmentProfile"/>
+					<xsd:element ref="RechargingEquipmentProfile">
+						<xsd:annotation>
+							<xsd:documentation>+v1.2.2</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -764,12 +764,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="PramPlaceCapacity" type="NumberOfPassengers" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>The number of places on the vehicle that are suitable for prams.</xsd:documentation>
+					<xsd:documentation>The number of places on the vehicle that are suitable for prams. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="BicycleRackCapacity" type="NumberOfPassengers" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>The number of bicycle racks on the vehicle. Also non-rack places should be counted here. The name might change in future to BicycleCapacity.</xsd:documentation>
+					<xsd:documentation>The number of bicycle racks on the vehicle. Also non-rack places should be counted here. The name might change in future to BicycleCapacity. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_1/part1_frames/netex_siteFrame_version.xsd
+++ b/xsd/netex_part_1/part1_frames/netex_siteFrame_version.xsd
@@ -181,7 +181,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="taxiRanks" type="taxiRanksInFrame_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>TAXI RANKs in frame.</xsd:documentation>
+					<xsd:documentation>TAXI RANKs in frame. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="pointsOfInterest" type="pointsOfInterestInFrame_RelStructure" minOccurs="0">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -1002,7 +1002,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="LiftCallEquipment" substitutionGroup="AccessEquipment">
 		<xsd:annotation>
-			<xsd:documentation>Specialisation of PLACE ACCESS EQUIPMENT for calling LIFTs (provides specific characteristics that may differ from floor to floor like button height, door, etc.).</xsd:documentation>
+			<xsd:documentation>Specialisation of PLACE ACCESS EQUIPMENT for calling LIFTs (provides specific characteristics that may differ from floor to floor like button height, door, etc.). +v1.3.1</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -1068,7 +1068,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="GroundMarkAlignedWithButton" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Indicates a tactile marker on floor under the buttons (or aligned with). +v1.1</xsd:documentation>
+					<xsd:documentation>Indicates a tactile marker on floor under the buttons (or aligned with).</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="AudioAnnouncements" type="xsd:boolean" minOccurs="0">
@@ -1078,7 +1078,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MagneticInductionLoop" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Indicates existence of a magnetic induction loop. +v1.1</xsd:documentation>
+					<xsd:documentation>Indicates existence of a magnetic induction loop.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="DoorOrientation" type="CompassBearing8Enumeration" minOccurs="0" maxOccurs="2">
@@ -1088,7 +1088,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="MonitoringRemoteControl" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether the lift is equipped with a remote operation control system</xsd:documentation>
+					<xsd:documentation>Whether the lift is equipped with a remote operation control system.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -1294,18 +1294,18 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="DoorOrientation" type="CompassBearing8Enumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Pointing towards outside (or, for doors within a StopPlace, to label the side as outside).</xsd:documentation>
+					<xsd:documentation>Pointing towards outside (or, for doors within a StopPlace, to label the side as outside). +v1.3.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="DoorHandleOutside" type="DoorHandleEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Type of door handle.</xsd:documentation>
+					<xsd:documentation>Type of door handle. +v1.3.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="DoorHandleInside" type="DoorHandleEnumeration" minOccurs="0"/>
 			<xsd:element name="KeptOpen" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether the door is kept open.</xsd:documentation>
+					<xsd:documentation>Whether the door is kept open. +v1.3.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="RevolvingDoor" type="xsd:boolean" minOccurs="0">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
@@ -587,7 +587,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="RelativeLevelOrder" type="xsd:integer" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Order of LEVELs. The level numbers are not absolute, but only give a relative order within the SITE. 0 should be the ground floor, even when it is often difficult to determine which one that is in a complex structure. Complex buildings can be modelled with multiple SITEs and referenced by SiteRef.</xsd:documentation>
+					<xsd:documentation>Order of LEVELs. The level numbers are not absolute, but only give a relative order within the SITE. 0 should be the ground floor, even when it is often difficult to determine which one that is in a complex structure. Complex buildings can be modelled with multiple SITEs and referenced by SiteRef. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="AccessibilityAssessment" type="AccessibilityAssessment_VersionedChildStructure" minOccurs="0">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
@@ -371,7 +371,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="tramStop"/>
 			<xsd:enumeration value="boatQuay"/>
 			<xsd:enumeration value="ferryLanding"/>
-			<xsd:enumeration value="telecabinPlatform"/>
+			<xsd:enumeration value="telecabinPlatform">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="taxiStand"/>
 			<xsd:enumeration value="setDownPlace"/>
 			<xsd:enumeration value="vehicleLoadingPlace"/>
@@ -379,12 +383,12 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="multimodal"/>
 			<xsd:enumeration value="busStopWithinRoadwayBoarding">
 				<xsd:annotation>
-					<xsd:documentation>Bus stop directly on street. This means people waiting to board will literally be standing on the street. The usual elements of a stop (pole, bank, information) usually are present at the road side. Often there are markings on the floor and sometimes also traffic lights stopping the traffic for boarding and alighting. Often the area to wait is on the side of the road and the BOARDING POSITION could indicate, where to board/alight. However, BOARDING POSITIONs are often not modeled.</xsd:documentation>
+					<xsd:documentation>Bus stop directly on street. This means people waiting to board will literally be standing on the street. The usual elements of a stop (pole, bank, information) usually are present at the road side. Often there are markings on the floor and sometimes also traffic lights stopping the traffic for boarding and alighting. Often the area to wait is on the side of the road and the BOARDING POSITION could indicate, where to board/alight. However, BOARDING POSITIONs are often not modeled. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="tramStopWithinRoadwayBoarding">
 				<xsd:annotation>
-					<xsd:documentation>Tram stop directly on street. This means people waiting to board will literally be standing on the street. The usual elements of a stop (pole, bank, information) usually are present at the road side. Often there are markings on the floor and sometimes also traffic lights stopping the traffic for boarding and alighting. Often the area to wait is on the side of the road and the BOARDING POSITION could indicate, where to board/alight. However, BOARDING POSITIONs are often not modeled.</xsd:documentation>
+					<xsd:documentation>Tram stop directly on street. This means people waiting to board will literally be standing on the street. The usual elements of a stop (pole, bank, information) usually are present at the road side. Often there are markings on the floor and sometimes also traffic lights stopping the traffic for boarding and alighting. Often the area to wait is on the side of the road and the BOARDING POSITION could indicate, where to board/alight. However, BOARDING POSITIONs are often not modeled. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="other"/>
@@ -403,7 +407,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="positionAtBusStop"/>
 			<xsd:enumeration value="boatGangway"/>
 			<xsd:enumeration value="ferryGangway"/>
-			<xsd:enumeration value="telecabinPlatform"/>
+			<xsd:enumeration value="telecabinPlatform">
+				<xsd:annotation>
+					<xsd:documentation>+v1.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="setDownPoint"/>
 			<xsd:enumeration value="taxiBay"/>
 			<xsd:enumeration value="vehicleLoadingRamp"/>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
@@ -1441,10 +1441,14 @@ contained within its parent QUAY.</xsd:documentation>
 			<xsd:element ref="gml:Polygon" minOccurs="0"/>
 			<xsd:element name="TransportMode" type="AllVehicleModesOfTransportEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Primary MODE of Vehicle transport associated by this component.</xsd:documentation>
+					<xsd:documentation>Primary MODE of Vehicle transport associated by this component. +v1.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:group ref="PtSubmodeChoiceGroup" minOccurs="0"/>
+			<xsd:group ref="PtSubmodeChoiceGroup" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>PUBLIC TRANSPORT subMODE. +v1.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:group>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->

--- a/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
@@ -398,7 +398,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="OperatorRef" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>An OPERATOR should be set, even when the same as the AUTHORITY. In some cases OPERATOR or AUTHORITY are managed through a ResponsibilitySet. However, for compatibility OperatorRef and AuthorityRef still should be filled in.</xsd:documentation>
+					<xsd:documentation>An OPERATOR should be set, even when the same as the AUTHORITY. In some cases OPERATOR or AUTHORITY are managed through a ResponsibilitySet. However, for compatibility OperatorRef and AuthorityRef still should be filled in. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="additionalOperators" type="transportOrganisationRefs_RelStructure" minOccurs="0">

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_passengerInformationEquipment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_passengerInformationEquipment_version.xsd
@@ -251,7 +251,7 @@ LOGICAL DISPLAY corresponds to a SIRI STOP MONITORING point.</xsd:documentation>
 			<xsd:element ref="TypeOfPassengerInformationEquipmentRef" minOccurs="0"/>
 			<xsd:group ref="TicketingEquipmentAccessibilityGroup" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Detailed information about accessibility uses. Borrowed from TicketOffice.</xsd:documentation>
+					<xsd:documentation>Detailed information about accessibility uses. Borrowed from TicketOffice. +v1.3.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
 			<xsd:element ref="PassengerInformationFacilityList" minOccurs="0">

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_routingConstraint_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_routingConstraint_version.xsd
@@ -249,7 +249,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Excluded other JOURNEY PATTERNs.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="LineRef" minOccurs="0"/>
+			<xsd:element ref="LineRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_support.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_support.xsd
@@ -447,7 +447,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="speakToDriverOnboard">
 				<xsd:annotation>
-					<xsd:documentation>Tell the driver to request stop. Mainly used for on demand traffic, where the route depends on where passengers want to leave the vehicle.</xsd:documentation>
+					<xsd:documentation>Tell the driver to request stop. Mainly used for on demand traffic, where the route depends on where passengers want to leave the vehicle. +v1.3.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="other">

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
@@ -356,17 +356,17 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="RequestMethodType" type="RequestMethodTypeEnumeration" default="noneRequired" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Method of request stop. Default is noneRequired. DEPRECATED: USE BoardingRquestMethod OR AlightingRequestMethod INSTEAD.</xsd:documentation>
+					<xsd:documentation>Method of request stop. Default is noneRequired. DEPRECATED: USE BoardingRquestMethod OR AlightingRequestMethod INSTEAD. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="BoardingRequestMethod" type="RequestMethodTypeListOfEnumerations" default="noneRequired" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Methods to Request Stop for boarding in this particular service pattern; Default is noneRequired.</xsd:documentation>
+					<xsd:documentation>Methods to Request Stop for boarding in this particular service pattern; Default is noneRequired. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="AlightingRequestMethod" type="RequestMethodTypeListOfEnumerations" default="noneRequired" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Methods to Request Stop for alighting in this particular service pattern; Default is noneRequired.</xsd:documentation>
+					<xsd:documentation>Methods to Request Stop for alighting in this particular service pattern; Default is noneRequired. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -595,12 +595,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="Submode" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>SUBMODE of end Point of CONNECTION. SUBMODE of SCHEDULED STOP POINT can be derived.</xsd:documentation>
+					<xsd:documentation>SUBMODE of end Point of CONNECTION. SUBMODE of SCHEDULED STOP POINT can be derived. +v1.2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TransportOrganisationRef" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>TransportOrganisation to which the end of CONNECTION applies.</xsd:documentation>
+					<xsd:documentation>TransportOrganisation to which the end of CONNECTION applies. +v1.2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:choice>
@@ -845,12 +845,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="AlightingSideInDirectionOfTravel" type="SideInDirectionOfTravelEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>On which side the vehicle can be alighted on this stop in the direction of travel. This is often not relevant. And it is difficult to define this from the QUAY when the direction of travel is not known.</xsd:documentation>
+					<xsd:documentation>On which side the vehicle can be alighted on this stop in the direction of travel. This is often not relevant. And it is difficult to define this from the QUAY when the direction of travel is not known. +v1.3.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="BoardingSideInDirectionOfTravel" type="SideInDirectionOfTravelEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>On which side the vehicle can be boarded on this stop in the direction of travel.</xsd:documentation>
+					<xsd:documentation>On which side the vehicle can be boarded on this stop in the direction of travel. +v1.3.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="StopPointInPatternPropertiesGroup"/>
@@ -883,17 +883,17 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="RequestMethod" type="RequestMethodTypeEnumeration" default="noneRequired" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Method to Request Stop in this particular service pattern; if none specified, as as per stop. DEPRECATED: USE BoardingRquestMethod OR AlightingRequestMethod INSTEAD.</xsd:documentation>
+					<xsd:documentation>Method to Request Stop in this particular service pattern; if none specified, as as per stop. DEPRECATED: USE BoardingRquestMethod OR AlightingRequestMethod INSTEAD. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="BoardingRequestMethod" type="RequestMethodTypeListOfEnumerations" default="noneRequired" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Methods to Request Stop for boarding in this particular service pattern; Default is noneRequired.</xsd:documentation>
+					<xsd:documentation>Methods to Request Stop for boarding in this particular service pattern; Default is noneRequired. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="AlightingRequestMethod" type="RequestMethodTypeListOfEnumerations" default="noneRequired" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Methods to Request Stop for alighting in this particular service pattern; Default is noneRequired.</xsd:documentation>
+					<xsd:documentation>Methods to Request Stop for alighting in this particular service pattern; Default is noneRequired. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="StopUse" type="StopUseEnumeration" minOccurs="0">

--- a/xsd/netex_part_2/part2_frames/netex_serviceFrame_version.xsd
+++ b/xsd/netex_part_2/part2_frames/netex_serviceFrame_version.xsd
@@ -132,7 +132,11 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="RouteInFrameGroup"/>
 			<xsd:group ref="FlexibleRouteInFrameGroup"/>
 			<xsd:group ref="SectionInFrameGroup"/>
-			<xsd:group ref="ProjectionInFrameGroup"/>
+			<xsd:group ref="ProjectionInFrameGroup">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:group>
 			<xsd:group ref="CommonPointAndLInkFrameGroup"/>
 			<xsd:group ref="LineInFrameGroup"/>
 			<xsd:group ref="LineNetworkInFrameGroup"/>


### PR DESCRIPTION
3rd series series following #762 and #764. 

I am through with the complete  part 1 of the documentation. I only added labels for changes found in the document that  are linked to a PR  (i.e., that have a comment mentioning a PR).

- That means, uncommented changes have not been treated. There are many of them.
- For the pending PRs, we have to take care adding labels when merging and documenting them.

I was unsure what to do with changes preceding V2.0. Not in a consistent manner, I sometimes added +v1.3.1 or +v1.2.2 labels mainly. But was hesitating whether it makes sense to have some sparse +v1.3.1 labels at all because there haven't been many of them until now. The version is often just my best guess (v1.3.1, v1.3.0, v1.2.3, …) and should be reviewed.

I put "needs documentation update" on this PR because if you want me to remove or change some of the labels then this needs to be duplicated in the documentation.