### PR TITLE
Deprecate BaselineVersionRef

### DIFF
--- a/examples/functions/timetable/Netex_08.2_Bus_SimpleTimetable_Cancellation.xml
+++ b/examples/functions/timetable/Netex_08.2_Bus_SimpleTimetable_Cancellation.xml
@@ -204,7 +204,6 @@ The Calendar is shown coded as
 						</AvailabilityCondition>
 					</validityConditions>
 					<Name>Winter timetable for route 23 outbound</Name>
-					<BaselineVersionFrameRef nameOfRefClass="TimetableFrame" ref="hde:1"/>
 					<VehicleModes>bus</VehicleModes>
 					<vehicleJourneys>
 						<ServiceJourney version="2" id="hde:sj_24o_01">

--- a/examples/functions/timetable/Netex_09.1_Bus_InterchangeRule.xml
+++ b/examples/functions/timetable/Netex_09.1_Bus_InterchangeRule.xml
@@ -275,7 +275,6 @@ The Calendar is shown coded as
 						</AvailabilityCondition>
 					</validityConditions>
 					<Name>Winter timetable for route 23 outbound</Name>
-					<BaselineVersionFrameRef nameOfRefClass="TimetableFrame" ref="hde:1"/>
 					<!-- ======INTERCHANGE RUKES====== -->
 					<interchangeRules>
 						<InterchangeRule version="any" id="hde:IR_25_all_f">
@@ -375,7 +374,6 @@ The Calendar is shown coded as
 				<!-- ======Timetable ======= -->
 				<ResourceFrame version="2" id="hde:RS_23_O">
 					<Name>Resoucres</Name>
-					<BaselineVersionFrameRef nameOfRefClass="ResourceFrame" ref="hde:1"/>
 					<organisations>
 						<Authority version="101" id="hde:TFO">
 							<Name>Mission Central</Name>

--- a/examples/functions/variant/Netex_VariantExample_Step_05.xml
+++ b/examples/functions/variant/Netex_VariantExample_Step_05.xml
@@ -88,7 +88,6 @@ This is variant on the multistep SImple Network Version example on versioning.
 						</AvailabilityCondition>
 					</validityConditions>
 					<Name>ntwkf002  - Frame with SERVICE PATTERN for Normal conditions</Name>
-					<BaselineVersionFrameRef version="001" ref="mybus:GeneralFrame"/>
 					<members>
 						<GeneralFrameMember modification="revise" id="mybus:GeneralFrameMember:ntwkf002_01">
 							<ScheduledStopPointRef ref="mybus:ScheduledStopPoint:SSP0001A">EXTERNAL</ScheduledStopPointRef>
@@ -132,7 +131,6 @@ This is variant on the multistep SImple Network Version example on versioning.
 						</AvailabilityCondition>
 					</validityConditions>
 					<Name>ntwkf003 Different Frame  with a different condition - a different frame</Name>
-					<BaselineVersionFrameRef version="001" ref="mybus:GeneralFrame:ntwkf001"/>
 					<members>
 						<GeneralFrameMember modification="revise" id="mybus:GeneralFrameMember:ntwkf003_01">
 							<ScheduledStopPointRef ref="mybus:ScheduledStopPoint:SSP0001A"/>

--- a/examples/functions/versioning/Netex_VersioningExample_Step_03.xml
+++ b/examples/functions/versioning/Netex_VersioningExample_Step_03.xml
@@ -101,7 +101,6 @@ This is part 3 of a multistep example on versioning
 						</AvailabilityCondition>
 					</validityConditions>
 					<Name>My Network  Version 3 with two stops in it and a VALIDITY CONDITIONa added  in it. Baseline is version 2 as stops A and B must exist</Name>
-					<BaselineVersionFrameRef ref="mybus:002">EXTERNAL</BaselineVersionFrameRef>
 					<scheduledStopPoints>
 						<!-- == Frame contents == -->
 						<ScheduledStopPoint version="002" created="2010-05-17T09:30:47.0Z" changed="2010-05-18T10:30:47.0Z" modification="revise" derivedFromVersionRef="001" id="mybus:SSP0001A">

--- a/examples/functions/versioning/Netex_VersioningExample_Step_04.xml
+++ b/examples/functions/versioning/Netex_VersioningExample_Step_04.xml
@@ -105,7 +105,6 @@ This is part 4 of a multistep example on versioning.
 						</AvailabilityCondition>
 					</validityConditions>
 					<Name>My Network  Version 4 with three stops in it </Name>
