### PR TITLE
Remove unused chargingEquipmenProfilesInFrame_RelStructure

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_chargingEquipmentProfile_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_chargingEquipmentProfile_version.xsd
@@ -55,22 +55,6 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>RECHARGING EQUIPMENT PROFILE types for NeTEx.</xsd:documentation>
 	</xsd:annotation>
 	<!-- === VEHICLE RECHARGING EQUIPMENT PROFILE ============================================ -->
-	<xsd:complexType name="chargingEquipmenProfilesInFrame_RelStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for containment in frame of RECHARGING EQUIPMENT PROFILEs.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="containmentAggregationStructure">
-				<xsd:sequence>
-					<xsd:element ref="RechargingEquipmentProfile" maxOccurs="unbounded">
-						<xsd:annotation>
-							<xsd:documentation>Charging equipment profile for VEHICLE.</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
 	<xsd:element name="RechargingEquipmentProfile" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Specialisation of VEHICLE EQUIPMENT PROFILE describing vehicle charging features.</xsd:documentation>


### PR DESCRIPTION
`chargingEquipmenProfilesInFrame_RelStructure` has three flaws: a typo (..EquipmenProf..), it should be renamed to *re*changing..., and it is unused. 

Instead of this structure, we have now `vehicleEquipmentProfilesInFram_RelStructure` that does the job of referencing the `RechargingEquipmentProfile`s.