### PR TITLE
Correct typos in netex_flexibleNetwork_support.xsd

### DIFF
--- a/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_support.xsd
@@ -107,7 +107,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:simpleType name="FlexibleLineTypeEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for FlexibleLINE  TYPE.</xsd:documentation>
+			<xsd:documentation>Allowed values for Flexible LINE  TYPE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="corridorService"/>
@@ -119,6 +119,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="mixedFlexible"/>
 			<xsd:enumeration value="mixedFlexibleAndFixed"/>
 			<xsd:enumeration value="fixed"/>
+			<xsd:enumeration value="notFlexible"/>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>


### PR DESCRIPTION
2 corrections:
- typo in the documentation part
- missing enum compared to the UML model (refer to screenshot below)

![Capture d'écran 2025-01-20 155420](https://github.com/user-attachments/assets/b997586c-3046-46c8-9908-0cda6b0cdd44)
