### PR TITLE
typo in netex_line_version.xsd

### DIFF
--- a/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
@@ -525,7 +525,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:group name="LinePaymentMethodGroup">
 		<xsd:annotation>
-			<xsd:documentation>Defauly Mayment methods supported for l LINE. +v1.1</xsd:documentation>
+			<xsd:documentation>Default Payment methods supported for LINE. +v1.1</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="PaymentMethods" type="PaymentMethodListOfEnumerations" minOccurs="0">
@@ -535,7 +535,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="typesOfPaymentMethod" type="TypeOfPaymentMethod_ValueStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>TYPES OF PAYMENT yment Methods allowed on LINE. +v1.1</xsd:documentation>
+					<xsd:documentation>TYPES OF PAYMENT METHOD allowed on LINE. +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="PurchaseMoment" type="PurchaseMomentListOfEnumerations" minOccurs="0">


### PR DESCRIPTION
The typos are only in the annotation part of the XSD
Refers to issue #821 