### PR TITLE
Cleaning up PassengerStopAssignment

### DIFF
--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
@@ -231,12 +231,12 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>STOP PLACE to which SCHEDULED STOP POINT is to be assigned.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="QuayRef">
+			<xsd:element ref="QuayRef" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>QUAY to which SCHEDULED STOP POINT is to be assigned.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="BoardingPositionRef">
+			<xsd:element ref="BoardingPositionRef" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>BOARDING POSITION to which SCHEDULED STOP POINT is to be assigned.</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
@@ -137,13 +137,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>DEPRECATED - use privateCodes. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:choice minOccurs="0">
+			<xsd:element ref="ScheduledStopPointRef" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Reference or inline declaration of SCHEDULED STOP POINT which is being assigned.</xsd:documentation>
+					<xsd:documentation>Reference  of SCHEDULED STOP POINT which is being assigned.</xsd:documentation>
 				</xsd:annotation>
-				<xsd:element ref="ScheduledStopPointRef"/>
-				<xsd:element ref="ScheduledStopPoint"/>
-			</xsd:choice>
+			</xsd:element>
 			<xsd:group ref="StopAssignmentDirectionGroup">
 				<xsd:annotation>
 					<xsd:documentation>Directional elements for a STOP ASSIGNMENT. +v2.0</xsd:documentation>
@@ -228,27 +226,21 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements for a PASSENGER STOP ASSIGNMENT. Either StopPlace(Ref) or Quay(Ref) must at least be present. Best practice is to always have at least the StopPlace(Ref). It is also prefered that the Ref are used and the Quay/StopPlace are defined on their own in the appropriate Frame.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:choice minOccurs="0">
+			<xsd:element ref="StopPlaceRef" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>STOP PLACE to which SCHEDULED STOP POINT is to be assigned.</xsd:documentation>
 				</xsd:annotation>
-				<xsd:element ref="StopPlaceRef"/>
-				<xsd:element ref="StopPlace"/>
-			</xsd:choice>
-			<xsd:choice minOccurs="0">
+			</xsd:element>
+			<xsd:element ref="QuayRef">
 				<xsd:annotation>
 					<xsd:documentation>QUAY to which SCHEDULED STOP POINT is to be assigned.</xsd:documentation>
 				</xsd:annotation>
-				<xsd:element ref="QuayRef"/>
-				<xsd:element ref="Quay"/>
-			</xsd:choice>
-			<xsd:choice minOccurs="0">
+			</xsd:element>
+			<xsd:element ref="BoardingPositionRef">
 				<xsd:annotation>
 					<xsd:documentation>BOARDING POSITION to which SCHEDULED STOP POINT is to be assigned.</xsd:documentation>
 				</xsd:annotation>
-				<xsd:element ref="BoardingPositionRef"/>
-				<xsd:element ref="BoardingPosition"/>
-			</xsd:choice>
+			</xsd:element>
 			<xsd:choice minOccurs="0">
 				<xsd:element name="passengerBoardingPositionAssignments" minOccurs="0" maxOccurs="unbounded">
 					<xsd:annotation>


### PR DESCRIPTION
Currently it would be allowed to create SSP, SP, Quay and BoardingPosition in PassengerStopAssignments. In my view this is unnecessary and evil as if somebody really would do it, then we have even more problems in finding the stuff.