### PR TITLE
Update netex_flexibleNetwork_support.xsd

### DIFF
--- a/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_support.xsd
@@ -107,7 +107,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:simpleType name="FlexibleLineTypeEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for FlexibleLINE  TYPE.</xsd:documentation>
+			<xsd:documentation>Allowed values for Flexible LINE TYPE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="corridorService"/>
@@ -119,6 +119,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="mixedFlexible"/>
 			<xsd:enumeration value="mixedFlexibleAndFixed"/>
 			<xsd:enumeration value="fixed"/>
+			<xsd:enumeration value="notFlexible"/>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>


### PR DESCRIPTION
2 different types of changes:
* type in the documentation part (very minimal)
* addition of a value in the enum of `FlexibleLineType`, so it is consistent with the UML model

Below, what I found in the model: 
![Capture d'écran 2025-01-20 155420](https://github.com/user-attachments/assets/287a5c7b-4346-444f-8e09-0fa107169e0e)
