### PR TITLE
TrainBlock and TrainBlockPart definition update

### DIFF
--- a/xsd/netex_part_2/part2_journeyTimes/netex_coupledJourney_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_coupledJourney_support.xsd
@@ -61,36 +61,6 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: COUPLED JOURNEY identifier types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ======================================================================= -->
-	<xsd:simpleType name="TypeOfCouplingListOfEnumerations">
-		<xsd:annotation>
-			<xsd:documentation>Allowed values for Type of Coupling.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:list itemType="TypeOfCouplingEnumeration"/>
-	</xsd:simpleType>
-	<xsd:simpleType name="TypeOfCouplingEnumeration">
-		<xsd:annotation>
-			<xsd:documentation>Nature of Coupling.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="xsd:NMTOKEN">
-			<xsd:enumeration value="serviceFacility">
-				<xsd:annotation>
-					<xsd:documentation>INTERCHANGE is considered a possible connection between journeys.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:enumeration>
-			<xsd:enumeration value="coupling">
-				<xsd:annotation>
-					<xsd:documentation>INTERCHANGE is advertised to public as a possible connection between journeys.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:enumeration>
-			<xsd:enumeration value="tariffSection">
-				<xsd:annotation>
-					<xsd:documentation>INTERCHANGE is actively managed as a possible connection between journeys and passengers are informed of real-time alterations.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:enumeration>
-			<xsd:enumeration value="uncoupled"/>
-		</xsd:restriction>
-	</xsd:simpleType>
 	<!-- ===JOURNEY PART====================================================== -->
 	<xsd:simpleType name="JourneyPartIdType">
 		<xsd:annotation>

--- a/xsd/netex_part_2/part2_vehicleService/netex_vehicleService_version.xsd
+++ b/xsd/netex_part_2/part2_vehicleService/netex_vehicleService_version.xsd
@@ -514,7 +514,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="TrainBlockPart" abstract="false" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation> Part of a TRAIN BLOCK corresponding to a specific JOURNEY PART of the relevant JOURNEY of a TRAIN BLOCK. Note: Any train reversal, splitting, or joining operation marks the start of a new TRAIN BLOCK PART.</xsd:documentation>
+			<xsd:documentation>Part of a TRAIN BLOCK corresponding to a specific JOURNEY PART of the relevant JOURNEY of a TRAIN BLOCK. Note: Any train reversal, splitting, or joining operation marks the start of a new TRAIN BLOCK PART.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_2/part2_vehicleService/netex_vehicleService_version.xsd
+++ b/xsd/netex_part_2/part2_vehicleService/netex_vehicleService_version.xsd
@@ -311,7 +311,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="TrainBlock" abstract="false" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation>A composite train formed of several BLOCKs coupled together during a certain period. Any coupling or separation action marks the start of a new TRAIN BLOCK.</xsd:documentation>
+			<xsd:documentation>The vehicle work required by a train-based JOURNEY or sequence of JOURNEYs, from the time it leaves a PARKING POINT after parking until its next return to park at a PARKING POINT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -514,7 +514,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="TrainBlockPart" abstract="false" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
-			<xsd:documentation>The work of a vehicle from the time it leaves a PARKING POINT after parking until its next return to park at a PARKING POINT. Any subsequent departure from a PARKING POINT after parking marks the start of a new TRAIN BLOCK PART. The period of a TRAIN BLOCK PART has to be covered by DUTies.</xsd:documentation>
+			<xsd:documentation> Part of a TRAIN BLOCK corresponding to a specific JOURNEY PART of the relevant JOURNEY of a TRAIN BLOCK. Note: Any train reversal, splitting, or joining operation marks the start of a new TRAIN BLOCK PART.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>


### PR DESCRIPTION
Update of definitions following the decisions from the Transmodel meeting on January 29th 2025
Drop of the unused TypeOfCoupling enumeration

_For reference, and input for the documentation, the Basecamp discussion https://3.basecamp.com/3256016/buckets/2570434/messages/8174036170_