### PR TITLE
Correct typo in netex_flexibleNetwork_support.xsd

### DIFF
--- a/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_support.xsd
@@ -107,7 +107,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:simpleType name="FlexibleLineTypeEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for FlexibleLINE  TYPE.</xsd:documentation>
+			<xsd:documentation>Allowed values for Flexible LINE  TYPE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="corridorService"/>
@@ -119,6 +119,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="mixedFlexible"/>
 			<xsd:enumeration value="mixedFlexibleAndFixed"/>
 			<xsd:enumeration value="fixed"/>
+			<xsd:enumeration value="notFlexible"/>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>

--- a/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_support.xsd
@@ -119,7 +119,6 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="mixedFlexible"/>
 			<xsd:enumeration value="mixedFlexibleAndFixed"/>
 			<xsd:enumeration value="fixed"/>
-			<xsd:enumeration value="notFlexible"/>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>

--- a/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_support.xsd
@@ -107,7 +107,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:simpleType name="FlexibleLineTypeEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for Flexible LINE  TYPE.</xsd:documentation>
+			<xsd:documentation>Allowed values for Flexible LINE TYPE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="corridorService"/>


### PR DESCRIPTION
Typo in the documentation of FlexibleLineTypeEnumeration