### PR TITLE
Proposal for #399

### DIFF
--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_support.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_support.xsd
@@ -94,6 +94,17 @@ Rail transport, Roads and Road transport
 						<xsd:documentation>Identifier of SCHEDULED STOP POINT.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
+				<xsd:attribute name="nameOfRefClass" use="optional" default="ScheduledStopPoint">
+					<xsd:annotation>
+						<xsd:documentation>The natural class expected in the reference and alternative options, automatically updated.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="NameOfClass">
+							<xsd:enumeration value="ScheduledStopPoint"/>
+							<xsd:enumeration value="TimingPoint"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>


### PR DESCRIPTION
In order to futher the restrict the schema to sensible values and relations I would like to introduce two things:
1. Have an **explicit** default for non-generic nameOfRefClass attributes, in the case below, ScheduledStopPointRef has a natural nameOfRefClass being _ScheduledSopPoint_. Now a _parser_ does not have to guess what the default might be. And this could also help with schematron validation, since conditional key-identity-constraints are still _far away_.
2. Further we would like to have a sane list of Elements that _might_ be referenced. From my perspective this should include all objects up to some predefined point. I think that should be something like "every parent, excluding abstract parents, up to and not included DataManagedObject". I would like to prevent siblings to be included.