### PR TITLE
Labelling v2.0 changes, fourth series

### DIFF
--- a/xsd/netex_framework/netex_responsibility/netex_responsibility_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibility_version.xsd
@@ -99,7 +99,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="privateCodes" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>A list of private codes that uniquely identifiy the element. May be used for inter-operating with other (legacy) systems.</xsd:documentation>
+					<xsd:documentation>A list of private codes that uniquely identifiy the element. May be used for inter-operating with other (legacy) systems. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="Extensions" minOccurs="0"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_facility_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_facility_version.xsd
@@ -184,7 +184,11 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="CarServiceFacilityList" minOccurs="0"/>
 			<xsd:element ref="CateringFacilityList" minOccurs="0"/>
-			<xsd:element ref="ClimateControlList" minOccurs="0"/>
+			<xsd:element ref="ClimateControlList" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="FamilyFacilityList" minOccurs="0"/>
 			<xsd:element ref="FareClasses" minOccurs="0">
 				<xsd:annotation>
@@ -192,7 +196,11 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="GenderLimitation" minOccurs="0"/>
-			<xsd:element ref="LightingControlFacilityList" minOccurs="0"/>
+			<xsd:element ref="LightingControlFacilityList" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="MealFacilityList" minOccurs="0"/>
 			<xsd:element ref="MedicalFacilityList" minOccurs="0"/>
 			<xsd:element ref="MobilityFacilityList" minOccurs="0"/>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
@@ -555,7 +555,7 @@ Rail transport, Roads and Road transport
 						</xsd:element>
 						<xsd:element name="Distance" type="DistanceType" minOccurs="0">
 							<xsd:annotation>
-								<xsd:documentation>Distance for TIMING LINK.</xsd:documentation>
+								<xsd:documentation>Distance for TIMING LINK. +v1.2.2</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
 						<xsd:element name="RunTime" type="xsd:duration" minOccurs="0">

--- a/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
+++ b/xsd/netex_part_2/part2_frames/netex_timetableFrame_version.xsd
@@ -123,7 +123,11 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="InterchangeInFrameGroup"/>
 			<xsd:group ref="VehicleTypeInFrameGroup"/>
 			<xsd:group ref="JourneyAccountingInFrameGroup"/>
-			<xsd:group ref="OccupancyViewInFrameGroup"/>
+			<xsd:group ref="OccupancyViewInFrameGroup">
+				<xsd:annotation>
+					<xsd:documentation>+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:group>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="TimetableDefaultsGroup">

--- a/xsd/netex_part_2/part2_journeyTimes/netex_call_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_call_version.xsd
@@ -252,7 +252,7 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="CallPartGroup"/>
 			<xsd:element name="occupancies" type="OccupancyView_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>OCCUPANCYs associated with this journey.</xsd:documentation>
+					<xsd:documentation>OCCUPANCYs associated with this journey. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_coupledJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_coupledJourney_version.xsd
@@ -205,7 +205,7 @@ of the corresponding VEHICLE TYPE. true for forward.</xsd:documentation>
 			</xsd:element>
 			<xsd:element name="occupancies" type="OccupancyView_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>OCCUPANCYs associated with this journey.</xsd:documentation>
+					<xsd:documentation>OCCUPANCYs associated with this journey. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfProductCategoryRef" minOccurs="0"/>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -182,7 +182,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="ServiceAlterationType" type="ServiceAlterationEnumeration" default="planned" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Type of Service alteration. Default is planned.</xsd:documentation>
+					<xsd:documentation>Type of Service alteration. Default is planned. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -195,7 +195,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="JourneyRef" minOccurs="0"/>
 			<xsd:element name="replacedJourneys" type="replacedJourneys_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DATED VEHICLE JOURNEYs for which current VEHICLE JOURNEY is an alteration (i.e. change, replacement, supplement)</xsd:documentation>
+					<xsd:documentation>DATED VEHICLE JOURNEYs for which current VEHICLE JOURNEY is an alteration (i.e. change, replacement, supplement). +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="OperatingDayRef" minOccurs="0">

--- a/xsd/netex_part_2/part2_journeyTimes/netex_journey_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_journey_version.xsd
@@ -137,7 +137,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="occupancies" type="OccupancyView_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>OCCUPANCYs associated with this journey.</xsd:documentation>
+					<xsd:documentation>OCCUPANCYs associated with this JOURNEY. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_passingTimes_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_passingTimes_version.xsd
@@ -205,7 +205,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="occupancies" type="OccupancyView_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>OCCUPANCYs associated with this journey.</xsd:documentation>
+					<xsd:documentation>OCCUPANCYs associated with this journey. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd
@@ -202,7 +202,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="provisional">
 				<xsd:annotation>
-					<xsd:documentation>Provisional service that has not yet been firmly scheduled for the timetable.</xsd:documentation>
+					<xsd:documentation>Provisional service that has not yet been firmly scheduled for the timetable. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="planned">