-					<BaselineVersionFrameRef ref="mybus:003">EXTERNAL</BaselineVersionFrameRef>
 					<scheduledStopPoints>
 						<ScheduledStopPoint version="002" created="2010-05-17T09:30:47.0Z" changed="2010-05-18T09:30:47.0Z" modification="revise" id="mybus:SSP0001A">
 							<Name>Haltstelle A - Museum</Name>
@@ -164,7 +163,6 @@ This is part 4 of a multistep example on versioning.
 		<!--- =====NETWORK VERSIONChanges only ========== -->
 		<GeneralFrame version="004" created="2010-05-21T10:30:51.0Z" changed="2010-05-21T10:30:51.0Z" modification="revise" responsibilitySetRef="mybus:RS_10" id="mybus:GeneralFrame:ntwkf001_Delta">
 			<Name>ntwkf001 experssed as a delta - only the removed stop is described - Baseline is version 3</Name>
-			<BaselineVersionFrameRef version="003" ref="mybus:GeneralFrame:ntwkf001"/>
 			<members modificationSet="changesOnly">
 				<GeneralFrameMember modification="delete" id="mybus:EntityInVersionInFrame:ntwkf001_05">
 					<ServiceLinkRef version="002" ref="mybu:SL_BtoA01"/>

--- a/examples/functions/versioning/Netex_VersioningExample_Step_05.xml
+++ b/examples/functions/versioning/Netex_VersioningExample_Step_05.xml
@@ -100,7 +100,6 @@ This is part 4 of a multistep example on versioning.
 						</AvailabilityCondition>
 					</validityConditions>
 					<Name>My Network  Version 5 with three stops in it </Name>
-					<BaselineVersionFrameRef ref="mybus:004">EXTERNAL</BaselineVersionFrameRef>
 					<scheduledStopPoints>
 						<!--- =====Data objects ========= -->
 						<ScheduledStopPoint version="002" created="2010-05-17T09:30:47.0Z" changed="2010-05-18T09:30:47.0Z" modification="revise" id="mybus:SSP0001A">

--- a/examples/functions/versioning/Netex_VersioningExample_Step_05_ByRef.xml
+++ b/examples/functions/versioning/Netex_VersioningExample_Step_05_ByRef.xml
@@ -51,7 +51,6 @@ This version shows the use of thye general  frame to hold references rather than
 				</AvailabilityCondition>
 			</validityConditions>
 			<Name>My Network  Version 4 One link has been removed. Baseline is version 3 as Links  needs exist</Name>
-			<BaselineVersionFrameRef ref="mybus:GeneralFrame:003">EXTERNAL</BaselineVersionFrameRef>
 			<!--- ======= CODESPACEs======== -->
 			<codespaces>
 				<Codespace id="mybus">

--- a/examples/functions/versioning/Netex_VersioningExample_Step_05_GeneralFrame.xml
+++ b/examples/functions/versioning/Netex_VersioningExample_Step_05_GeneralFrame.xml
@@ -55,7 +55,6 @@ This is part 4 of a multistep example on versioning.
 				</AvailabilityCondition>
 			</validityConditions>
 			<Name>My Network  Version 4 One link has been removed. Baseline is version 3 as Links  needs exist</Name>
-			<BaselineVersionFrameRef ref="mybus:GeneralFrame:003">EXTERNAL</BaselineVersionFrameRef>
 			<!--- ======= CODESPACEs======== -->
 			<codespaces>
 				<Codespace id="mybus">

--- a/examples/standards/vdv452/calendar/Netex_de_calendarExample_01_gd.xml
+++ b/examples/standards/vdv452/calendar/Netex_de_calendarExample_01_gd.xml
@@ -100,7 +100,6 @@ eof; 1
 		</ResourceFrame>
 		<ServiceCalendarFrame version="78" dataSourceRef="Interplan" changed="2009-01-09T15:19:20Z" id="ust:ServiceCalendarFrame:CAL_01">
 			<Name>Calender Example for Netex   GD</Name>
-			<BaselineVersionFrameRef ref="ust:October2010_Week2@77">EXTERNAL</BaselineVersionFrameRef>
 			<!--- ======= CODESPACEs======== -->
 			<codespaces>
 				<Codespace id="ust_data">

--- a/xsd/netex_framework/netex_responsibility/netex_versionFrame_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_versionFrame_version.xsd
@@ -104,7 +104,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="BaselineVersionFrameRef" type="VersionRefStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Prerequisite Baseline VERSION FRAME  that all objects in this VERSION require.</xsd:documentation>
+					<xsd:documentation>DEPRECATED: Prerequisite Baseline VERSION FRAME  that all objects in this VERSION require. -v2.0</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="codespaces" type="codespaces_RelStructure" minOccurs="0">


### PR DESCRIPTION
Since we have already deprecated Version it does not make sence to keep BaselineVersionRef.