### PR TITLE
Stratification of transport mode enumerations

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_access_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_access_version.xsd
@@ -148,9 +148,9 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Type for ACCESS link end.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="TransportMode" type="AllModesEnumeration" default="all" minOccurs="0">
+			<xsd:element name="TransportMode" type="AllModesOfTransportEnumeration" default="all" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Identifier of MODE of end point of ACCESS link. Default is all modes.</xsd:documentation>
+					<xsd:documentation>Identifier of MODE of TRANSPORT of end point of ACCESS link. Default is all modes.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="PlaceRef" type="PlaceRefStructure" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_mode_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_mode_support.xsd
@@ -112,41 +112,13 @@ Rail transport, Roads and Road transport
 		<xsd:list itemType="AccessModeEnumeration"/>
 	</xsd:simpleType>
 	<!--======Vehicle===================================================================================-->
-	<xsd:element name="VehicleMode" type="AllModesEnumeration">
+	<xsd:element name="VehicleMode" type="AllVehicleModesOfTransportEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>VEHICLE MODE: a characterisation of the operation according to the means of transport (bus, tram, metro, train, ferry, ship).</xsd:documentation>
+			<xsd:documentation>VEHICLE TRANSPORT MODE: a characterisation of the operation according to the means of transport (bus, tram, metro, train, ferry, ship).</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:simpleType name="VehicleModeEnumeration">
-		<xsd:annotation>
-			<xsd:documentation>Allowed values for MODES of Public Transport applicable to timetabled public transport.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="xsd:NMTOKEN">
-			<xsd:enumeration value="air"/>
-			<xsd:enumeration value="bus"/>
-			<xsd:enumeration value="coach"/>
-			<xsd:enumeration value="ferry"/>
-			<xsd:enumeration value="metro"/>
-			<xsd:enumeration value="rail"/>
-			<xsd:enumeration value="trolleyBus"/>
-			<xsd:enumeration value="tram"/>
-			<xsd:enumeration value="water"/>
-			<xsd:enumeration value="cableway"/>
-			<xsd:enumeration value="funicular"/>
-			<xsd:enumeration value="lift"/>
-			<xsd:enumeration value="snowAndIce"/>
-			<xsd:enumeration value="other"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="VehicleModeListOfEnumerations">
-		<xsd:annotation>
-			<xsd:documentation>Allowed values for List of PT MODES of transport applicable to timetabled public transport.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:list itemType="VehicleModeEnumeration"/>
-	</xsd:simpleType>
 	<!--======Modes===================================================================================-->
-	<!--======Modes===================================================================================-->
-	<xsd:element name="RoadVehicleMode" type="AllModesEnumeration">
+	<xsd:element name="RoadVehicleMode" type="RoadVehicleModeEnumeration">
 		<xsd:annotation>
 			<xsd:documentation>Road Vehicle MODE: a characterisation of the operation according to the means of transport (bus, tram, coach).</xsd:documentation>
 		</xsd:annotation>
@@ -174,9 +146,9 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>All MODEs including vehicle transport and self drive.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:simpleType name="AllModesEnumeration">
+	<xsd:simpleType name="AllModesOfTransportEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for r MODES: TPEG pti_table 01.</xsd:documentation>
+			<xsd:documentation>Allowed values for MODES of TRANSPORT: TPEG pti_table 01.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="all"/>
@@ -213,15 +185,15 @@ Rail transport, Roads and Road transport
 			<!-- NOT IN tpeg -->
 		</xsd:restriction>
 	</xsd:simpleType>
-	<xsd:simpleType name="AllModesListOfEnumerations">
+	<xsd:simpleType name="AllModesOfTransportListOfEnumerations">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for List of ALL MODES of transport.</xsd:documentation>
+			<xsd:documentation>Allowed values for List of ALL MODES of TRANSPORT.</xsd:documentation>
 		</xsd:annotation>
-		<xsd:list itemType="AllModesEnumeration"/>
+		<xsd:list itemType="AllModesOfTransportEnumeration"/>
 	</xsd:simpleType>
-	<xsd:simpleType name="AllVehicleModesListOfEnumerations">
+	<xsd:simpleType name="AllVehicleModesOfTransportListOfEnumerations">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for List of PT MODES of transport applicable to timetabled public transport.</xsd:documentation>
+			<xsd:documentation>Allowed values for List of PT MODES of TRANSPORT applicable to timetabled public transport.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:list itemType="AllVehicleModesOfTransportEnumeration"/>
 	</xsd:simpleType>

--- a/xsd/netex_framework/netex_reusableComponents/netex_mode_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_mode_version.xsd
@@ -43,9 +43,9 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements for a Transport MODE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="TransportMode" type="AllModesEnumeration">
+			<xsd:element name="TransportMode" type="AllModesOfTransportEnumeration">
 				<xsd:annotation>
