### PR TITLE
Entrance deprecation as instance

### DIFF
--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
@@ -332,9 +332,9 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Entrance" type="SiteEntrance_VersionStructure" abstract="true" substitutionGroup="SiteComponent">
+	<xsd:element name="Entrance" type="SiteEntrance_VersionStructure" abstract="false" substitutionGroup="SiteComponent">
 		<xsd:annotation>
-			<xsd:documentation>A physical entrance or exit to/from a SITE. May be a door, barrier, gate or other recognizable point of access.</xsd:documentation>
+			<xsd:documentation>A physical entrance or exit to/from a SITE. May be a door, barrier, gate or other recognizable point of access. The ENTRANCE is an abstract Transmodel object and therfore should not ne used as an instance (use specialisations like StopPalceEntrance, PointOfInterestEntrance, etc.). It still has "abstract="false" for backward compatibility, but using it as an instance is DEPRECATED from v2.0 and it will be formally changed to abstract in v3.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="SiteEntrance_VersionStructure" abstract="false">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
@@ -334,7 +334,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:element name="Entrance" type="SiteEntrance_VersionStructure" abstract="false" substitutionGroup="SiteComponent">
 		<xsd:annotation>
-			<xsd:documentation>A physical entrance or exit to/from a SITE. May be a door, barrier, gate or other recognizable point of access. The ENTRANCE is an abstract Transmodel object and therfore should not ne used as an instance (use specialisations like StopPalceEntrance, PointOfInterestEntrance, etc.). It still has "abstract="false" for backward compatibility, but using it as an instance is DEPRECATED from v2.0 and it will be formally changed to abstract in v3.0</xsd:documentation>
+			<xsd:documentation>A physical entrance or exit to/from a SITE. May be a door, barrier, gate or other recognizable point of access. The ENTRANCE is an abstract Transmodel object and therefore should not be used as an instance (use specialisations like StopPlaceEntrance, PointOfInterestEntrance, etc.). It still has abstract="false" for backward compatibility, but using it as an instance is DEPRECATED from v2.0 and it will be formally changed to abstract in v3.0. -v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="SiteEntrance_VersionStructure" abstract="false">


### PR DESCRIPTION
The ENTRANCE is an abstract Transmodel object and therfore should not ne used as an instance (use specialisations like StopPalceEntrance, PointOfInterestEntrance, etc.). It still has "abstract="false" for backward compatibility, but using it as an instance is DEPRECATED from v2.0 and it will be formally changed to abstract in v3.0