### PR TITLE
fixing From/To JourneyRefStructure

### DIFF
--- a/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
@@ -159,26 +159,52 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>SCHEDULED STOP POINT at which JOURNEY MEETING takes place.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="FromJourneyRef" type="JourneyRefStructure">
-				<xsd:annotation>
-					<xsd:documentation>JOURNEY that feeds JOURNEY MEETING.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="ToJourneyRef" type="JourneyRefStructure">
-				<xsd:annotation>
-					<xsd:documentation>JOURNEY that distributes from JOURNEY MEETING.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="FromPointInJourneyPatternRef" type="PointInJourneyPatternRefStructure" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>POINT IN JOURNEY PATTERN ofr  feeder  journey JOURNEY PATTERN.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="ToPointInJourneyPatternRef" type="PointInJourneyPatternRefStructure" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>POINT IN JOURNEY PATTERN ofr  distributorjourney JOURNEY PATTERN.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:choice>
+				<xsd:sequence>
+					<xsd:element name="FromJourneyRef" type="JourneyRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>DEPRECATE: JOURNEY that feeds JOURNEY MEETING. -v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ToJourneyRef" type="JourneyRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>DEPRECATE: JOURNEY that distributes from JOURNEY MEETING. -v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="FromPointInJourneyPatternRef" type="PointInJourneyPatternRefStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>DEPRECATE: POINT IN JOURNEY PATTERN of feeder journey JOURNEY PATTERN. -v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ToPointInJourneyPatternRef" type="PointInJourneyPatternRefStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>DEPRECATE: POINT IN JOURNEY PATTERN of distributor journey JOURNEY PATTERN. -v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:sequence>
+					<xsd:element name="FromServiceJourneyRef" type="ServiceJourneyRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>SERVICE JOURNEY that feeds JOURNEY MEETING. +v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ToServiceJourneyRef" type="ServiceJourneyRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>SERVICE JOURNEY that distributes from JOURNEY MEETING. +v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="FromStopPointInJourneyPatternRef" type="StopPointInJourneyPatternRefStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>STOP POINT IN JOURNEY PATTERN of feeder journey SERVICE JOURNEY PATTERN. +v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ToStopPointInJourneyPatternRef" type="StopPointInJourneyPatternRefStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>STOP POINT IN JOURNEY PATTERN of distributor journey SERVICE JOURNEY PATTERN. +v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:choice>
 			<xsd:group ref="JourneyMeetingPropertiesGroup"/>
 			<xsd:group ref="JourneyMeetingConnectionGroup"/>
 		</xsd:sequence>
@@ -323,7 +349,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<xsd:element name="DefaultInterchange" abstract="false" substitutionGroup="Interchange_">
 		<xsd:annotation>
-			<xsd:documentation>A quality parameter fixing the acceptable duration (standard and maximum) for an INTERCHANGE to be planned between two SCHEDULED STOP POINTs. This parameter will be used to control whether any two VEHICLE JOURNEYs serving those points may be in connection.</xsd:documentation>
+			<xsd:documentation>A quality parameter fixing the acceptable duration (standard and maximum) for an INTERCHANGE to be planned between two SCHEDULED STOP POINTs. This parameter will be used to control whether any two SERVICE JOURNEYs serving those points may be in connection.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -607,16 +633,32 @@ Default is false.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:group ref="InterchangeEndpointGroup" minOccurs="0"/>
-			<xsd:element name="FromJourneyRef" type="JourneyRefStructure">
-				<xsd:annotation>
-					<xsd:documentation>JOURNEY that feeds the INTERCHANGE.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="ToJourneyRef" type="JourneyRefStructure">
-				<xsd:annotation>
-					<xsd:documentation>JOURNEY that distributes from the INTERCHANGE.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:choice>
+				<xsd:sequence>
+					<xsd:element name="FromJourneyRef" type="JourneyRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>DEPRECATE: JOURNEY that feeds the INTERCHANGE. -v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ToJourneyRef" type="JourneyRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>DEPRECATE: JOURNEY that distributes from the INTERCHANGE. -v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:sequence>
+					<xsd:element name="FromServiceJourneyRef" type="ServiceJourneyRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>SERVICE JOURNEY that feeds the INTERCHANGE. +v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ToServiceJourneyRef" type="ServiceJourneyRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>SERVICE JOURNEY that distributes from the INTERCHANGE. +v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:choice>
 			<xsd:element ref="ServiceJourneyPatternInterchangeRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