--- a/xsd/netex_part_2/part2_occupancy/netex_oc_occupancy_support.xsd
+++ b/xsd/netex_part_2/part2_occupancy/netex_oc_occupancy_support.xsd
@@ -5,7 +5,7 @@
 	<!-- ====  INDIVIDUAL TRAVELLER ============================================ -->
 	<xsd:simpleType name="OccupancyEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Passenger load status of a VEHICLE - GTFS-R / TPEG Pts045</xsd:documentation>
+			<xsd:documentation>Passenger load status of a VEHICLE - GTFS-R / TPEG Pts045. +v2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="unknown">

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -536,7 +536,11 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="TransferRestrictionRef" minOccurs="0"/>
 			<xsd:element ref="RoutingConstraintZoneRef" minOccurs="0"/>
-			<xsd:element ref="ServiceExclusionRef" minOccurs="0"/>
+			<xsd:element ref="ServiceExclusionRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a SERVICE EXCLUSION.+v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="ServiceValidityParametersGroup">
@@ -614,9 +618,21 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element ref="TrainElementRef" minOccurs="0"/>
 			<xsd:element ref="TrainComponentLabelAssignmentRef" minOccurs="0"/>
-			<xsd:element ref="DeckPlanRef" minOccurs="0"/>
-			<xsd:element ref="DeckSpaceRef" minOccurs="0"/>
-			<xsd:group ref="SpotValidityParametersGroup"/>
+			<xsd:element ref="DeckPlanRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a DECK PLAN to which the ACCESS RIGHT PARAMETER ASSIGNMENTs applies. +v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="DeckSpaceRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a DECK SPACE to which the ACCESS RIGHT PARAMETER ASSIGNMENTs applies. +v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:group ref="SpotValidityParametersGroup">
+				<xsd:annotation>
+					<xsd:documentation>RReference to a SPOT VALIDITY PARAMETER GROUP to which the ACCESS RIGHT PARAMETER ASSIGNMENTs applies. +v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:group>
 			<xsd:element ref="PassengerSeatRef" minOccurs="0"/>
 			<xsd:element ref="VehicleRef" minOccurs="0"/>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
@@ -277,7 +277,11 @@ Rail transport, Roads and Road transport
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
-			<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+			<xsd:element ref="OrganisationRef_" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>ORGANISATION in charge of the FARE PRODUCT. +v1.2.2</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="ConditionSummary" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>

--- a/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
@@ -815,7 +815,7 @@ Rail transport, Roads and Road transport
 				</xsd:sequence>
 				<xsd:attribute name="order" type="xsd:positiveInteger">
 					<xsd:annotation>
-						<xsd:documentation>Order in which FARE TABLE COLUMN HEADING is to appear in a view.</xsd:documentation>
+						<xsd:documentation>Order in which FARE TABLE COLUMN HEADING is to appear in a view. +v2.0</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -803,17 +803,17 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="AccessNumber" type="xsd:integer" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Access number of instance +V1.2.2.</xsd:documentation>
+					<xsd:documentation>Access number of instance +v1.2.2.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="StartOfValidity" type="xsd:dateTime" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Start Validity of element access.</xsd:documentation>
+					<xsd:documentation>Start Validity of element access. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="EndOfValidity" type="xsd:dateTime" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>End Validity of element access.</xsd:documentation>
+					<xsd:documentation>End Validity of element access. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="validityParameterAssignments" type="customerPurchaseParameterAssignments_RelStructure" minOccurs="0">

--- a/xsd/netex_part_3/part3_salesTransactions/netex_travelSpecificationSummary_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_travelSpecificationSummary_version.xsd
@@ -167,7 +167,11 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:choice minOccurs="0">
-				<xsd:element ref="TransportOrganisationRef"/>
+				<xsd:element ref="TransportOrganisationRef">
+					<xsd:annotation>
+						<xsd:documentation>TRANSPORT ORGANISATION for trip. +v1.2.2</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
 				<xsd:element ref="GroupOfOperatorsRef"/>
 			</xsd:choice>
 		</xsd:sequence>

--- a/xsd/netex_part_5/part5_fm/netex_nm_individualTraveller_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_individualTraveller_version.xsd
@@ -289,7 +289,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="VehicleRef" minOccurs="0"/>
 			<xsd:element name="reviews" type="reviews_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Reviews associated to the vehicle pooling driver</xsd:documentation>
+					<xsd:documentation>Reviews associated to the vehicle pooling driver. +v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -378,7 +378,7 @@ Rail transport, Roads and Road transport
 	<!-- ====  REVIEWS.  ============================================ -->
 	<xsd:element name="Review" type="ReviewStructure">
 		<xsd:annotation>
-			<xsd:documentation>A review of a diver or of a traveler.</xsd:documentation>
+			<xsd:documentation>A review of a diver or of a traveller. +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="reviews_RelStructure">


### PR DESCRIPTION
4th (and last) series following #762, #764, #781. Covers the rest in parts 2, 3, 4, 5. 

Again, only changes accompanied by a comment in the documentation have been treated. Especially part 4 has many, typically older, changes without any comment hinting to a PR or version. 