-					<xsd:documentation>Categorisation of mode.</xsd:documentation>
+					<xsd:documentation>Categorisation of MODE of TRANSPORT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="AllSubmodeChoiceGroup"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_version.xsd
@@ -276,9 +276,9 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>MODE  elements of an TRANSPORT ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="PrimaryMode" type="AllModesEnumeration" minOccurs="0">
+			<xsd:element name="PrimaryMode" type="AllModesOfTransportEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Primary transport MODE of TRANSPORT ORGANISATION</xsd:documentation>
+					<xsd:documentation>Primary TRANSPORT MODE of TRANSPORT ORGANISATION</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="AllSubmodeChoiceGroup" minOccurs="0"/>
@@ -731,7 +731,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements for an TRANSPORT ADMINISTRATIVE  ZONE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="VehicleModes" type="AllModesListOfEnumerations" default="all" minOccurs="0">
+			<xsd:element name="VehicleModes" type="AllVehicleModesOfTransportListOfEnumerations" default="all" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>TRANSPORT MODEs for which this zone applies. Default is all.</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentTicketing_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentTicketing_version.xsd
@@ -114,9 +114,9 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements for a TICKETING EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="VehicleModes" type="AllModesListOfEnumerations" minOccurs="0">
+			<xsd:element name="VehicleModes" type="AllVehicleModesOfTransportListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Modes for which ticketing services apply.</xsd:documentation>
+					<xsd:documentation>MODES of TRANSPORT for which ticketing services apply.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="TicketingEquipmentPropertiesGroup"/>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_localService_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_localService_version.xsd
@@ -178,7 +178,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements for a TICKETING SERVICE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="VehicleModes" type="VehicleModeListOfEnumerations" minOccurs="0">
+			<xsd:element name="VehicleModes" type="AllVehicleModesOfTransportListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Modes for which TICKETING SERVICEs apply.</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
@@ -350,7 +350,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Mode Elements of a SITE COMPONENT. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
-			<xsd:element name="OtherTransportModes" type="VehicleModeListOfEnumerations" minOccurs="0">
+			<xsd:element name="OtherTransportModes" type="AllVehicleModesOfTransportListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Public transport MODES which may be accessed through associated place.</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_lineNetwork_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_lineNetwork_version.xsd
@@ -312,7 +312,7 @@ Rail transport, Roads and Road transport
 	</xsd:element>
 	<xsd:complexType name="PointOnLineSection_VersionedChildStructure" abstract="false">
 		<xsd:annotation>
-			<xsd:documentation>Type for a  POINT on LINE SECTION.</xsd:documentation>
+			<xsd:documentation>Type for a POINT on LINE SECTION.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="PointOnSection_VersionedChildStructure">
@@ -324,29 +324,29 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:group name="PointOnLineSectionGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for a POINT ON  LINE SECTION.</xsd:documentation>
+			<xsd:documentation>Elements for a POINT ON LINE SECTION.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="LineSectionPointType" type="LineSectionPointTypeEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Classification of Point Member.</xsd:documentation>
+					<xsd:documentation>Classification of POINT member.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ShowAsAccessible" type="xsd:boolean" default="true" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether point is to be shown as Accessible.</xsd:documentation>
+					<xsd:documentation>Whether POINT is to be shown as accessible.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="ConnectingVehicleModes" type="VehicleModeListOfEnumerations" minOccurs="0">
+			<xsd:element name="ConnectingVehicleModes" type="AllVehicleModesOfTransportListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Connecting Vehicle Modes to show for Point if different from  point.</xsd:documentation>
+					<xsd:documentation>Connecting VEHICLE MODEs of TRANSPORT to show for POINT if different from POINT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:element name="LineSectionPointMember" abstract="false" substitutionGroup="CommonSectionPointMember">
 		<xsd:annotation>
-			<xsd:documentation>[DEPRECATED use POINT ON LINE SECTION INSTEAD ] An ordered set of LINKs for a line.</xsd:documentation>
+			<xsd:documentation>[DEPRECATED - use POINT ON LINE SECTION INSTEAD] An ordered set of LINKs for a line.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_1/part1_networkDescription/netex_route_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_route_version.xsd
@@ -593,7 +593,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="RouteRef" minOccurs="0"/>
 			<xsd:element name="VehicleMode" type="AllVehicleModesOfTransportEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Mode of ROUTE.</xsd:documentation>
+					<xsd:documentation>MODE of TRANSPORT of ROUTE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="Name" type="MultilingualString" minOccurs="0">

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
@@ -334,9 +334,9 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements for properties of a SCHEDULED STOP POINT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="VehicleModes" type="VehicleModeListOfEnumerations" minOccurs="0">
+			<xsd:element name="VehicleModes" type="AllVehicleModesOfTransportListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>TRANSPORT MODE or MODES of STOP POINT.</xsd:documentation>
+					<xsd:documentation>TRANSPORT MODE or TRANPORT MODEs of STOP POINT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="ForAlighting" type="xsd:boolean" minOccurs="0">
@@ -588,7 +588,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Type for a CONNECTION END.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="TransportMode" type="AllModesEnumeration" minOccurs="0">
+			<xsd:element name="TransportMode" type="AllModesOfTransportEnumeration" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>MODE of end Point of CONNECTION. Default is all modes, MODE of SCHEDULED STOP POINT can be derived.</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
+++ b/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
@@ -134,9 +134,9 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="LineView" minOccurs="0"/>
 			<xsd:element ref="OperatorView" minOccurs="0"/>
 			<xsd:element ref="ServiceCalendarFrameRef" minOccurs="0"/>