@@ -661,16 +703,32 @@ Default is false.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:group ref="InterchangeEndpointGroup"/>
-			<xsd:element name="FromJourneyPatternRef" type="JourneyPatternRefStructure">
-				<xsd:annotation>
-					<xsd:documentation>JOURNEY PATTERN that feeds INTERCHANGE.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="ToJourneyPatternRef" type="JourneyPatternRefStructure">
-				<xsd:annotation>
-					<xsd:documentation>JOURNEY PATTERN that distributes from INTERCHANGE.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:choice>
+				<xsd:sequence>
+					<xsd:element name="FromJourneyPatternRef" type="JourneyPatternRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>DEPRECATE: JOURNEY PATTERN that feeds INTERCHANGE. -v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ToJourneyPatternRef" type="JourneyPatternRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>DEPRECATE: JOURNEY PATTERN that distributes from INTERCHANGE. -v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:sequence>
+					<xsd:element name="FromServiceJourneyPatternRef" type="ServiceJourneyPatternRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>SERVICE JOURNEY PATTERN that feeds INTERCHANGE. +v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ToServiceJourneyPatternRef" type="ServiceJourneyPatternRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>SERVICE JOURNEY PATTERN that distributes from INTERCHANGE. +v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:choice>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
@@ -750,12 +808,22 @@ Default is false.</xsd:documentation>
 						</xsd:complexType>
 					</xsd:element>
 					<xsd:choice>
-						<xsd:element name="ConnectingJourneyRef" type="VehicleJourneyRefStructure">
-							<xsd:annotation>
-								<xsd:documentation>VEHICLE JOURNEY that feeds the INTERCHANGE.</xsd:documentation>
-							</xsd:annotation>
-						</xsd:element>
-						<xsd:element ref="ConnectingJourneyView"/>
+						<xsd:choice>
+							<xsd:element name="ConnectingJourneyRef" type="JourneyRefStructure">
+								<xsd:annotation>
+									<xsd:documentation>DEPRECATE: JOURNEY that feeds the INTERCHANGE. -v2.0</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element ref="ConnectingJourneyView"/>
+						</xsd:choice>
+						<xsd:choice>
+							<xsd:element name="ConnectingServiceJourneyRef" type="ServiceJourneyRefStructure">
+								<xsd:annotation>
+									<xsd:documentation>SERVICE JOURNEY that feeds the INTERCHANGE. +v2.0</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element ref="ConnectingServiceJourneyView"/>
+						</xsd:choice>
 					</xsd:choice>
 					<xsd:element name="ConnectingLineView" type="Line_DerivedViewStructure" minOccurs="0">
 						<xsd:annotation>
@@ -768,14 +836,19 @@ Default is false.</xsd:documentation>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ConnectingJourneyView" type="ConnectingJourney_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="ConnectingJourneyView" type="ConnectingServiceJourney_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
 		<xsd:annotation>
-			<xsd:documentation>Simplified  view of CONNECTING JOURNEY.</xsd:documentation>
+			<xsd:documentation>Simplified view of CONNECTING JOURNEY.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ConnectingJourney_DerivedViewStructure">
+	<xsd:element name="ConnectingServiceJourneyView" type="ConnectingServiceJourney_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
 		<xsd:annotation>
-			<xsd:documentation>Type for CONNECTING JOURNEY VIEW.</xsd:documentation>
+			<xsd:documentation>Simplified view of CONNECTING SERVICE JOURNEY.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ConnectingServiceJourney_DerivedViewStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CONNECTING SERVICE JOURNEY VIEW.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="DerivedViewStructure">


### PR DESCRIPTION
Its From/To JourneyRef so the type is Journey and not VehicleJourney. 
This is also necessary, because VehicleJourney and ServiceJourney are both derived from Journey, but not one form the other.