-			<xsd:element name="DefaultMode" type="VehicleModeEnumeration" minOccurs="0">
+			<xsd:element name="DefaultMode" type="AllVehicleModesOfTransportEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Default VEHICLE MODE to use on JOURNEYs in TIMETABLE.</xsd:documentation>
+					<xsd:documentation>Default VEHICLE MODE of TRANSPORT to use on JOURNEYs in TIMETABLE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="JourneyAccountingRef" minOccurs="0"/>
@@ -154,7 +154,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Additional descriptive properties of TIMETABLE FRAME.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="VehicleModes" type="VehicleModeListOfEnumerations" minOccurs="0">
+			<xsd:element name="VehicleModes" type="AllVehicleModesOfTransportListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Modes of VEHICLE JOURNEYs in timetable.</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_part_2/part2_frames/netex_vehicleScheduleFrame_version.xsd
+++ b/xsd/netex_part_2/part2_frames/netex_vehicleScheduleFrame_version.xsd
@@ -59,9 +59,9 @@
 			<xsd:documentation>Additional descriptive properties of a VEHICLE SCHEDULE FRAME.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="VehicleModes" type="VehicleModeListOfEnumerations" minOccurs="0">
+			<xsd:element name="VehicleModes" type="AllVehicleModesOfTransportListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Modes of VEHICLE SCHEDULE.</xsd:documentation>
+					<xsd:documentation>TRANPORT MODEs of VEHICLE SCHEDULE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_2/part2_vehicleService/netex_duty_version.xsd
+++ b/xsd/netex_part_2/part2_vehicleService/netex_duty_version.xsd
@@ -506,9 +506,9 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>How long the DRIVER TRIP takes.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="TransportMode" type="AllModesEnumeration" minOccurs="0">
+			<xsd:element name="TransportMode" type="AllModesOfTransportEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Mode of Transport.</xsd:documentation>
+					<xsd:documentation>MODE of TRANSPORT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -421,12 +421,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:choice>
-				<xsd:element name="VehicleModes" type="VehicleModeListOfEnumerations" minOccurs="0">
+				<xsd:element name="VehicleModes" type="AllVehicleModesOfTransportListOfEnumerations" minOccurs="0">
 					<xsd:annotation>
-						<xsd:documentation>VEHICLE MODEs to which ACCESS RIGHTs apply. DEPRECATED - keep for backwards compatibility. -v1.2.2</xsd:documentation>
+						<xsd:documentation>VEHICLE TRANPORT MODEs to which ACCESS RIGHTs apply. DEPRECATED - keep for backwards compatibility. -v1.2.2</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
-				<xsd:element name="TransportModes" type="AllModesListOfEnumerations" minOccurs="0">
+				<xsd:element name="TransportModes" type="AllModesOfTransportListOfEnumerations" minOccurs="0">
 					<xsd:annotation>
 						<xsd:documentation>Any MODE to which mode validity parameters apply. +v1.2.2</xsd:documentation>
 					</xsd:annotation>
@@ -566,7 +566,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfServiceRef" minOccurs="0"/>
 			<xsd:group ref="EquipmentValidityParametersGroup">
 				<xsd:annotation>
-					<xsd:documentation>EQUIPMENT and LOCAL SERVICE   validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT. +V1.2.2</xsd:documentation>
+					<xsd:documentation>EQUIPMENT and LOCAL SERVICE validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT. +V1.2.2</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
 			<xsd:group ref="SeatingValidityParametersGroup">
@@ -597,7 +597,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="EquipmentValidityParametersGroup">
 		<xsd:annotation>
-			<xsd:documentation>EQUIPMENT and LOCAL SERVICE   validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
+			<xsd:documentation>EQUIPMENT and LOCAL SERVICE validity parameters for ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="VehicleModelProfileRef" minOccurs="0"/>


### PR DESCRIPTION
This resolves issue #772. Stratified `VehicleModeEnumeration, AllVehicleModesOfTransportEnumeration, AllModesEnumeration` to ony two: `AllVehicleModesOfTransportEnumeration` and `AllModesOfTransportEnumeration`.

`VehicleMode` now uniformly maps to `AllVehicleModesOfTransportEnumeration`.
`TransportMode` maps to both `AllVehicleModesOfTransportEnumeration` and `AllModesOfTransportEnumeration`, but context and annotations prevent confusion, in my view. 

The changes should keep backwards compatibilty, though I changed the mappings (to an enumeration type) at a few places where I thought the chosen enumeration likely to be erroneous. I'm going to mark them in this PR.
