### PR TITLE
Abstract work

### DIFF
--- a/xsd/netex_framework/netex_frames/netex_compositeFrame_version.xsd
+++ b/xsd/netex_framework/netex_frames/netex_compositeFrame_version.xsd
@@ -61,12 +61,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="CompositeFrameRef" type="CompositeFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="CompositeFrameRef" type="CompositeFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a COMPOSITE FRAME.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="CompositeFrameRefStructure" abstract="false">
+	<xsd:complexType name="CompositeFrameRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a COMPOSITE FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -93,7 +93,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CompositeFrame" abstract="false" substitutionGroup="VersionFrame">
+	<xsd:element name="CompositeFrame" substitutionGroup="VersionFrame">
 		<xsd:annotation>
 			<xsd:documentation>A container VERSION FRAME that groups a set of content VERSION FRAMsE to which the same VALIDITY CONDITIONs have been assigned.</xsd:documentation>
 		</xsd:annotation>
@@ -123,7 +123,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Composite_VersionFrameStructure" abstract="false">
+	<xsd:complexType name="Composite_VersionFrameStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a COMPOSITE FRAME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_frames/netex_generalFrame_version.xsd
+++ b/xsd/netex_framework/netex_frames/netex_generalFrame_version.xsd
@@ -107,12 +107,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GeneralFrameRef" type="GeneralFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="GeneralFrameRef" type="GeneralFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GENERAL FRAME.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="GeneralFrameRefStructure" abstract="false">
+	<xsd:complexType name="GeneralFrameRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a GENERAL FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -126,7 +126,7 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<xsd:element name="GeneralFrame" abstract="false" substitutionGroup="CommonFrame">
+	<xsd:element name="GeneralFrame" substitutionGroup="CommonFrame">
 		<xsd:annotation>
 			<xsd:documentation>A General purpose frame that can be used to exchange any NeTEx element. Does not impose any structure.</xsd:documentation>
 		</xsd:annotation>
@@ -152,7 +152,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="General_VersionFrameStructure" abstract="false">
+	<xsd:complexType name="General_VersionFrameStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a GENERAL FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -215,12 +215,12 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="VersionOfObjectRefStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GeneralFrameMember" type="GeneralFrameMemberStructure" abstract="false">
+	<xsd:element name="GeneralFrameMember" type="GeneralFrameMemberStructure">
 		<xsd:annotation>
 			<xsd:documentation>An association of an ENTITY in a GENERAL FRAME.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="GeneralFrameMemberStructure" abstract="false">
+	<xsd:complexType name="GeneralFrameMemberStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a GENERAL FRAME MEMBER.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_frames/netex_resourceFrame_support.xsd
+++ b/xsd/netex_framework/netex_frames/netex_resourceFrame_support.xsd
@@ -60,12 +60,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="ResourceFrameRef" type="ResourceFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="ResourceFrameRef" type="ResourceFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation> Reference to a RESOURCE FRAME.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ResourceFrameRefStructure" abstract="false">
+	<xsd:complexType name="ResourceFrameRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a RESOURCE FRAME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_grouping_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_grouping_support.xsd
@@ -119,7 +119,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PurposeOfGroupingRef" type="PurposeOfGroupingRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="PurposeOfGroupingRef" type="PurposeOfGroupingRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PURPOSE OF GROUPING.</xsd:documentation>
 		</xsd:annotation>
@@ -159,12 +159,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GeneralGroupOfEntitiesRef" type="GeneralGroupOfEntitiesRefStructure" abstract="false" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GeneralGroupOfEntitiesRef" type="GeneralGroupOfEntitiesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GENERAL GROUP OF ENTITies.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="GeneralGroupOfEntitiesRefStructure" abstract="false">
+	<xsd:complexType name="GeneralGroupOfEntitiesRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a GENERAL GROUP OF ENTITies.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_grouping_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_grouping_version.xsd
@@ -135,7 +135,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- =====GROUPING=============================================== -->
-	<xsd:element name="GeneralGroupOfEntities" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GeneralGroupOfEntities" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of ENTITies which will be commonly referenced for a specific purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -165,7 +165,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="GeneralGroupOfEntities_VersionStructure" abstract="false">
+	<xsd:complexType name="GeneralGroupOfEntities_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a GENERAL GROUP OF ENTITies.</xsd:documentation>
 		</xsd:annotation>
@@ -310,7 +310,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="GroupConstraintMember" type="GroupConstraintMember_VersionedChildStructure" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="GroupConstraintMember" type="GroupConstraintMember_VersionedChildStructure" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Specifies a member of a set.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_layer_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_layer_version.xsd
@@ -57,7 +57,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NetEX: LAYER types for NeTEx Network Exchange.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<xsd:element name="Layer" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="Layer" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A user-defined GROUP OF ENTITies, specified for a particular functional purpose, associating data referring to a particular LOCATING SYSTEM.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_loggable_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_loggable_support.xsd
@@ -57,7 +57,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="LogRef" type="LogRefStructure" abstract="false" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="LogRef" type="LogRefStructure" substitutionGroup="GroupOfEntitiesRef_">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a LOG.</xsd:documentation>
 		</xsd:annotation>
@@ -83,7 +83,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="LogEntryRef" type="LogEntryRefStructure" abstract="false" substitutionGroup="VersionOfObjectRef">
+	<xsd:element name="LogEntryRef" type="LogEntryRefStructure" substitutionGroup="VersionOfObjectRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a LOG ENTRY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_organisation_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_organisation_version.xsd
@@ -345,7 +345,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy supertype for ORGANISATION PART.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="OrganisationPart" abstract="false" substitutionGroup="OrganisationPart_">
+	<xsd:element name="OrganisationPart" substitutionGroup="OrganisationPart_">
 		<xsd:annotation>
 			<xsd:documentation>A named subdivision of an ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
@@ -368,7 +368,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="OrganisationPart_VersionStructure" abstract="false">
+	<xsd:complexType name="OrganisationPart_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an ORGANISATION PART.</xsd:documentation>
 		</xsd:annotation>
@@ -444,7 +444,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Department" abstract="false" substitutionGroup="OrganisationPart_">
+	<xsd:element name="Department" substitutionGroup="OrganisationPart_">
 		<xsd:annotation>
 			<xsd:documentation>Department of an ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
@@ -470,7 +470,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Department_VersionStructure" abstract="false">
+	<xsd:complexType name="Department_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a DEPARTMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -509,7 +509,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="OrganisationalUnit" abstract="false" substitutionGroup="OrganisationPart_">
+	<xsd:element name="OrganisationalUnit" substitutionGroup="OrganisationPart_">
 		<xsd:annotation>
 			<xsd:documentation>OrganisationalUnit of an ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
@@ -535,7 +535,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="OrganisationalUnit_VersionStructure" abstract="false">
+	<xsd:complexType name="OrganisationalUnit_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a ORGANISATIONAL UNIT.</xsd:documentation>
 		</xsd:annotation>
@@ -568,7 +568,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RelatedOrganisation" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="RelatedOrganisation" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>A formal relationship with another  ORGANISATION. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -591,7 +591,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RelatedOrganisation_VersionStructure" abstract="false">
+	<xsd:complexType name="RelatedOrganisation_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an RELATED ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
@@ -646,7 +646,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy supertype for ADMINISTRATIVE ZONE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="AdministrativeZone" abstract="false" substitutionGroup="AdministrativeZone_">
+	<xsd:element name="AdministrativeZone" substitutionGroup="AdministrativeZone_">
 		<xsd:annotation>
 			<xsd:documentation>A ZONE relating to the management responsibilities of an ORGANISATION. For example to allocate bus stop identifiers for a region.</xsd:documentation>
 		</xsd:annotation>
@@ -678,7 +678,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="AdministrativeZone_VersionStructure" abstract="false">
+	<xsd:complexType name="AdministrativeZone_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an ADMINISTRATIVE ZONE.</xsd:documentation>
 		</xsd:annotation>
@@ -735,7 +735,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CodespaceAssignment" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="CodespaceAssignment" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Assignment of use of a CODESPACE to identify data within a given ZONE.</xsd:documentation>
 		</xsd:annotation>
@@ -755,7 +755,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CodespaceAssignment_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="CodespaceAssignment_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a CODESPACE ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -839,7 +839,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfCodespaceAssignment" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfCodespaceAssignment" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Classification of an CODESPACE  ASSIGNMENT </xsd:documentation>
 		</xsd:annotation>
@@ -862,7 +862,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfCodespaceAssignment_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfCodespaceAssignment_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF CODESPACE ASSIGNMENT </xsd:documentation>
 		</xsd:annotation>
@@ -871,7 +871,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfOrganisation" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfOrganisation" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>Classification of an ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
@@ -899,7 +899,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfOrganisation_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfOrganisation_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
@@ -908,7 +908,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfOrganisationPart" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfOrganisationPart" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>Classification of an ORGANISATION PART.</xsd:documentation>
 		</xsd:annotation>
@@ -936,7 +936,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfOrganisationPart_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfOrganisationPart_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF ORGANISATION PART.</xsd:documentation>
 		</xsd:annotation>
@@ -945,7 +945,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfOperation" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfOperation" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>Classification of an OPERATION.</xsd:documentation>
 		</xsd:annotation>
@@ -973,7 +973,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfOperation_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfOperation_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF OPERATION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_pointAndLinkSequence_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_pointAndLinkSequence_support.xsd
@@ -155,7 +155,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfLinkSequenceRef" type="TypeOfLinkSequenceRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfLinkSequenceRef" type="TypeOfLinkSequenceRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF LINK SEQUENCE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_pointAndLinkSequence_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_pointAndLinkSequence_version.xsd
@@ -213,7 +213,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfLinkSequence" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfLinkSequence" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of LINK SEQUENCEs according to their functional purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -238,7 +238,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfLinkSequence_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfLinkSequence_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF LINK SEQUENCE.</xsd:documentation>
 		</xsd:annotation>
@@ -259,7 +259,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GroupOfLinkSequences" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfLinkSequences" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of LINK SEQUENCEs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_pointAndLink_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_pointAndLink_support.xsd
@@ -211,7 +211,7 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<xsd:complexType name="PointOnLinkByValueStructure" abstract="false">
+	<xsd:complexType name="PointOnLinkByValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a  reference to POINT ON LINK by Distance.</xsd:documentation>
 		</xsd:annotation>
@@ -242,7 +242,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfPointRef" type="TypeOfPointRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfPointRef" type="TypeOfPointRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -289,7 +289,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a TYPE OF LINK.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfLinkRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfLinkRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -324,7 +324,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="GroupOfPointsRefStructure" abstract="false">
+	<xsd:complexType name="GroupOfPointsRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a GROUP OF POINTs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_pointAndLink_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_pointAndLink_version.xsd
@@ -115,12 +115,12 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="Point" type="Point_VersionStructure" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="Point" type="Point_VersionStructure" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A 0-dimensional node of the network used for the spatial description of the network. POINTs may be located by a LOCATION in a given LOCATING SYSTEM.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="Point_VersionStructure" abstract="false">
+	<xsd:complexType name="Point_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -182,7 +182,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:complexType name="SimplePoint_VersionStructure" abstract="false">
+	<xsd:complexType name="SimplePoint_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a Simple POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -291,7 +291,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PointOnLink_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="PointOnLink_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a POINT ON LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -335,7 +335,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfPoint" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfPoint" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of POINTs according to their functional purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -363,7 +363,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfPoint_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfPoint_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -372,7 +372,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfLink" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfLink" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of LINKs according to their functional purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -400,7 +400,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfLink_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfLink_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -421,7 +421,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GroupOfPoints" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfPoints" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of POINTs.</xsd:documentation>
 		</xsd:annotation>
@@ -485,7 +485,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GroupOfLinks" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfLinks" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of LINKs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_projection_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_projection_version.xsd
@@ -59,7 +59,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>PROJECTION elements for NeTEx.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<xsd:complexType name="projections_RelStructure" abstract="false">
+	<xsd:complexType name="projections_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a list of PROJECTIONS.</xsd:documentation>
 		</xsd:annotation>
@@ -91,7 +91,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>An oriented correspondence - of the shape of an ENTITY on a source layer, - onto a ENTITY in a target layer: e.g. POINT, LINK, LINK SEQUENCE, COMPLEX FEATURE, - within a defined TYPE OF PROJECTION.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="Projection_VersionStructure" abstract="false">
+	<xsd:complexType name="Projection_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PROJECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -131,7 +131,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="PointProjection" abstract="false" substitutionGroup="Projection">
+	<xsd:element name="PointProjection" substitutionGroup="Projection">
 		<xsd:annotation>
 			<xsd:documentation>An oriented correspondence from one POINT of a source layer, onto a entity in a target layer:  e.g. POINT, LINK, LINK SEQUENCE, COMPLEX FEATURE, within a defined TYPE OF PROJECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -180,7 +180,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PointProjection_VersionStructure" abstract="false">
+	<xsd:complexType name="PointProjection_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a POINT PROJECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -212,7 +212,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="LinkProjection" abstract="false" substitutionGroup="Projection">
+	<xsd:element name="LinkProjection" substitutionGroup="Projection">
 		<xsd:annotation>
 			<xsd:documentation>An oriented correspondence from one LINK of a source layer, onto an entity in a target layer: e.g. LINK SEQUENCE, COMPLEX FEATURE, within a defined TYPE OF PROJECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -242,7 +242,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LinkProjection_VersionStructure" abstract="false">
+	<xsd:complexType name="LinkProjection_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a LINK PROJECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -296,7 +296,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="LinkSequenceProjection" abstract="false" substitutionGroup="Projection">
+	<xsd:element name="LinkSequenceProjection" substitutionGroup="Projection">
 		<xsd:annotation>
 			<xsd:documentation>A Projection of a whole LINK SEQUENCE as an ordered series of POINTs.</xsd:documentation>
 		</xsd:annotation>
@@ -336,7 +336,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LinkSequenceProjection_VersionStructure" abstract="false">
+	<xsd:complexType name="LinkSequenceProjection_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a LINK SEQUENCE PROJECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -372,7 +372,7 @@ Rail transport, Roads and Road transport
 		</xsd:choice>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="ComplexFeatureProjection" abstract="false" substitutionGroup="Projection">
+	<xsd:element name="ComplexFeatureProjection" substitutionGroup="Projection">
 		<xsd:annotation>
 			<xsd:documentation>An oriented correspondence:  from one COMPLEX FEATURE in the source layer, onto an entity in a target layer: e.g. POINT, COMPLEX FEATURE,  within a defined TYPE OF PROJECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -402,7 +402,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ComplexFeatureProjection_VersionStructure" abstract="false">
+	<xsd:complexType name="ComplexFeatureProjection_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a COMPLEX FEATURE PROJECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -438,7 +438,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="LineShape" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="LineShape" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>The graphical shape of a LINK obtained from a formula or other means, using the LOCATION of its limiting POINTs and depending on the LOCATING SYSTEM used for the graphical representation.</xsd:documentation>
 		</xsd:annotation>
@@ -480,7 +480,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LineShapeStructure" abstract="false">
+	<xsd:complexType name="LineShapeStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a LINE SHAPE.</xsd:documentation>
 		</xsd:annotation>
@@ -508,7 +508,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfProjection" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfProjection" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>Classification of a PROJECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -531,7 +531,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfProjection_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfProjection_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF PROJECTION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_section_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_section_support.xsd
@@ -59,7 +59,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="LinkSequenceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="SectionRef" type="SectionRefStructure" abstract="false" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="SectionRef" type="SectionRefStructure" substitutionGroup="GroupOfEntitiesRef_">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a SECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -78,7 +78,7 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<xsd:element name="ParentSectionRef" type="SectionRefStructure" abstract="false" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="ParentSectionRef" type="SectionRefStructure" substitutionGroup="GroupOfEntitiesRef_">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a parent SECTION. May be omitted if given by context..</xsd:documentation>
 		</xsd:annotation>
@@ -90,7 +90,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="SectionIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GeneralSectionRef" type="GeneralSectionRefStructure" abstract="false" substitutionGroup="SectionRef">
+	<xsd:element name="GeneralSectionRef" type="GeneralSectionRefStructure" substitutionGroup="SectionRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GENERAL SECTION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_section_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_section_version.xsd
@@ -131,7 +131,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="GeneralSection" abstract="false" substitutionGroup="Section_">
+	<xsd:element name="GeneralSection" substitutionGroup="Section_">
 		<xsd:annotation>
 			<xsd:documentation>A  resuable sequence of LINKS or POINTs.   +v1.1.</xsd:documentation>
 		</xsd:annotation>
@@ -401,7 +401,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SectionInSequence" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="SectionInSequence" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>A SECTION in Sequence</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_spatialFeature_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_spatialFeature_support.xsd
@@ -55,7 +55,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>SPATIAL FEATURE identifier types for NeTEx.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<xsd:element name="SpatialFeatureRef" type="GroupOfPointsRefStructure" abstract="false">
+	<xsd:element name="SpatialFeatureRef" type="GroupOfPointsRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a SPATIAL FEATURE.</xsd:documentation>
 		</xsd:annotation>
@@ -99,7 +99,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfPointsIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="ComplexFeatureRef" type="ComplexFeatureRefStructure" abstract="false" substitutionGroup="SpatialFeatureRef">
+	<xsd:element name="ComplexFeatureRef" type="ComplexFeatureRefStructure" substitutionGroup="SpatialFeatureRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a COMPLEX FEATURE.</xsd:documentation>
 		</xsd:annotation>
@@ -135,7 +135,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfFeatureRef" type="TypeOfFeatureRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfFeatureRef" type="TypeOfFeatureRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF FEATURE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_spatialFeature_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_spatialFeature_version.xsd
@@ -82,13 +82,13 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="SpatialFeature" type="GroupOfPoints_VersionStructure" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="SpatialFeature" type="GroupOfPoints_VersionStructure" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Abstract SPATIAL FEATURE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<!-- ==SIMPLE FEATURE============================================================ -->
-	<xsd:element name="SimpleFeature" abstract="false" substitutionGroup="SpatialFeature">
+	<xsd:element name="SimpleFeature" substitutionGroup="SpatialFeature">
 		<xsd:annotation>
 			<xsd:documentation>An abstract representation of elementary objects related to the spatial representation of the network POINTs (0-dimensional objects), LINKs (1-dimensional objects) and ZONEs (2-dimensional objects) may be viewed as SIMPLE FEATUREs.</xsd:documentation>
 		</xsd:annotation>
@@ -130,7 +130,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ComplexFeature" abstract="false" substitutionGroup="SpatialFeature">
+	<xsd:element name="ComplexFeature" substitutionGroup="SpatialFeature">
 		<xsd:annotation>
 			<xsd:documentation>An aggregate of SIMPLE FEATUREs and/or other COMPLEX FEATUREs; e.g. a STOP AREA : combination of STOP POINTs ; a train station : combination of SIMPLE FEATUREs (POINTs, LINKs) and COMPLEX FEATUREs (STOP AREAs).</xsd:documentation>
 		</xsd:annotation>
@@ -163,7 +163,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ComplexFeature_VersionStructure" abstract="false">
+	<xsd:complexType name="ComplexFeature_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a COMPLEX FEATURE.</xsd:documentation>
 		</xsd:annotation>
@@ -230,7 +230,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfFeature" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfFeature" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>TYPE OF FEATURe.</xsd:documentation>
 		</xsd:annotation>
@@ -253,7 +253,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfFeature_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfFeature_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF FEATURE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_zoneProjection_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zoneProjection_version.xsd
@@ -55,7 +55,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>ZONE PROJECTION types for NeTEx.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<xsd:element name="ZoneProjection" abstract="false" substitutionGroup="Projection">
+	<xsd:element name="ZoneProjection" substitutionGroup="Projection">
 		<xsd:annotation>
 			<xsd:documentation>An oriented correspondence from one ZONE in a source layer,  onto a target entity : e.g.  POINT, COMPLEX FEATURE, within a defined TYPE OF PROJECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -104,7 +104,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ZoneProjection_VersionStructure" abstract="false">
+	<xsd:complexType name="ZoneProjection_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a ZONE PROJECTION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_support.xsd
@@ -65,7 +65,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a ZONE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ZoneRefStructure" abstract="false">
+	<xsd:complexType name="ZoneRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a ZONE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
@@ -93,12 +93,12 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==== ZONE ===================================================== -->
-	<xsd:element name="Zone" type="Zone_VersionStructure" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="Zone" type="Zone_VersionStructure" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A two-dimensional PLACE within the service area of a public transport operator (administrative zone, TARIFF ZONE, ACCESS ZONE, etc.).</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="Zone_VersionStructure" abstract="false">
+	<xsd:complexType name="Zone_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a ZONE.</xsd:documentation>
 		</xsd:annotation>
@@ -145,7 +145,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===== GENERAL ZONE ====================================================== -->
-	<xsd:element name="GeneralZone" abstract="false" substitutionGroup="Zone">
+	<xsd:element name="GeneralZone" substitutionGroup="Zone">
 		<xsd:annotation>
 			<xsd:documentation>A GENERAL ZONE used to define a zonal fare structure in a zone-counting or zone-matrix system.</xsd:documentation>
 		</xsd:annotation>
@@ -174,7 +174,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="GeneralZone_VersionStructure" abstract="false">
+	<xsd:complexType name="GeneralZone_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a General ZONE.</xsd:documentation>
 		</xsd:annotation>
@@ -188,7 +188,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy TARIFF ZONE  to workaround xML spy Substitution Group limitations</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="TariffZone" abstract="false" substitutionGroup="TariffZone_">
+	<xsd:element name="TariffZone" substitutionGroup="TariffZone_">
 		<xsd:annotation>
 			<xsd:documentation>A ZONE used to define a zonal fare structure in a zone-counting or zone-matrix system.</xsd:documentation>
 		</xsd:annotation>
@@ -224,7 +224,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TariffZone_VersionStructure" abstract="false">
+	<xsd:complexType name="TariffZone_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TARIFF ZONE.</xsd:documentation>
 		</xsd:annotation>
@@ -259,7 +259,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==  GROUP OF TARIFF ZONEs ============================================== -->
-	<xsd:element name="GroupOfTariffZones" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfTariffZones" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of TARIFF ZONEs which will be commonly referenced for a specific purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -329,7 +329,7 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfZone" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfZone" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>Classification of a ZONe.</xsd:documentation>
 		</xsd:annotation>
@@ -365,12 +365,12 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ZoneView" type="Zone_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="ZoneView" type="Zone_DerivedViewStructure" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of SCHEDULED STOP POINT. Includes derived some propertries of a stop.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="Zone_DerivedViewStructure" abstract="false">
+	<xsd:complexType name="Zone_DerivedViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for SCHEDULED STOP POINT VIEW.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_responsibility/netex_entity_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_entity_version.xsd
@@ -75,7 +75,7 @@ Rail transport, Roads and Road transport
 		</xsd:attribute>
 	</xsd:complexType>
 	<!-- ====Namespace =================================================================== -->
-	<xsd:element name="Codespace" abstract="false">
+	<xsd:element name="Codespace">
 		<xsd:annotation>
 			<xsd:documentation>A system for uniquely identifying objects of a given type. Used for the distributed management of objects from many different sources. For example each region of a country may be given a different codespace to use when allocating stop identifieres which will be unique within a country.</xsd:documentation>
 		</xsd:annotation>
@@ -110,7 +110,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CodespaceStructure" abstract="false">
+	<xsd:complexType name="CodespaceStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for CODESPACE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_responsibility/netex_responsibilitySet_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibilitySet_version.xsd
@@ -326,7 +326,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====== TYPE RESPONSIBILITY ROLE =================================================== -->
-	<xsd:element name="TypeOfResponsibilityRole" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfResponsibilityRole" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>Classification of a RESPONSIBILITY ROLE</xsd:documentation>
 		</xsd:annotation>
@@ -374,7 +374,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Contract" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="Contract" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A CONTRACT between ORGANISATIONs to supply services or goods.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
@@ -292,12 +292,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="BrandingRef" type="BrandingRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="BrandingRef" type="BrandingRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a BRANDING.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="BrandingRefStructure" abstract="false">
+	<xsd:complexType name="BrandingRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a BRANDING.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_responsibility/netex_validityCondition_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_validityCondition_support.xsd
@@ -62,7 +62,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="ValidityConditionRef" type="ValidityConditionRefStructure" abstract="false" substitutionGroup="VersionOfObjectRef">
+	<xsd:element name="ValidityConditionRef" type="ValidityConditionRefStructure" substitutionGroup="VersionOfObjectRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a VALIDITY CONDITION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_responsibility/netex_validityCondition_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_validityCondition_version.xsd
@@ -80,7 +80,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 	</xsd:element>
 	<!-- ======================================================================= -->
-	<xsd:element name="ValidityCondition" abstract="false" substitutionGroup="ValidityCondition_">
+	<xsd:element name="ValidityCondition" substitutionGroup="ValidityCondition_">
 		<xsd:annotation>
 			<xsd:documentation>Condition used in order to characterise a given VERSION of a VERSION FRAME. A VALIDITY CONDITION consists of a parameter (e.g. date, triggering event, etc) and its type of application (e.g. for, from, until, etc.).</xsd:documentation>
 		</xsd:annotation>
@@ -173,7 +173,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ValidityTrigger" abstract="false" substitutionGroup="ValidityCondition_">
+	<xsd:element name="ValidityTrigger" substitutionGroup="ValidityCondition_">
 		<xsd:annotation>
 			<xsd:documentation>External event defining a VALIDITY CONDITION. E.g. exceptional flow of a river, bad weather, Road closure for works.</xsd:documentation>
 		</xsd:annotation>
@@ -261,7 +261,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ValidityRuleParameter" abstract="false" substitutionGroup="ValidityCondition_">
+	<xsd:element name="ValidityRuleParameter" substitutionGroup="ValidityCondition_">
 		<xsd:annotation>
 			<xsd:documentation>A user defined VALIDITY CONDITION used by a rule for selecting versions. E.g. river level &gt; 1,5 m and bad weather.</xsd:documentation>
 		</xsd:annotation>
@@ -359,7 +359,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="SimpleValidityCondition" abstract="false">
+	<xsd:element name="SimpleValidityCondition">
 		<xsd:annotation>
 			<xsd:documentation>OPTIMISATION Simple version of a VALIDITY CONDITION used in order to characterise a given VERSION of a VERSION FRAME. Comprises a simple period.Deprecated.</xsd:documentation>
 		</xsd:annotation>
@@ -389,7 +389,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:element name="ValidBetween" abstract="false">
+	<xsd:element name="ValidBetween">
 		<xsd:annotation>
 			<xsd:documentation>OPTIMISATION. Simple version of a VALIDITY CONDITION. Comprises a simple period. NO UNIQUENESS CONSTRAINT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_responsibility/netex_versionFrame_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_versionFrame_support.xsd
@@ -121,7 +121,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfFrameRef" type="TypeOfFrameRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfFrameRef" type="TypeOfFrameRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF VERSION FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -147,7 +147,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfValidityRef" type="TypeOfValidityRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfValidityRef" type="TypeOfValidityRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF VALIDITY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_responsibility/netex_versionFrame_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_versionFrame_version.xsd
@@ -458,7 +458,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== Entity MetaClass =================================================================== -->
-	<xsd:element name="ClassInFrame" type="ClassInFrameStructure" abstract="false">
+	<xsd:element name="ClassInFrame" type="ClassInFrameStructure">
 		<xsd:annotation>
 			<xsd:documentation>Class of an entity in a VERSION FRAME. This is a metaclass that allows services to specify whether a class must or must not be present.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_access_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_access_version.xsd
@@ -143,7 +143,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:complexType name="AccessEndStructure" abstract="false">
+	<xsd:complexType name="AccessEndStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for ACCESS link end.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_address_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_address_version.xsd
@@ -162,7 +162,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!--=============================================================================-->
-	<xsd:element name="RoadAddress" abstract="false" substitutionGroup="Address">
+	<xsd:element name="RoadAddress" substitutionGroup="Address">
 		<xsd:annotation>
 			<xsd:documentation>Specialisation of ADDRESS refining it by using the characteristics such as road number, and name used for conventional identification of along a road.</xsd:documentation>
 		</xsd:annotation>
@@ -266,7 +266,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:complexType>
 	<!--=============================================================================-->
-	<xsd:element name="PostalAddress" abstract="false" substitutionGroup="Address">
+	<xsd:element name="PostalAddress" substitutionGroup="Address">
 		<xsd:annotation>
 			<xsd:documentation>A POSTAL ADDRESS to which mail can be sent.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_availabilityCondition_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_availabilityCondition_version.xsd
@@ -185,7 +185,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===A simple availability condition==================================================================== -->
-	<xsd:element name="ValidDuring" abstract="false" substitutionGroup="ValidityCondition_">
+	<xsd:element name="ValidDuring" substitutionGroup="ValidityCondition_">
 		<xsd:annotation>
 			<xsd:documentation> OPTIMISATION: Sversion  of an AVAILABILITY CONDITION    Comprises a simple period and DAY TYPE.</xsd:documentation>
 		</xsd:annotation>
@@ -285,7 +285,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===ALIAS As (DEPRECATED)======================================================== -->
-	<xsd:element name="SimpleAvailabilityCondition" abstract="false" substitutionGroup="ValidityCondition_">
+	<xsd:element name="SimpleAvailabilityCondition" substitutionGroup="ValidityCondition_">
 		<xsd:annotation>
 			<xsd:documentation>Simple version of an  AVAILABILITY CONDITION used in order to characterise a given VERSION of a VERSION FRAME.  Comprises a simple period and DAY TYPE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_support.xsd
@@ -84,7 +84,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="DeckPlanRef" type="DeckPlanRefStructure" abstract="false" substitutionGroup="VersionOfObjectRef">
+	<xsd:element name="DeckPlanRef" type="DeckPlanRefStructure" substitutionGroup="VersionOfObjectRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a DECK PLAN. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -210,7 +210,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="DeckSpaceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PassengerSpaceRef" type="PassengerSpaceRefStructure" abstract="false" substitutionGroup="DeckSpaceRef">
+	<xsd:element name="PassengerSpaceRef" type="PassengerSpaceRefStructure" substitutionGroup="DeckSpaceRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PASSENGER SPACE. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -372,7 +372,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="DeckEntranceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PassengerEntranceRef" type="PassengerEntranceRefStructure" abstract="false" substitutionGroup="DeckEntranceRef">
+	<xsd:element name="PassengerEntranceRef" type="PassengerEntranceRefStructure" substitutionGroup="DeckEntranceRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PASSENGER ENTRANCE. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -398,7 +398,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="DeckEntranceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="DeckVehicleEntranceRef" type="DeckVehicleEntranceRefStructure" abstract="false" substitutionGroup="DeckEntranceRef">
+	<xsd:element name="DeckVehicleEntranceRef" type="DeckVehicleEntranceRefStructure" substitutionGroup="DeckEntranceRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a DECK VEHICLE ENTRANCE. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -424,7 +424,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="DeckEntranceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="OtherDeckEntranceRef" type="OtherDeckEntranceRefStructure" abstract="false" substitutionGroup="DeckEntranceRef">
+	<xsd:element name="OtherDeckEntranceRef" type="OtherDeckEntranceRefStructure" substitutionGroup="DeckEntranceRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an OTHER DECK ENTRANCE. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -634,12 +634,12 @@
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfDeckSpaceRef" type="TypeOfDeckSpaceProfileRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="TypeOfDeckSpaceRef" type="TypeOfDeckSpaceProfileRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF DECK SPACE PROFILE. +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfDeckSpaceProfileRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfDeckSpaceProfileRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a TYPE OF DECK SPACE PROFILE.</xsd:documentation>
 		</xsd:annotation>
@@ -660,12 +660,12 @@
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfDeckEntranceRef" type="TypeOfDeckEntranceRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="TypeOfDeckEntranceRef" type="TypeOfDeckEntranceRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF DECK ENTRANCE. +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfDeckEntranceRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfDeckEntranceRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a TYPE OF DECK ENTRANCE.</xsd:documentation>
 		</xsd:annotation>
@@ -686,12 +686,12 @@
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfDeckEntranceUsageRef" type="TypeOfDeckEntranceUsageRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="TypeOfDeckEntranceUsageRef" type="TypeOfDeckEntranceUsageRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF DECK VEHICLE ENTRANCE USAGE. +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfDeckEntranceUsageRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfDeckEntranceUsageRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a TYPE OF DECK VEHICLE ENTRANCE USAGE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -212,7 +212,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Deck_VersionStructure" abstract="false">
+	<xsd:complexType name="Deck_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a DECK.</xsd:documentation>
 		</xsd:annotation>
@@ -266,7 +266,7 @@
 			<xsd:documentation>An abstract element providing common features for spatially located elements within the DECK PLAN. +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="DeckComponent_VersionStructure" abstract="false">
+	<xsd:complexType name="DeckComponent_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a DECK COMPONENT.</xsd:documentation>
 		</xsd:annotation>
@@ -1006,7 +1006,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="DeckEntranceUsage_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="DeckEntranceUsage_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a DECK ENTRANCE USAGE.</xsd:documentation>
 		</xsd:annotation>
@@ -1089,7 +1089,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="DeckEntranceCouple_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="DeckEntranceCouple_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a DECK ENTRANCE COUPLE.</xsd:documentation>
 		</xsd:annotation>
@@ -1385,7 +1385,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ========= TYPE OF DECK SPACE ============================================ -->
-	<xsd:element name="TypeOfDeckSpace" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfDeckSpace" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Classification for DECK SPACE, e.g. as WC, Restaurant, luggage area, etc. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -1412,7 +1412,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfDeckSpace_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfDeckSpace_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF DECK SPACE.</xsd:documentation>
 		</xsd:annotation>
@@ -1421,7 +1421,7 @@
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- =========TYPE OF DECK ENTRANCE. ============================================ -->
-	<xsd:element name="TypeOfDeckEntrance" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfDeckEntrance" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Classification for TYPE OF DECK ENTRANCE . +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -1448,7 +1448,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfDeckEntrance_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfDeckEntrance_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF DECK ENTRANCE.</xsd:documentation>
 		</xsd:annotation>
@@ -1457,7 +1457,7 @@
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- =========TYPE OF DECK ENTRANCE USAGE. ============================================ -->
-	<xsd:element name="TypeOfDeckEntranceUsage" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfDeckEntranceUsage" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Open classification for DECK  USAGE. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -1484,7 +1484,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfDeckEntranceUsage_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfDeckEntranceUsage_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF DECK ENTRANCE USAGE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
@@ -94,7 +94,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to an ACCESS VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="AccessVehicleEquipmentRefStructure" abstract="false">
+	<xsd:complexType name="AccessVehicleEquipmentRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to an ACCESS VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -120,7 +120,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a WHEELCHAIR VEHICLE EQUIPMENT. DEPRECATED -v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="WheelchairVehicleRefStructure" abstract="false">
+	<xsd:complexType name="WheelchairVehicleRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>DEPRECATED -v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -139,7 +139,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="WheelchairVehicleEquipmentRefStructure" abstract="false">
+	<xsd:complexType name="WheelchairVehicleEquipmentRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -172,7 +172,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfWheelchairRef" type="TypeOfWheelchairRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfWheelchairRef" type="TypeOfWheelchairRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF WHEELCHAIR. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -100,12 +100,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ActualVehicleEquipment" type="ActualVehicleEquipment_VersionStructure" abstract="false" substitutionGroup="PassengerEquipment">
+	<xsd:element name="ActualVehicleEquipment" type="ActualVehicleEquipment_VersionStructure" substitutionGroup="PassengerEquipment">
 		<xsd:annotation>
 			<xsd:documentation>An item of EQUIPMENT of a particular type actually available in an individual VEHICLE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ActualVehicleEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="ActualVehicleEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Abstract Type for an ACTUAL VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -170,7 +170,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="AccessVehicleEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="AccessVehicleEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an ACCESS VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -340,7 +340,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="WheelchairVehicleEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="WheelchairVehicleEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -400,7 +400,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- =========TYPE OF DECK ENTRANCE. ============================================ -->
-	<xsd:element name="TypeOfWheelchair" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfWheelchair" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Classification for TYPE OF WHEELCHAIR. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -427,7 +427,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfWheelchair_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfWheelchair_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF WHEELCHAIR.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipment_version.xsd
@@ -271,7 +271,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfEquipment" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfEquipment" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of a EQUIPMENT according to its functional purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -294,7 +294,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfEquipment_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfEquipment_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_facility_support.xsd
@@ -1032,12 +1032,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfFacilityRef" type="TypeOfFacilityRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfFacilityRef" type="TypeOfFacilityRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF FACILITY.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfFacilityRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfFacilityRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a TYPE OF FACILITY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_facility_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_facility_version.xsd
@@ -126,7 +126,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Facility. Set of enumerated FACILITY values (names based on TPEG classifications, augmented with UIC etc.).</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="FacilitySet_VersionStructure" abstract="false">
+	<xsd:complexType name="FacilitySet_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a FACILITY.</xsd:documentation>
 		</xsd:annotation>
@@ -295,7 +295,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ServiceFacilitySet" abstract="false" substitutionGroup="FacilitySet">
+	<xsd:element name="ServiceFacilitySet" substitutionGroup="FacilitySet">
 		<xsd:annotation>
 			<xsd:documentation>Service FACILITY. Set of enumerated FACILITY values (Where available names are based on TPEG classifications, augmented with UIC etc.).</xsd:documentation>
 		</xsd:annotation>
@@ -544,7 +544,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfFacility" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfFacility" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of FACILITYs expressing their general functionalities and local functional characteristics specific to the operator. Types of FACILITYs like e.g. throw-away ticket, throw-away ticket unit, value card, electronic purse allowing access, public transport credit card etc. may be used to define these categories.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_support.xsd
@@ -114,7 +114,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ConventionalModeOfOperationIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="ScheduledModeOfOperationRef" type="ScheduledModeOfOperationRefStructure" abstract="false" substitutionGroup="ConventionalModeOfOperationRef">
+	<xsd:element name="ScheduledModeOfOperationRef" type="ScheduledModeOfOperationRefStructure" substitutionGroup="ConventionalModeOfOperationRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a SCHEDULED MODE OF OPERATION. +V1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -149,7 +149,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ConventionalModeOfOperationIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="FlexibleModeOfOperationRef" type="FlexibleModeOfOperationRefStructure" abstract="false" substitutionGroup="ConventionalModeOfOperationRef">
+	<xsd:element name="FlexibleModeOfOperationRef" type="FlexibleModeOfOperationRefStructure" substitutionGroup="ConventionalModeOfOperationRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a FLEXIBLE MODE OF OPERATION.</xsd:documentation>
 		</xsd:annotation>
@@ -211,7 +211,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="AlternativeModeOfOperationIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="VehicleRentalRef" type="VehicleRentalModeOfOperationRefStructure" abstract="false" substitutionGroup="AlternativeModeOfOperationRef">
+	<xsd:element name="VehicleRentalRef" type="VehicleRentalModeOfOperationRefStructure" substitutionGroup="AlternativeModeOfOperationRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a VEHICLE RENTAL MODE OF OPERATION. +V1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -246,7 +246,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="AlternativeModeOfOperationIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="VehicleSharingRef" type="VehicleSharingModeOfOperationRefStructure" abstract="false" substitutionGroup="AlternativeModeOfOperationRef">
+	<xsd:element name="VehicleSharingRef" type="VehicleSharingModeOfOperationRefStructure" substitutionGroup="AlternativeModeOfOperationRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a VEHICLE SHARING MODE OF OPERATION. +V1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -282,7 +282,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="AlternativeModeOfOperationIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="VehiclePoolingRef" type="VehiclePoolingModeOfOperationRefStructure" abstract="false" substitutionGroup="AlternativeModeOfOperationRef">
+	<xsd:element name="VehiclePoolingRef" type="VehiclePoolingModeOfOperationRefStructure" substitutionGroup="AlternativeModeOfOperationRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a VEHICLE POOLING MODE OF OPERATION. +V1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -323,7 +323,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ModeOfOperationIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PersonalModeOfOperationRef" type="PersonalModeOfOperationRefStructure" abstract="false" substitutionGroup="ModeOfOperationRef">
+	<xsd:element name="PersonalModeOfOperationRef" type="PersonalModeOfOperationRefStructure" substitutionGroup="ModeOfOperationRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PERSONAL MODE OF OPERATION. +V1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_version.xsd
@@ -101,7 +101,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ModeOfOperation_ValueStructure" abstract="false">
+	<xsd:complexType name="ModeOfOperation_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a MODE OF OPERATION.</xsd:documentation>
 		</xsd:annotation>
@@ -173,7 +173,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ScheduledOperation" abstract="false" substitutionGroup="ConventionalModeOfOperation_">
+	<xsd:element name="ScheduledOperation" substitutionGroup="ConventionalModeOfOperation_">
 		<xsd:annotation>
 			<xsd:documentation>The operation of a transportation using any kind of vehicle with a predefined time table. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -227,7 +227,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="FlexibleOperation" abstract="false" substitutionGroup="ConventionalModeOfOperation_">
+	<xsd:element name="FlexibleOperation" substitutionGroup="ConventionalModeOfOperation_">
 		<xsd:annotation>
 			<xsd:documentation>Passenger transport operation linked to a fixed network/schedule but offering flexibility, in order for instance, to optimise the service or to satisfy passenger demand. +v1.2.2
 </xsd:documentation>
@@ -482,7 +482,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ====== PERSONAL MODEs  ============================================ -->
-	<xsd:element name="PersonalModeOfOperation" abstract="false" substitutionGroup="ModeOfOperation_">
+	<xsd:element name="PersonalModeOfOperation" substitutionGroup="ModeOfOperation_">
 		<xsd:annotation>
 			<xsd:documentation>A non-advertised mode of operation of vehicles by persons using their own vehicle. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_chargingEquipmentProfile_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_chargingEquipmentProfile_version.xsd
@@ -83,7 +83,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RechargingEquipmentProfile_VersionStructure" abstract="false">
+	<xsd:complexType name="RechargingEquipmentProfile_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a RECHARGING EQUIPMENT PROFILE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_equipmentEnergy_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_equipmentEnergy_support.xsd
@@ -156,7 +156,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfBatteryChemistryRef" type="TypeOfBatteryChemistryRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfBatteryChemistryRef" type="TypeOfBatteryChemistryRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF BATTERY CHEMISTRY. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -182,7 +182,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfPlugRef" type="TypeOfPlugRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfPlugRef" type="TypeOfPlugRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF PLUG. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_equipmentEnergy_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_equipmentEnergy_version.xsd
@@ -94,7 +94,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleChargingEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleChargingEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a VEHICLE CHARGING EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -188,7 +188,7 @@ points cannot exceed this value.</xsd:documentation>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RefuellingEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="RefuellingEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a REFUELLING EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -243,7 +243,7 @@ points cannot exceed this value.</xsd:documentation>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="BatteryEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="BatteryEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a BATTERY EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -291,7 +291,7 @@ points cannot exceed this value.</xsd:documentation>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====TYPE OF BATTERY CHEMISTRY ======================================================== -->
-	<xsd:element name="TypeOfBatteryChemistry" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfBatteryChemistry" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of a BATTERY CHEMISTRY  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -319,7 +319,7 @@ points cannot exceed this value.</xsd:documentation>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfBatteryChemistry_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfBatteryChemistry_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF BATTERY CHEMISTRY. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -328,7 +328,7 @@ points cannot exceed this value.</xsd:documentation>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====TYPE OF BATTERY CHEMISTRY ======================================================== -->
-	<xsd:element name="TypeOfPlug" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfPlug" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of a PLUG  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -356,7 +356,7 @@ points cannot exceed this value.</xsd:documentation>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfPlug_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfPlug_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF PLUG. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_fleetEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_fleetEquipment_version.xsd
@@ -154,7 +154,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- =======CAR MODEL PROFILE================================================== -->
-	<xsd:element name="CarModelProfile" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="CarModelProfile" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A set of characteristics of equipment installed on-board and characterising a CAR MODEL PROFILE. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -184,7 +184,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CarModelProfile_VersionStructure" abstract="false">
+	<xsd:complexType name="CarModelProfile_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a CAR MODEL PROFILE.</xsd:documentation>
 		</xsd:annotation>
@@ -304,7 +304,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CycleModelProfile_VersionStructure" abstract="false">
+	<xsd:complexType name="CycleModelProfile_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a CYCLE MODEL PROFILE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_fleet_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_fleet_support.xsd
@@ -101,12 +101,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfFleetRef" type="TypeOfFleetRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="TypeOfFleetRef" type="TypeOfFleetRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF FLEET. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfFleetRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfFleetRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a TYPE OF FLEET.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_fleet_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_fleet_version.xsd
@@ -137,7 +137,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== TYPE OF FLEET ============================================================ -->
-	<xsd:element name="TypeOfFleet" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfFleet" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>A classification for a FLEET of VEHICLEs.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -164,7 +164,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfFleet_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfFleet_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF FLEET.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_noticeAssignment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_noticeAssignment_version.xsd
@@ -108,7 +108,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy abstract NOTICE ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="NoticeAssignment" abstract="false" substitutionGroup="NoticeAssignment_">
+	<xsd:element name="NoticeAssignment" substitutionGroup="NoticeAssignment_">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a NOTICE showing an exception in a JOURNEY PATTERN, a COMMON SECTION, or a VEHICLE JOURNEY, possibly specifying at which POINT IN JOURNEY PATTERN the validity of the NOTICE starts and ends respectively.</xsd:documentation>
 		</xsd:annotation>
@@ -235,7 +235,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="NoticeAssignmentView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="NoticeAssignmentView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>View of a NOTICE ASSIGNMENT. for use in a specific context such as a CALL. This can be used to embed the notice itself in the context.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_notice_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_notice_version.xsd
@@ -85,7 +85,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Notice" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="Notice" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A note or footnote about any aspect of a service, e.g. an announcement, notice, etc. May have different DELIVERY VARIANTs for different media.</xsd:documentation>
 		</xsd:annotation>
@@ -195,7 +195,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DeliveryVariant" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="DeliveryVariant" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A variant text of a NOTICE for use in a specific media or delivery channel (voice, printed material, etc).</xsd:documentation>
 		</xsd:annotation>
@@ -259,7 +259,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfNotice" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfNotice" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of a NOTICE according to its functional purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -282,7 +282,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfNotice_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfNotice_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF NOTICe.</xsd:documentation>
 		</xsd:annotation>
@@ -291,7 +291,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfDeliveryVariant" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfDeliveryVariant" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of DELIVERY VARIANT according to its functional purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -314,7 +314,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfDeliveryVariant_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfDeliveryVariant_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF DELIVERY VARIANT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_support.xsd
@@ -240,7 +240,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="LocatableSpotIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PassengerSpotRef" type="PassengerSpotRefStructure" abstract="false" substitutionGroup="LocatableSpotRef">
+	<xsd:element name="PassengerSpotRef" type="PassengerSpotRefStructure" substitutionGroup="LocatableSpotRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PASSENGER SPOT. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -266,7 +266,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="LocatableSpotIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PassengerVehicleSpotRef" type="PassengerVehicleSpotRefStructure" abstract="false" substitutionGroup="LocatableSpotRef">
+	<xsd:element name="PassengerVehicleSpotRef" type="PassengerVehicleSpotRefStructure" substitutionGroup="LocatableSpotRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PASSENGER VEHICLE SPOT. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -292,7 +292,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="LocatableSpotIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="LuggageSpotRef" type="LuggageSpotRefStructure" abstract="false" substitutionGroup="LocatableSpotRef">
+	<xsd:element name="LuggageSpotRef" type="LuggageSpotRefStructure" substitutionGroup="LocatableSpotRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a LUGGAGE SPOT. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -318,12 +318,12 @@
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfLocatableSpotRef" type="TypeOfLocatableSpotRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="TypeOfLocatableSpotRef" type="TypeOfLocatableSpotRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF LOCATABLE SPOT. +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfLocatableSpotRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfLocatableSpotRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a TYPE OF LOCATABLE SPOT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
@@ -373,7 +373,7 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:complexType name="PassengerSpot_VersionStructure" abstract="false">
+	<xsd:complexType name="PassengerSpot_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PASSENGER SPOT.</xsd:documentation>
 		</xsd:annotation>
@@ -448,7 +448,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== PASSENGER VEHICLE SPOT =================================== -->
-	<xsd:element name="PassengerSpot" abstract="false" substitutionGroup="LocatableSpot">
+	<xsd:element name="PassengerSpot" substitutionGroup="LocatableSpot">
 		<xsd:annotation>
 			<xsd:documentation>A designated seat or other space for a passenger within a given DECK SPACE. +v2.0.</xsd:documentation>
 		</xsd:annotation>
@@ -502,7 +502,7 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PassengerVehicleSpot" abstract="false" substitutionGroup="LocatableSpot">
+	<xsd:element name="PassengerVehicleSpot" substitutionGroup="LocatableSpot">
 		<xsd:annotation>
 			<xsd:documentation> A designated space to stow a passenger's luggage onboard.+v2.0.</xsd:documentation>
 		</xsd:annotation>
@@ -543,7 +543,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PassengerVehicleSpot_VersionStructure" abstract="false">
+	<xsd:complexType name="PassengerVehicleSpot_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PASSENGER VEHICLE SPOT.</xsd:documentation>
 		</xsd:annotation>
@@ -586,7 +586,7 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="LuggageSpot" abstract="false" substitutionGroup="LocatableSpot">
+	<xsd:element name="LuggageSpot" substitutionGroup="LocatableSpot">
 		<xsd:annotation>
 			<xsd:documentation> A specified space to stow a passenger's luggage onboard.+v2.0.</xsd:documentation>
 		</xsd:annotation>
@@ -627,7 +627,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LuggageSpot_VersionStructure" abstract="false">
+	<xsd:complexType name="LuggageSpot_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a LUGGAGE SPOT.</xsd:documentation>
 		</xsd:annotation>
@@ -657,7 +657,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ========= TYPE OF LOCATABLE SPOT ============================================ -->
-	<xsd:element name="TypeOfLocatableSpot" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfLocatableSpot" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Classification for LOCATABLE SPOT. +v2.0.</xsd:documentation>
 		</xsd:annotation>
@@ -684,7 +684,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfLocatableSpot_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfLocatableSpot_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF LOCATABLE SPOT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_securityList_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_securityList_support.xsd
@@ -114,7 +114,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="SecurityListIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="BlacklistRef" type="BlacklistRefStructure" abstract="false" substitutionGroup="SecurityListRef">
+	<xsd:element name="BlacklistRef" type="BlacklistRefStructure" substitutionGroup="SecurityListRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a BLACKLIST.</xsd:documentation>
 		</xsd:annotation>
@@ -152,12 +152,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="SecurityListIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="WhitelistRef" type="WhitelistRefStructure" abstract="false" substitutionGroup="SecurityListRef">
+	<xsd:element name="WhitelistRef" type="WhitelistRefStructure" substitutionGroup="SecurityListRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a WHITELIST.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="WhitelistRefStructure" abstract="false">
+	<xsd:complexType name="WhitelistRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Reference to a WHITELIST.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_securityList_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_securityList_version.xsd
@@ -266,7 +266,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfSecurityList" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfSecurityList" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>A classification of SECURITY LIST. +v1.1</xsd:documentation>
 		</xsd:annotation>
@@ -312,7 +312,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Blacklist" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="Blacklist" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A list of items (TRAVEL DOCUMENTs,  CONTRACTs etc) the validity of which has been cancelled temporarily or permanently, for a specific reason like loss of the document, technical malfunction, no credit on bank account, offences committed by the customer, etc.</xsd:documentation>
 		</xsd:annotation>
@@ -374,7 +374,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Whitelist" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="Whitelist" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A list of  items (TRAVEL DOCUMENTs, CONTRACTs, etc) explicitly approved for processing.+v1.1</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_version.xsd
@@ -117,7 +117,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="SensorEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="SensorEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SENSOR EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -175,7 +175,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="SpotSensor_VersionStructure" abstract="false">
+	<xsd:complexType name="SpotSensor_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SPOT SENSOR.</xsd:documentation>
 		</xsd:annotation>
@@ -227,7 +227,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="EntranceSensor_VersionStructure" abstract="false">
+	<xsd:complexType name="EntranceSensor_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a ENTRANCE SENSOR.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_support.xsd
@@ -774,7 +774,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfServiceRef" type="TypeOfServiceRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfServiceRef" type="TypeOfServiceRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -812,7 +812,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfProductCategoryRef" type="TypeOfProductCategoryRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="TypeOfProductCategoryRef" type="TypeOfProductCategoryRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF PRODUCT CATEGORY. Product of a JOURNEY. e.g. ICS, Thales etc
 See ERA B.4 7037 Characteristic description code.</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_version.xsd
@@ -209,7 +209,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="BookingArrangement_VersionStructure" abstract="false">
+	<xsd:complexType name="BookingArrangement_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a BOOKING ARRANGEMENT</xsd:documentation>
 		</xsd:annotation>
@@ -283,7 +283,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- =Deprecated structures for BookingArrangements (for backward compatibility only)========== -->
-	<xsd:complexType name="BookingArrangementsStructure" abstract="false">
+	<xsd:complexType name="BookingArrangementsStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for BOOKING ARRANGEMENTs.</xsd:documentation>
 		</xsd:annotation>
@@ -412,7 +412,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ServiceBookingArrangement_VersionStructure" abstract="false">
+	<xsd:complexType name="ServiceBookingArrangement_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Version of a SERVICE BOOKING ARRANGEMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -529,7 +529,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfService" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfService" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>Classification of a Service.</xsd:documentation>
 		</xsd:annotation>
@@ -556,7 +556,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfServiceStructure" abstract="false">
+	<xsd:complexType name="TypeOfServiceStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -565,7 +565,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfProductCategory" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfProductCategory" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Classification of a PRODUCT CATEGORY.</xsd:documentation>
 		</xsd:annotation>
@@ -595,7 +595,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfProductCategoryStructure" abstract="false">
+	<xsd:complexType name="TypeOfProductCategoryStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF PRODUCT CATEGORY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_spotAffinity_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_spotAffinity_support.xsd
@@ -65,7 +65,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="SpotAffinityRef" type="SpotAffinityRefStructure" abstract="false" substitutionGroup="VersionOfObjectRef">
+	<xsd:element name="SpotAffinityRef" type="SpotAffinityRefStructure" substitutionGroup="VersionOfObjectRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a SPOT AFFINITY. +v2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_spotAffinity_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_spotAffinity_version.xsd
@@ -73,13 +73,13 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SpotAffinity" type="SpotAffinity_VersionStructure" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="SpotAffinity" type="SpotAffinity_VersionStructure" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A group of proximate seats suitable for selection for use by a group of travellers, for example, as being side by side, face to face, around a table, near a wheelchair spot, etc.
  +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="SpotAffinity_VersionStructure" abstract="false">
+	<xsd:complexType name="SpotAffinity_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SPOT AFFINITY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
@@ -56,7 +56,7 @@
 		<xsd:documentation>SPOT EQUIPMENT types for NeTEx.</xsd:documentation>
 	</xsd:annotation>
 	<!-- === SPOT EQUIPMENT ============================================ -->
-	<xsd:element name="SpotEquipment_" substitutionGroup="InstalledEquipment">
+	<xsd:element name="SpotEquipment_" abstract="true" substitutionGroup="InstalledEquipment">
 		<xsd:annotation>
 			<xsd:documentation>An abstract EQUIPMENT in a LOCATABLE SPOT providing a onboard seat, bed or other amenity. +V2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
@@ -113,7 +113,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="SpotEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="SpotEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SPOT EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -196,7 +196,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="SeatEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="SeatEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SEAT EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -284,7 +284,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="BedEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="BedEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a BED EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -357,7 +357,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LuggageSpotEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="LuggageSpotEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a LUGGAGE SPOT EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_topographicPlace_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_topographicPlace_version.xsd
@@ -278,7 +278,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==GROUP OF PLACEs=========================================================== -->
-	<xsd:element name="GroupOfPlaces" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfPlaces" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of PLACEs which will be commonly referenced for a specific purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -378,7 +378,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TopographicProjection" abstract="false" substitutionGroup="Projection">
+	<xsd:element name="TopographicProjection" substitutionGroup="Projection">
 		<xsd:annotation>
 			<xsd:documentation>TOPOGRAPHICAL PROJECTION allows any ZONE to be directly mapped to a TOPOGRAPHICAL PLACE, e.g. a TARIFF ZONE, ADMINISTRATIVE ZONE can be stated as having the same bounds as another zone. +v1.1</xsd:documentation>
 		</xsd:annotation>
@@ -412,7 +412,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TopographicProjection_VersionStructure" abstract="false">
+	<xsd:complexType name="TopographicProjection_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TOPOGRAPHIC  PROJECTION. +v1.1</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_trainElementType_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_trainElementType_support.xsd
@@ -64,7 +64,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TrainIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PoweredTrainRef" type="PoweredTrainRefStructure" abstract="false" substitutionGroup="TrainRef">
+	<xsd:element name="PoweredTrainRef" type="PoweredTrainRefStructure" substitutionGroup="TrainRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a POWERED TRAIN. v2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_trainElementType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_trainElementType_version.xsd
@@ -84,7 +84,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====== POWERED TRAIN =================================================== -->
-	<xsd:element name="PoweredTrain" abstract="false" substitutionGroup="Train_DummyType">
+	<xsd:element name="PoweredTrain" substitutionGroup="Train_DummyType">
 		<xsd:annotation>
 			<xsd:documentation>A TRAIN that is able to move under its own power. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -140,7 +140,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ====== UNPOWERED TRAIN =================================================== -->
-	<xsd:element name="UnpoweredTrain" abstract="false" substitutionGroup="Train_DummyType">
+	<xsd:element name="UnpoweredTrain" substitutionGroup="Train_DummyType">
 		<xsd:annotation>
 			<xsd:documentation>A TRAIN that is able to move under its own power. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -200,7 +200,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ====== TRACTIVE ELEMENT TYPE =================================================== -->
-	<xsd:element name="TractiveElementType" abstract="false">
+	<xsd:element name="TractiveElementType">
 		<xsd:annotation>
 			<xsd:documentation>A TRAIN ELEMENT TYPE that is self-propelled, e.g., a locomotive or powered railcar. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -245,7 +245,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ====== TRAILING ELEMENT TYPE =============================================== -->
-	<xsd:element name="TrailingElementType" abstract="false">
+	<xsd:element name="TrailingElementType">
 		<xsd:annotation>
 			<xsd:documentation>A TRAIN ELEMENT TYPE that cannot propel itself, e.g. a railway carriage, luggage van, passenger vehicle wagon, etc. +v2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_trainElement_version.xsd
@@ -200,7 +200,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Train_VersionStructure" abstract="false">
+	<xsd:complexType name="Train_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TRAIN.</xsd:documentation>
 		</xsd:annotation>
@@ -274,7 +274,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CompoundTrain_VersionStructure" abstract="false">
+	<xsd:complexType name="CompoundTrain_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for COMPOUND TRAIN.</xsd:documentation>
 		</xsd:annotation>
@@ -344,7 +344,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TrainElementType_VersionStructure" abstract="false">
+	<xsd:complexType name="TrainElementType_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TRAIN ELEMENT TYPE.</xsd:documentation>
 		</xsd:annotation>
@@ -492,7 +492,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TrainComponent_VersionStructure" abstract="false">
+	<xsd:complexType name="TrainComponent_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TRAIN COMPONENT.</xsd:documentation>
 		</xsd:annotation>
@@ -544,7 +544,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:complexType name="TrainComponentCouplingStructure" abstract="false">
+	<xsd:complexType name="TrainComponentCouplingStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TRAIN COMPONENT COUPLING.</xsd:documentation>
 		</xsd:annotation>
@@ -578,7 +578,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:complexType name="TrainInCompoundTrain_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="TrainInCompoundTrain_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TRAIN IN COMPOUND TRAIN.</xsd:documentation>
 		</xsd:annotation>
@@ -639,7 +639,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TrainComponentView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="TrainComponentView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of TRAIN COMPONENT +2.0.</xsd:documentation>
 		</xsd:annotation>
@@ -649,7 +649,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TrainComponent_DerivedViewStructure" abstract="false">
+	<xsd:complexType name="TrainComponent_DerivedViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TRAIN COMPONENT VIEW.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_version.xsd
@@ -390,7 +390,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ==== GROUP OF OPERATORs ========================================================== -->
-	<xsd:element name="GroupOfOperators" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfOperators" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of OPERATORs.</xsd:documentation>
 		</xsd:annotation>
@@ -675,7 +675,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===== TRANSPORT ADMINISTRATIVE ZONE ================================================ -->
-	<xsd:element name="TransportAdministrativeZone" abstract="false" substitutionGroup="AdministrativeZone_">
+	<xsd:element name="TransportAdministrativeZone" substitutionGroup="AdministrativeZone_">
 		<xsd:annotation>
 			<xsd:documentation>A ZONE relating to the management responsibilities of an ORGANISATION. For example to allocate bus stop identifiers for a region.</xsd:documentation>
 		</xsd:annotation>
@@ -714,7 +714,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TransportAdministrativeZone_VersionStructure" abstract="false">
+	<xsd:complexType name="TransportAdministrativeZone_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an TRANSPORT ADMINISTRATIVE  ZONE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_support.xsd
@@ -636,12 +636,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PurposeOfEquipmentProfileRef" type="PurposeOfEquipmentProfileRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="PurposeOfEquipmentProfileRef" type="PurposeOfEquipmentProfileRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PURPOSE OF EQUIPMENT PROFILE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="PurposeOfEquipmentProfileRefStructure" abstract="false">
+	<xsd:complexType name="PurposeOfEquipmentProfileRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a PURPOSE OF EQUIPMENT PROFILE.</xsd:documentation>
 		</xsd:annotation>
@@ -700,12 +700,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="AcceptedDriverPermitRef" type="AcceptedDriverPermitRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="AcceptedDriverPermitRef" type="AcceptedDriverPermitRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an ACCEPTED DRIVER PERMIT.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="AcceptedDriverPermitRefStructure" abstract="false">
+	<xsd:complexType name="AcceptedDriverPermitRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to an ACCEPTED DRIVER PERMIT.</xsd:documentation>
 		</xsd:annotation>
@@ -726,12 +726,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfDriverPermitRef" type="TypeOfDriverPermitRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="TypeOfDriverPermitRef" type="TypeOfDriverPermitRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF DRIVER PERMIT.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfDriverPermitRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfDriverPermitRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a TYPE OF DRIVER PERMIT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -540,7 +540,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="AcceptedDriverPermit_VersionStructure" abstract="false">
+	<xsd:complexType name="AcceptedDriverPermit_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an ACCEPTED DRIVER PERMIT.</xsd:documentation>
 		</xsd:annotation>
@@ -1093,7 +1093,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleModel_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleModel_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a VEHICLE MODEL.</xsd:documentation>
 		</xsd:annotation>
@@ -1190,7 +1190,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleEquipmentProfile_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleEquipmentProfile_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a VEHICLE EQUIPMENT PROFILE.</xsd:documentation>
 		</xsd:annotation>
@@ -1277,7 +1277,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleEquipmentProfileMember_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleEquipmentProfileMember_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a VEHICLE EQUIPMENT PROFILE MEMBER.</xsd:documentation>
 		</xsd:annotation>
@@ -1312,7 +1312,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ========= PURPOSE OF EQUIPMENT ============================================ -->
-	<xsd:element name="PurposeOfEquipmentProfile" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="PurposeOfEquipmentProfile" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>A functional purpose which requires a certain set of EQUIPMENT of different types put together in a VEHICLE EQUIPMENT PROFILE or STOP POINT EQUIPMENT PROFILE.</xsd:documentation>
 		</xsd:annotation>
@@ -1339,7 +1339,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PurposeOfEquipmentProfile_ValueStructure" abstract="false">
+	<xsd:complexType name="PurposeOfEquipmentProfile_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PURPOSE OF EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -1348,7 +1348,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- =========TYPE OF DRIVER PERMIT. ============================================ -->
-	<xsd:element name="TypeOfDriverPermit" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfDriverPermit" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>A type of driving license (e.g. https://en.wikipedia.org/wiki/European_driving_licence ). +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -1375,7 +1375,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfDriverPermit_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfDriverPermit_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF DRIVER PERMIT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicle_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicle_support.xsd
@@ -234,7 +234,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a TYPE OF ROLLING STOCK. +V2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfRollingStockRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfRollingStockRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF ROLLING STOCK.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicle_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicle_version.xsd
@@ -156,7 +156,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Vehicle_VersionStructure" abstract="false">
+	<xsd:complexType name="Vehicle_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a VEHICLE.</xsd:documentation>
 		</xsd:annotation>
@@ -323,7 +323,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== TRAILING ROLLING STOCK ITEM ===================================================== -->
-	<xsd:element name="TrailingRollingStockItem" abstract="false" substitutionGroup="RollingStockItem_DummyType">
+	<xsd:element name="TrailingRollingStockItem" substitutionGroup="RollingStockItem_DummyType">
 		<xsd:annotation>
 			<xsd:documentation>An unpowered item of rolling stock such as a specific passenger carriage, luggage van, passenger vehicle carrier wagon or freight wagon. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -356,7 +356,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TrailingRollingStockItem_VersionStructure" abstract="false">
+	<xsd:complexType name="TrailingRollingStockItem_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TRAILING ROLLING STOCK ITEM.</xsd:documentation>
 		</xsd:annotation>
@@ -377,7 +377,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== TRACTIVE ROLLING STOCK ITEM ===================================================== -->
-	<xsd:element name="TractiveRollingStockItem" abstract="false" substitutionGroup="RollingStockItem_DummyType">
+	<xsd:element name="TractiveRollingStockItem" substitutionGroup="RollingStockItem_DummyType">
 		<xsd:annotation>
 			<xsd:documentation>A powered item of rolling stock, such as a specific locomotive or powered railcar. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -410,7 +410,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TractiveRollingStockItem_VersionStructure" abstract="false">
+	<xsd:complexType name="TractiveRollingStockItem_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TRACTIVE ROLLING STOCK ITEM.</xsd:documentation>
 		</xsd:annotation>
@@ -476,7 +476,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RollingStockInventory_VersionStructure" abstract="false">
+	<xsd:complexType name="RollingStockInventory_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a ROLLING STOCK INVENTORY.</xsd:documentation>
 		</xsd:annotation>
@@ -507,12 +507,12 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===== TYPE OF ROLLING STOCK =================================================== -->
-	<xsd:element name="TypeOfRollingStock" type="TypeOfRollingStock_ValueStructure" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfRollingStock" type="TypeOfRollingStock_ValueStructure" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of a ROLLING STOCK ITEM according to its functional purpose. +v1.1.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfRollingStock_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfRollingStock_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF ROLLING STOCK. +v2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_utility/netex_utility_contact.xsd
+++ b/xsd/netex_framework/netex_utility/netex_utility_contact.xsd
@@ -58,7 +58,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>Contact utility types for NeTEx.</xsd:documentation>
 	</xsd:annotation>
 	<!--====Basic Types =======================================================================-->
-	<xsd:complexType name="ContactDetailsStructure" abstract="false">
+	<xsd:complexType name="ContactDetailsStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for contact details.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_frames/netex_infrastructureFrame_version.xsd
+++ b/xsd/netex_part_1/part1_frames/netex_infrastructureFrame_version.xsd
@@ -64,7 +64,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="InfrastructureFrameRef" type="InfrastructureFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="InfrastructureFrameRef" type="InfrastructureFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an INFRASTRUCTURE FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -84,7 +84,7 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="InfrastructureFrame" abstract="false" substitutionGroup="CommonFrame">
+	<xsd:element name="InfrastructureFrame" substitutionGroup="CommonFrame">
 		<xsd:annotation>
 			<xsd:documentation>A coherent set of infrastructure network description data to which the same VALIDITY CONDITIONs have been assigned.</xsd:documentation>
 		</xsd:annotation>
@@ -110,7 +110,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Infrastructure_VersionFrameStructure" abstract="false">
+	<xsd:complexType name="Infrastructure_VersionFrameStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an INFRASTRUCTURE FRAME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_frames/netex_siteFrame_version.xsd
+++ b/xsd/netex_part_1/part1_frames/netex_siteFrame_version.xsd
@@ -79,12 +79,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="SiteFrameRef" type="SiteFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="SiteFrameRef" type="SiteFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a SITE FRAME.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="SiteFrameRefStructure" abstract="false">
+	<xsd:complexType name="SiteFrameRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a SITE FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -95,7 +95,7 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="SiteFrame" abstract="false" substitutionGroup="CommonFrame">
+	<xsd:element name="SiteFrame" substitutionGroup="CommonFrame">
 		<xsd:annotation>
 			<xsd:documentation>A coherent set of SITE data to which the same frame VALIDITY CONDITIONs have been assigned.</xsd:documentation>
 		</xsd:annotation>
@@ -121,7 +121,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Site_VersionFrameStructure" abstract="false">
+	<xsd:complexType name="Site_VersionFrameStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SITE FRAME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_assistanceBooking_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_assistanceBooking_version.xsd
@@ -80,7 +80,7 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="AssistanceBookingService" abstract="false" substitutionGroup="LocalService">
+	<xsd:element name="AssistanceBookingService" substitutionGroup="LocalService">
 		<xsd:annotation>
 			<xsd:documentation>Information about how to book assistance for wheelchair and disabled users.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_checkConstraint_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_checkConstraint_support.xsd
@@ -69,7 +69,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a TYPE OF CONGESTION.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfCongestionRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfCongestionRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF CONGESTION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_checkConstraint_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_checkConstraint_version.xsd
@@ -436,7 +436,7 @@ screening, ticket control or immigration, that may potentially incur a time pena
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfCongestion" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfCongestion" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of CONGESTIONs according to their functional purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -464,7 +464,7 @@ screening, ticket control or immigration, that may potentially incur a time pena
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfCongestion_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfCongestion_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF CONGESTION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -226,7 +226,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RoughSurfaceStructure" abstract="false">
+	<xsd:complexType name="RoughSurfaceStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a ROUGH SURFACE.</xsd:documentation>
 		</xsd:annotation>
@@ -298,7 +298,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PlaceLighting_VersionStructure" abstract="false">
+	<xsd:complexType name="PlaceLighting_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PLACE LIGHTING EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -472,7 +472,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="EscalatorEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="EscalatorEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an ESCALATOR EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -551,7 +551,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="StaircaseEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="StaircaseEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a STAIRCASE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -707,7 +707,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TravelatorEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="TravelatorEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TRAVELATOR EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -794,7 +794,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LiftEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="LiftEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a LIFT EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -1037,7 +1037,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LiftCallEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="LiftCallEquipment_VersionStructure">
 		<xsd:complexContent>
 			<xsd:extension base="AccessEquipment_VersionStructure">
 				<xsd:sequence>
@@ -1131,7 +1131,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RampEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="RampEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a RAMP EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -1260,7 +1260,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="EntranceEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="EntranceEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an ENTRANCE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -1492,7 +1492,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="QueueingEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="QueueingEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a QUEUEING EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -1566,7 +1566,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CrossingEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="CrossingEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a CROSSING EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentParking_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentParking_version.xsd
@@ -95,7 +95,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CycleStorageEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="CycleStorageEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a CYCLE STORAGE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -165,7 +165,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleReleaseEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleReleaseEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a VEHICLE RELEASE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentPassenger_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentPassenger_version.xsd
@@ -137,7 +137,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="SanitaryEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="SanitaryEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SANITARY FACILITY EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -286,7 +286,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PassengerSafetyEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="PassengerSafetyEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PASSENGER SAFETY EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -389,7 +389,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="HelpPointEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="HelpPointEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a HELP POINT EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -473,7 +473,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PassengerBeaconEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="PassengerBeaconEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a BEACON EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -547,7 +547,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RubbishDisposalEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="RubbishDisposalEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for RUBBISH DISPOSAL EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentSigns_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentSigns_version.xsd
@@ -231,7 +231,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PlaceSignStructure" abstract="false">
+	<xsd:complexType name="PlaceSignStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PLACE SIGN.</xsd:documentation>
 		</xsd:annotation>
@@ -287,7 +287,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="HeadingSignStructure" abstract="false">
+	<xsd:complexType name="HeadingSignStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a HEADING SIGN.</xsd:documentation>
 		</xsd:annotation>
@@ -374,7 +374,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="GeneralSignStructure" abstract="false">
+	<xsd:complexType name="GeneralSignStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an GENERAL SIGN.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentTicketing_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentTicketing_version.xsd
@@ -97,7 +97,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TicketingEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="TicketingEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TICKETING EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -243,7 +243,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TicketValidatorEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="TicketValidatorEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TICKET VALIDATOR EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentWaiting_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentWaiting_version.xsd
@@ -125,7 +125,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LuggageLockerEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="LuggageLockerEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a Luggage Locker.</xsd:documentation>
 		</xsd:annotation>
@@ -330,7 +330,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="WaitingRoomEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="WaitingRoomEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a Waiting Room EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -396,7 +396,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TrolleyStandEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="TrolleyStandEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a Trolley Stand EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -473,7 +473,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ShelterEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="ShelterEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SHELTER EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -540,7 +540,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="SeatingEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="SeatingEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SEATING EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_localServiceCommercial_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_localServiceCommercial_version.xsd
@@ -97,7 +97,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CommunicationService_VersionStructure" abstract="false">
+	<xsd:complexType name="CommunicationService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Communication Service.</xsd:documentation>
 		</xsd:annotation>
@@ -155,7 +155,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="HireService_VersionStructure" abstract="false">
+	<xsd:complexType name="HireService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for HIRE SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -213,7 +213,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="MoneyService_VersionStructure" abstract="false">
+	<xsd:complexType name="MoneyService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for MONEY SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -271,7 +271,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RetailService_VersionStructure" abstract="false">
+	<xsd:complexType name="RetailService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for RETAIL SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -329,7 +329,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CateringService_VersionStructure" abstract="false">
+	<xsd:complexType name="CateringService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for CATERING SERVICE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_localService_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_localService_version.xsd
@@ -161,7 +161,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TicketingService_VersionStructure" abstract="false">
+	<xsd:complexType name="TicketingService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Ticketing Service.</xsd:documentation>
 		</xsd:annotation>
@@ -255,7 +255,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="AssistanceService_VersionStructure" abstract="false">
+	<xsd:complexType name="AssistanceService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an ASSISTANCE SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -336,7 +336,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LuggageService_VersionStructure" abstract="false">
+	<xsd:complexType name="LuggageService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for LUGGAGE SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -401,12 +401,12 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="CustomerService" type="CustomerService_VersionStructure" abstract="false" substitutionGroup="LocalService">
+	<xsd:element name="CustomerService" type="CustomerService_VersionStructure" substitutionGroup="LocalService">
 		<xsd:annotation>
 			<xsd:documentation>Generic specialisation of LOCAL SERVICE for CUSTOMER SERVICEs (lost properties, meeting point, complaints, etc.).</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="CustomerService_VersionStructure" abstract="false">
+	<xsd:complexType name="CustomerService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for CUSTOMER SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -447,7 +447,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ComplaintsService_VersionStructure" abstract="false">
+	<xsd:complexType name="ComplaintsService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a COMPLAINTS SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -491,7 +491,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LeftLuggageService_VersionStructure" abstract="false">
+	<xsd:complexType name="LeftLuggageService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a LEFT LUGGAGE SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -589,7 +589,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LostPropertyService_VersionStructure" abstract="false">
+	<xsd:complexType name="LostPropertyService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a LOST PROPERTY SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -641,7 +641,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="MeetingPointService_VersionStructure" abstract="false">
+	<xsd:complexType name="MeetingPointService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a MEETING POINT SERVICE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_support.xsd
@@ -646,12 +646,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfParkingRef" type="TypeOfParkingRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="TypeOfParkingRef" type="TypeOfParkingRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF PARKING.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfParkingRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfParkingRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a TYPE OF PARKING.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_version.xsd
@@ -1097,7 +1097,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== TYPE OF FLEET ============================================================ -->
-	<xsd:element name="TypeOfParking" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfParking" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>A classification for a PARKING. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -1124,7 +1124,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfParking_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfParking_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF PARKING.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_path_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_path_version.xsd
@@ -168,7 +168,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="OffSitePathLink_VersionStructure" abstract="false">
+	<xsd:complexType name="OffSitePathLink_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an  OFF SITE PATH LINK.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_pointOfInterest_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_pointOfInterest_version.xsd
@@ -155,7 +155,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PointOfInterestClassification_VersionStructure" abstract="false">
+	<xsd:complexType name="PointOfInterestClassification_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Classification of a POINT OF INTEREST.</xsd:documentation>
 		</xsd:annotation>
@@ -257,7 +257,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PointOfInterestClassificationHierarchy_VersionStructure" abstract="false">
+	<xsd:complexType name="PointOfInterestClassificationHierarchy_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for POINT OF INTEREST CLASSIFICATION HIERARCHY.</xsd:documentation>
 		</xsd:annotation>
@@ -312,7 +312,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:complexType name="PointOfInterestClassificationHierarchyMemberStructure" abstract="false">
+	<xsd:complexType name="PointOfInterestClassificationHierarchyMemberStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for POINT OF INTEREST CLASSIFICATION HIERARCHY MEMBER.</xsd:documentation>
 		</xsd:annotation>
@@ -579,7 +579,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PointOfInterestEntrance" abstract="false" substitutionGroup="Entrance">
+	<xsd:element name="PointOfInterestEntrance" substitutionGroup="Entrance">
 		<xsd:annotation>
 			<xsd:documentation>Specialisation of ENTRANCE of ENTRANCE for a passenger to a POINT OF INTEREST.</xsd:documentation>
 		</xsd:annotation>
@@ -624,7 +624,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PointOfInterestEntrance_VersionStructure" abstract="false">
+	<xsd:complexType name="PointOfInterestEntrance_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a POINT OF INTEREST Passenger ENTRANCE.</xsd:documentation>
 		</xsd:annotation>
@@ -633,7 +633,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="PointOfInterestVehicleEntrance" abstract="false" substitutionGroup="Entrance">
+	<xsd:element name="PointOfInterestVehicleEntrance" substitutionGroup="Entrance">
 		<xsd:annotation>
 			<xsd:documentation>A VEHICLE ENTRANCE to a POINT OF INTEREST.</xsd:documentation>
 		</xsd:annotation>
@@ -671,7 +671,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PointOfInterestVehicleEntrance_VersionStructure" abstract="false">
+	<xsd:complexType name="PointOfInterestVehicleEntrance_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a POINT OF INTEREST VEHICLE ENTRANCE.</xsd:documentation>
 		</xsd:annotation>
@@ -680,12 +680,12 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="PointOfInterestView" type="PointOfInterest_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="PointOfInterestView" type="PointOfInterest_DerivedViewStructure" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of POINT OF INTEREST.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="PointOfInterest_DerivedViewStructure" abstract="false">
+	<xsd:complexType name="PointOfInterest_DerivedViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for POINT OF INTEREST VIEW.</xsd:documentation>
 		</xsd:annotation>
@@ -726,12 +726,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PointOfInterestClassificationView" type="PointOfInterestClassification_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="PointOfInterestClassificationView" type="PointOfInterestClassification_DerivedViewStructure" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of POINT OF INTEREST CLASSIFICATION.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="PointOfInterestClassification_DerivedViewStructure" abstract="false">
+	<xsd:complexType name="PointOfInterestClassification_DerivedViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for POINT OF INTEREST CLASSIFICATION VIEW.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
@@ -332,12 +332,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Entrance" type="SiteEntrance_VersionStructure" abstract="false" substitutionGroup="SiteComponent">
+	<xsd:element name="Entrance" type="SiteEntrance_VersionStructure" substitutionGroup="SiteComponent">
 		<xsd:annotation>
 			<xsd:documentation>A physical entrance or exit to/from a SITE. May be a door, barrier, gate or other recognizable point of access. The ENTRANCE is an abstract Transmodel object and therefore should not be used as an instance (use specialisations like StopPlaceEntrance, PointOfInterestEntrance, etc.). It still has abstract="false" for backward compatibility, but using it as an instance is DEPRECATED from v2.0 and it will be formally changed to abstract in v3.0. -v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="SiteEntrance_VersionStructure" abstract="false">
+	<xsd:complexType name="SiteEntrance_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for SITE ENTRANCe.</xsd:documentation>
 		</xsd:annotation>
@@ -478,7 +478,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleEntrance_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleEntrance_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a VEHICLE ENTRANCE.</xsd:documentation>
 		</xsd:annotation>
@@ -616,7 +616,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GroupOfSites" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfSites" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of SITEs which will be commonly referenced for a specific purpose. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -708,12 +708,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SiteStructure" type="SiteStructure_VersionStructure" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="SiteStructure" type="SiteStructure_VersionStructure" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A building or a separate part thereof within a SITE. +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="SiteStructure_VersionStructure" abstract="false">
+	<xsd:complexType name="SiteStructure_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SITE STRUCTURE.</xsd:documentation>
 		</xsd:annotation>
@@ -761,12 +761,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="LevelInStructure" type="LevelInStructure_VersionStructure" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="LevelInStructure" type="LevelInStructure_VersionStructure" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>A LEVEL that is accessible in a SITE STRUCTURE with its relative lateral order in that SITE STRUCTURE counted from the bottom and upwards. +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="LevelInStructure_VersionStructure" abstract="false">
+	<xsd:complexType name="LevelInStructure_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for LEVEL IN STRUCTURE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
@@ -897,7 +897,7 @@ contained within its parent QUAY.</xsd:documentation>
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ======================================================================= -->
-	<xsd:element name="StopPlaceEntrance" abstract="false" substitutionGroup="Entrance">
+	<xsd:element name="StopPlaceEntrance" substitutionGroup="Entrance">
 		<xsd:annotation>
 			<xsd:documentation>Passenger Entrance to a STOP PLACE.</xsd:documentation>
 		</xsd:annotation>
@@ -942,7 +942,7 @@ contained within its parent QUAY.</xsd:documentation>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="StopPlaceEntrance_VersionStructure" abstract="false">
+	<xsd:complexType name="StopPlaceEntrance_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Passenger STOP PLACE ENTRANCE.</xsd:documentation>
 		</xsd:annotation>
@@ -968,7 +968,7 @@ contained within its parent QUAY.</xsd:documentation>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="StopPlaceVehicleEntrance" abstract="false" substitutionGroup="Entrance">
+	<xsd:element name="StopPlaceVehicleEntrance" substitutionGroup="Entrance">
 		<xsd:annotation>
 			<xsd:documentation>A physical entrance or exit to/from a SITE for a VEHICLE. May be a door, barrier, gate or other recognizable point of access.</xsd:documentation>
 		</xsd:annotation>
@@ -1016,7 +1016,7 @@ contained within its parent QUAY.</xsd:documentation>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="StopPlaceVehicleEntrance_VersionStructure" abstract="false">
+	<xsd:complexType name="StopPlaceVehicleEntrance_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for STOP PLACE VEHICLE ENTRANCE.</xsd:documentation>
 		</xsd:annotation>
@@ -1457,7 +1457,7 @@ contained within its parent QUAY.</xsd:documentation>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="StopPlaceView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="StopPlaceView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of STOP PLACE. Contains.</xsd:documentation>
 		</xsd:annotation>
@@ -1502,7 +1502,7 @@ contained within its parent QUAY.</xsd:documentation>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="StopPlace_DerivedViewStructure" abstract="false">
+	<xsd:complexType name="StopPlace_DerivedViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for STOP PLACE VIEW.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_rechargingPointAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_rechargingPointAssignment_version.xsd
@@ -91,12 +91,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RechargingPointAssignment" type="RechargingPointAssignment_VersionStructure" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="RechargingPointAssignment" type="RechargingPointAssignment_VersionStructure" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a TIMING POINT to a SITE COMPONENT such as a PARKING BAY that has VEHICLE CHARGING EQUIPMENT. +v2.0</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="RechargingPointAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="RechargingPointAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a RECHARGING POINT ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -138,7 +138,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RechargingStation" abstract="false" substitutionGroup="Parking_">
+	<xsd:element name="RechargingStation" substitutionGroup="Parking_">
 		<xsd:annotation>
 			<xsd:documentation>A PARKING with bays specifically equipped for recharging VEHICLEs. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -183,7 +183,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RechargingStation_VersionStructure" abstract="false">
+	<xsd:complexType name="RechargingStation_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a RECHARGING Station.</xsd:documentation>
 		</xsd:annotation>
@@ -222,7 +222,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RechargingBay" abstract="false" substitutionGroup="ParkingBay_">
+	<xsd:element name="RechargingBay" substitutionGroup="ParkingBay_">
 		<xsd:annotation>
 			<xsd:documentation>A PARKING BAY specifically equipped for recharging VEHICLEs. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -270,7 +270,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RechargingBay_VersionStructure" abstract="false">
+	<xsd:complexType name="RechargingBay_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a RECHARGING BAY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_taxiPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_taxiPlace_version.xsd
@@ -76,7 +76,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TaxiRank" abstract="false" substitutionGroup="StopPlace_">
+	<xsd:element name="TaxiRank" substitutionGroup="StopPlace_">
 		<xsd:annotation>
 			<xsd:documentation>A place comprising one or more locations where taxis may stop to pick up or set down passengers.  +v1.2.2
 </xsd:documentation>
@@ -124,7 +124,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TaxiRank_VersionStructure" abstract="false">
+	<xsd:complexType name="TaxiRank_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TAXI RANK.</xsd:documentation>
 		</xsd:annotation>
@@ -166,7 +166,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TaxiStand" abstract="false" substitutionGroup="StopPlaceComponent">
+	<xsd:element name="TaxiStand" substitutionGroup="StopPlaceComponent">
 		<xsd:annotation>
 			<xsd:documentation> A set of spots where any taxi is able to safely stop for a short period of time to load passengers.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -239,7 +239,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TaxiStand_VersionStructure" abstract="false">
+	<xsd:complexType name="TaxiStand_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TAXI STAND.</xsd:documentation>
 		</xsd:annotation>
@@ -264,7 +264,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== TAXI PARKING AREA  ============================================================ -->
-	<xsd:element name="TaxiParkingArea" abstract="false" substitutionGroup="ParkingArea_">
+	<xsd:element name="TaxiParkingArea" substitutionGroup="ParkingArea_">
 		<xsd:annotation>
 			<xsd:documentation> A specific area where any taxi is able to safely park for a long period.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -314,7 +314,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TaxiParkingArea_VersionStructure" abstract="false">
+	<xsd:complexType name="TaxiParkingArea_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TAXI PARKING AREA.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_activation_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_activation_version.xsd
@@ -146,7 +146,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<!-- ==Activation============================================================ -->
 	<!-- ======================================================================= -->
-	<xsd:element name="ActivatedEquipment" abstract="false">
+	<xsd:element name="ActivatedEquipment">
 		<xsd:annotation>
 			<xsd:documentation>An EQUIPMENT activated by the passage of a vehicle at an ACTIVATION POINT or on an ACTIVATION LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -172,7 +172,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ActivatedEquipment_VersionStructure" abstract="false">
+	<xsd:complexType name="ActivatedEquipment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an ACTIVATED EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -204,7 +204,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>A POINT where a control process is activated when a vehicle passes it. EQUIPMENT may be needed for the activation.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ActivationPoint" abstract="false" substitutionGroup="ActivationPoint_">
+	<xsd:element name="ActivationPoint" substitutionGroup="ActivationPoint_">
 		<xsd:annotation>
 			<xsd:documentation>A POINT where a control process is activated when a vehicle passes it. EQUIPMENT may be needed for the activation.</xsd:documentation>
 		</xsd:annotation>
@@ -230,7 +230,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ActivationPoint_VersionStructure" abstract="false">
+	<xsd:complexType name="ActivationPoint_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for ACTIVATION POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -266,7 +266,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ================================================================== -->
-	<xsd:element name="BeaconPoint" abstract="false" substitutionGroup="ActivationPoint_">
+	<xsd:element name="BeaconPoint" substitutionGroup="ActivationPoint_">
 		<xsd:annotation>
 			<xsd:documentation>A POINT where a beacon or similar device to support the automatic detection of vehicles passing by is located.</xsd:documentation>
 		</xsd:annotation>
@@ -301,7 +301,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TrafficControlPoint" abstract="false" substitutionGroup="Point">
+	<xsd:element name="TrafficControlPoint" substitutionGroup="Point">
 		<xsd:annotation>
 			<xsd:documentation>A POINT where the traffic flow can be influenced. Examples are: traffic lights (lanterns), barriers.</xsd:documentation>
 		</xsd:annotation>
@@ -327,7 +327,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TrafficControlPoint_VersionStructure" abstract="false">
+	<xsd:complexType name="TrafficControlPoint_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TRAFFIC CONTROL POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -346,7 +346,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="ActivationLink" abstract="false" substitutionGroup="Link">
+	<xsd:element name="ActivationLink" substitutionGroup="Link">
 		<xsd:annotation>
 			<xsd:documentation>A LINK where a control process is activated when a vehicle passes it.</xsd:documentation>
 		</xsd:annotation>
@@ -372,7 +372,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ActivationLink_VersionStructure" abstract="false">
+	<xsd:complexType name="ActivationLink_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an ACTIVATION LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -416,7 +416,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ActivationAssignment" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="ActivationAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>An assignment of an ACTIVATION POINT/LINK to an ACTIVATED EQUIPMENT related on its turn to a TRAFFIC CONTROL POINT. The considered ACTIVATION POINT/LINK will be used to influence the control process for that TRAFFIC CONTROL POINT (e.g. to fix priorities as regards the processing of competing requests from different ACTIVATION POINTs/LINKs).</xsd:documentation>
 		</xsd:annotation>
@@ -444,7 +444,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ActivationAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="ActivationAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an ACTIVATION ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -479,7 +479,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfActivation" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfActivation" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of real-time processes that are activated when vehicles passes an ACTIVATION POINT or an ACTIVATION LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -503,7 +503,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfActivation_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfActivation_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF ACTIVATION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_version.xsd
@@ -44,7 +44,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="FlexibleLine" abstract="false" substitutionGroup="Line_">
+	<xsd:element name="FlexibleLine" substitutionGroup="Line_">
 		<xsd:annotation>
 			<xsd:documentation>A group of FLEXIBLE ROUTEs of which is generally known to the public by a similar name or number and which have common booking arrangements. DEPRECATED: please use LINE instead. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -70,7 +70,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="FlexibleLine_VersionStructure" abstract="false">
+	<xsd:complexType name="FlexibleLine_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for FLEXIBLE LINE.</xsd:documentation>
 		</xsd:annotation>
@@ -101,7 +101,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==FlexibleRoute============================================================ -->
-	<xsd:element name="FlexibleRoute" abstract="false" substitutionGroup="Route_">
+	<xsd:element name="FlexibleRoute" substitutionGroup="Route_">
 		<xsd:annotation>
 			<xsd:documentation>Specialisation of ROUTE for flexible service.  May include both point and zonal areas and ordered and unordered sections.</xsd:documentation>
 		</xsd:annotation>
@@ -130,7 +130,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="FlexibleRoute_VersionStructure" abstract="false">
+	<xsd:complexType name="FlexibleRoute_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a FLEXIBLE ROUTE.</xsd:documentation>
 		</xsd:annotation>
@@ -167,7 +167,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FlexibleLinkProperties" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="FlexibleLinkProperties" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Flexible properties of a LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -190,7 +190,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="FlexibleLinkProperties_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="FlexibleLinkProperties_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for FLEXIBLE LINK PROPERTies.</xsd:documentation>
 		</xsd:annotation>
@@ -243,7 +243,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FlexiblePointProperties" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="FlexiblePointProperties" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Flexible properties of a POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -266,7 +266,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="FlexiblePointProperties_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="FlexiblePointProperties_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for FLEXIBLE POINT PROPERTies.</xsd:documentation>
 		</xsd:annotation>
@@ -310,7 +310,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="FlexibleLineView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="FlexibleLineView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>A group of FLEXIBLE ROUTEs of which is generally known to the public by a similar name or number and which have common booking arrangements.</xsd:documentation>
 		</xsd:annotation>
@@ -320,7 +320,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="FlexibleLine_DerivedViewStructure" abstract="false">
+	<xsd:complexType name="FlexibleLine_DerivedViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for FLEXIBLE LINE is DEPRECATED: please use Type of LINE. -v2.0.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_lineNetwork_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_lineNetwork_version.xsd
@@ -94,7 +94,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ===LINE NETWORK =================================================== -->
-	<xsd:element name="LineNetwork" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="LineNetwork" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A description of the topological connectivity of a LINE as a set of LINE SECTIONs. This is sufficient to draw a route map for the whole line including branches and loops.</xsd:documentation>
 		</xsd:annotation>
@@ -117,7 +117,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LineNetwork_VersionStructure" abstract="false">
+	<xsd:complexType name="LineNetwork_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a LINE NETWORK restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -168,7 +168,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="LineSection" abstract="false" substitutionGroup="Section_">
+	<xsd:element name="LineSection" substitutionGroup="Section_">
 		<xsd:annotation>
 			<xsd:documentation>A section of a LINE NETWORK comprising an edge between two nodes. Not directional.</xsd:documentation>
 		</xsd:annotation>
@@ -197,7 +197,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LineSection_VersionStructure" abstract="false">
+	<xsd:complexType name="LineSection_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a LINE SECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -260,7 +260,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PointOnLineSection" abstract="false" substitutionGroup="PointOnSection_">
+	<xsd:element name="PointOnLineSection" substitutionGroup="PointOnSection_">
 		<xsd:annotation>
 			<xsd:documentation>Inclusion of a POINT on a LINE SECTION. +v1.1</xsd:documentation>
 		</xsd:annotation>
@@ -310,7 +310,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PointOnLineSection_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="PointOnLineSection_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a POINT on LINE SECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -344,7 +344,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="LineSectionPointMember" abstract="false" substitutionGroup="CommonSectionPointMember">
+	<xsd:element name="LineSectionPointMember" substitutionGroup="CommonSectionPointMember">
 		<xsd:annotation>
 			<xsd:documentation>[DEPRECATED - use POINT ON LINE SECTION INSTEAD] An ordered set of LINKs for a line.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_line_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_support.xsd
@@ -334,7 +334,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a TYPE OF LINE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfLineRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfLineRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF LINE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
@@ -189,7 +189,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==GROUP OF LINES============================================================ -->
-	<xsd:element name="GroupOfLines" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfLines" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of LINEs which will be commonly referenced for a specific purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -284,7 +284,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy Supertype for LINE &amp; FLEXIBLE LINe.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Line" abstract="false" substitutionGroup="Line_" id="Line">
+	<xsd:element name="Line" substitutionGroup="Line_" id="Line">
 		<xsd:annotation>
 			<xsd:documentation>A group of ROUTEs which is generally known to the public by a similar name or number.</xsd:documentation>
 		</xsd:annotation>
@@ -553,7 +553,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="Network" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="Network" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A named grouping of LINEs under which a Transport network is known.</xsd:documentation>
 		</xsd:annotation>
@@ -582,7 +582,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Network_VersionStructure" abstract="false">
+	<xsd:complexType name="Network_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a NETWORK.</xsd:documentation>
 		</xsd:annotation>
@@ -622,7 +622,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="DestinationDisplay" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="DestinationDisplay" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>An advertised destination of a specific JOURNEY PATTERN, usually displayed on a head sign or at other on-board locations.</xsd:documentation>
 		</xsd:annotation>
@@ -645,7 +645,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="DestinationDisplay_VersionStructure" abstract="false">
+	<xsd:complexType name="DestinationDisplay_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a DESTINATION DISPLAY.</xsd:documentation>
 		</xsd:annotation>
@@ -753,7 +753,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DestinationDisplayVariant" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="DestinationDisplayVariant" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A variant text of a DESTINATION DISPLAY for informational purposes.</xsd:documentation>
 		</xsd:annotation>
@@ -908,7 +908,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="AllowedLineDirection" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="AllowedLineDirection" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A set of allowed DIRECTIONs that can be used on a given ROUTE.</xsd:documentation>
 		</xsd:annotation>
@@ -975,7 +975,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="LineInDirectionRef" type="LineInDirectionRef_Structure" abstract="false">
+	<xsd:element name="LineInDirectionRef" type="LineInDirectionRef_Structure">
 		<xsd:annotation>
 			<xsd:documentation>Reference to LINEs in a specific DIRECTION</xsd:documentation>
 		</xsd:annotation>
@@ -1000,7 +1000,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="NetworkView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="NetworkView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of a NETWORK.</xsd:documentation>
 		</xsd:annotation>
@@ -1033,7 +1033,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="LineView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="LineView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of a LINE.</xsd:documentation>
 		</xsd:annotation>
@@ -1092,7 +1092,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DestinationDisplayView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="DestinationDisplayView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of a DESTINATION DISPLAY. Includes derived properties of the DESTINATION DISPLAY.</xsd:documentation>
 		</xsd:annotation>
@@ -1122,7 +1122,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfLine" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfLine" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of a LINE according to its functional purpose. +v1.1.</xsd:documentation>
 		</xsd:annotation>
@@ -1150,7 +1150,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfLine_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfLine_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF LINE. +v1.1</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_support.xsd
@@ -92,7 +92,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:annotation>
 		<xsd:restriction base="InfrastructurePointIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="RailwayPointRef" type="RailwayPointRefStructure" abstract="false" substitutionGroup="InfrastructurePointRef">
+	<xsd:element name="RailwayPointRef" type="RailwayPointRefStructure" substitutionGroup="InfrastructurePointRef">
 		<xsd:annotation>
 			<xsd:documentation> Reference to a RAILWAY POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -118,7 +118,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:annotation>
 		<xsd:restriction base="InfrastructurePointIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="RoadPointRef" type="RoadPointRefStructure" abstract="false" substitutionGroup="InfrastructurePointRef">
+	<xsd:element name="RoadPointRef" type="RoadPointRefStructure" substitutionGroup="InfrastructurePointRef">
 		<xsd:annotation>
 			<xsd:documentation> Reference to a ROAD POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -144,7 +144,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:annotation>
 		<xsd:restriction base="InfrastructurePointIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="WirePointRef" type="WirePointRefStructure" abstract="false" substitutionGroup="InfrastructurePointRef">
+	<xsd:element name="WirePointRef" type="WirePointRefStructure" substitutionGroup="InfrastructurePointRef">
 		<xsd:annotation>
 			<xsd:documentation> Reference to a WIRE POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -198,7 +198,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:annotation>
 		<xsd:restriction base="InfrastructureLinkIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="RailwayLinkRef" type="RailwayLinkRefStructure" abstract="false" substitutionGroup="InfrastructureLinkRef">
+	<xsd:element name="RailwayLinkRef" type="RailwayLinkRefStructure" substitutionGroup="InfrastructureLinkRef">
 		<xsd:annotation>
 			<xsd:documentation> Reference to a RAILWAY LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -254,7 +254,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:annotation>
 		<xsd:restriction base="InfrastructureLinkIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="RoadLinkRef" type="RoadLinkRefStructure" abstract="false" substitutionGroup="InfrastructureLinkRef">
+	<xsd:element name="RoadLinkRef" type="RoadLinkRefStructure" substitutionGroup="InfrastructureLinkRef">
 		<xsd:annotation>
 			<xsd:documentation> Reference to a ROAD LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -310,7 +310,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:annotation>
 		<xsd:restriction base="InfrastructureLinkIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="WireLinkRef" type="WireLinkRefStructure" abstract="false" substitutionGroup="InfrastructureLinkRef">
+	<xsd:element name="WireLinkRef" type="WireLinkRefStructure" substitutionGroup="InfrastructureLinkRef">
 		<xsd:annotation>
 			<xsd:documentation> Reference to a WIRE LINK.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_version.xsd
@@ -127,7 +127,7 @@ Rail transport, Roads and ROAD transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="RailwayJunction" abstract="false" substitutionGroup="InfrastructurePoint">
+	<xsd:element name="RailwayJunction" substitutionGroup="InfrastructurePoint">
 		<xsd:annotation>
 			<xsd:documentation>A type of INFRASTRUCTURE POINT used to describe a RAILWAY network.</xsd:documentation>
 		</xsd:annotation>
@@ -163,7 +163,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="RoadJunction" abstract="false" substitutionGroup="InfrastructurePoint">
+	<xsd:element name="RoadJunction" substitutionGroup="InfrastructurePoint">
 		<xsd:annotation>
 			<xsd:documentation>A type of INFRASTRUCTURE POINT used to describe a ROAD network.</xsd:documentation>
 		</xsd:annotation>
@@ -199,7 +199,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="WireJunction" abstract="false" substitutionGroup="InfrastructurePoint">
+	<xsd:element name="WireJunction" substitutionGroup="InfrastructurePoint">
 		<xsd:annotation>
 			<xsd:documentation>A type of INFRASTRUCTURE POINT used to describe a WIRE network.</xsd:documentation>
 		</xsd:annotation>
@@ -272,7 +272,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====Railway ============================================================ -->
-	<xsd:element name="RailwayElement" abstract="false" substitutionGroup="InfrastructureLink_">
+	<xsd:element name="RailwayElement" substitutionGroup="InfrastructureLink_">
 		<xsd:annotation>
 			<xsd:documentation>A type of INFRASTRUCTURE LINK used to describe a RAILWAY network.</xsd:documentation>
 		</xsd:annotation>
@@ -300,7 +300,7 @@ Rail transport, Roads and ROAD transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RailwayElement_VersionStructure" abstract="false">
+	<xsd:complexType name="RailwayElement_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for RAILWAY ELEMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -388,7 +388,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====Wire=============================================================== -->
-	<xsd:element name="WireElement" abstract="false" substitutionGroup="InfrastructureLink_">
+	<xsd:element name="WireElement" substitutionGroup="InfrastructureLink_">
 		<xsd:annotation>
 			<xsd:documentation>A type of INFRASTRUCTURE LINK used to describe a WIRE network.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_networkRestriction_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_networkRestriction_version.xsd
@@ -127,7 +127,7 @@ Rail transport, Roads and ROAD transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ====Point Restriction====================================================== -->
-	<xsd:element name="VehicleTypeAtPoint" abstract="false" substitutionGroup="NetworkRestriction">
+	<xsd:element name="VehicleTypeAtPoint" substitutionGroup="NetworkRestriction">
 		<xsd:annotation>
 			<xsd:documentation>NETWORK RESTRICTION. specifying whether a vehicle of a specified VEHICLE TYPE may visit a point.</xsd:documentation>
 		</xsd:annotation>
@@ -156,7 +156,7 @@ Rail transport, Roads and ROAD transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleTypeAtPoint_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleTypeAtPoint_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a VEHICLE TYPE AT POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -252,7 +252,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="RestrictedManoeuvre" abstract="false" substitutionGroup="NetworkRestriction">
+	<xsd:element name="RestrictedManoeuvre" substitutionGroup="NetworkRestriction">
 		<xsd:annotation>
 			<xsd:documentation>A specification of a move for a certain type of vehicle. It specifies from which INFRASTRUCTURE LINK to which other (adjacent) INFRASTRUCTURE LINK a certain can or cannot VEHICLE TYPE cannot proceed, due to physical restrictions.</xsd:documentation>
 		</xsd:annotation>
@@ -317,7 +317,7 @@ Rail transport, Roads and ROAD transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ======================================================================= -->
-	<xsd:element name="MeetingRestriction" abstract="false" substitutionGroup="NetworkRestriction">
+	<xsd:element name="MeetingRestriction" substitutionGroup="NetworkRestriction">
 		<xsd:annotation>
 			<xsd:documentation>A pair of INFRASTRUCTURE LINKs where vehicles of specified VEHICLE TYPEs are not allowed to meet.</xsd:documentation>
 		</xsd:annotation>
@@ -380,7 +380,7 @@ Rail transport, Roads and ROAD transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ======================================================================= -->
-	<xsd:element name="OvertakingPossibility" abstract="false" substitutionGroup="NetworkRestriction">
+	<xsd:element name="OvertakingPossibility" substitutionGroup="NetworkRestriction">
 		<xsd:annotation>
 			<xsd:documentation>NETWORK RESTRICTION specifying a POINT or a LINK where vehicles of specified VEHICLE TYPEs are or are  not allowed to overtake each other.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_routeInstruction_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_routeInstruction_version.xsd
@@ -89,7 +89,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RouteInstruction" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="RouteInstruction" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>An Instruction on how to follow a ROUTE through the network.</xsd:documentation>
 		</xsd:annotation>
@@ -112,7 +112,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RouteInstruction_VersionStructure" abstract="false">
+	<xsd:complexType name="RouteInstruction_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for ROUTE a POINT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_route_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_route_version.xsd
@@ -144,7 +144,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- === DIRECTION ===================================================== -->
-	<xsd:element name="Direction" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="Direction" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>A classification for the general orientation of ROUTEs.</xsd:documentation>
 		</xsd:annotation>
@@ -170,7 +170,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Direction_ValueStructure" abstract="false">
+	<xsd:complexType name="Direction_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for DIRECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -219,7 +219,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy supertype for Route.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Route" abstract="false" substitutionGroup="Route_">
+	<xsd:element name="Route" substitutionGroup="Route_">
 		<xsd:annotation>
 			<xsd:documentation>An ordered list of located POINTs defining one single path through the Road (or rail) network. A ROUTE may pass through the same POINT more than once.</xsd:documentation>
 		</xsd:annotation>
@@ -245,7 +245,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Route_VersionStructure" abstract="false">
+	<xsd:complexType name="Route_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a ROUTE.</xsd:documentation>
 		</xsd:annotation>
@@ -290,7 +290,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PointOnRoute" abstract="false" substitutionGroup="PointInLinkSequence">
+	<xsd:element name="PointOnRoute" substitutionGroup="PointInLinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>A reference to a ROUTE POINT used to define a ROUTE with its order on that ROUTE.</xsd:documentation>
 		</xsd:annotation>
@@ -331,7 +331,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PointOnRoute_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="PointOnRoute_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a POINT ON ROUTE.</xsd:documentation>
 		</xsd:annotation>
@@ -362,7 +362,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- === ROUTE POINT ========================================================= -->
-	<xsd:element name="RoutePoint" abstract="false" substitutionGroup="Point">
+	<xsd:element name="RoutePoint" substitutionGroup="Point">
 		<xsd:annotation>
 			<xsd:documentation>A POINT used to define the shape of a ROUTE through the network.</xsd:documentation>
 		</xsd:annotation>
@@ -388,7 +388,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RoutePoint_VersionStructure" abstract="false">
+	<xsd:complexType name="RoutePoint_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for ROUTE POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -418,7 +418,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!--=== ROUTE LINK ========================================================= -->
-	<xsd:element name="RouteLink" abstract="false" substitutionGroup="Link">
+	<xsd:element name="RouteLink" substitutionGroup="Link">
 		<xsd:annotation>
 			<xsd:documentation>An oriented link between two ROUTE POINTs allowing the definition of a unique path through the network. Because ROUTE LINKs are directional   there will be separate links for each direction of a route.</xsd:documentation>
 		</xsd:annotation>
@@ -442,7 +442,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RouteLink_VersionStructure" abstract="false">
+	<xsd:complexType name="RouteLink_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for ROUTE LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -489,7 +489,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ModeRestrictionAssessment" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="ModeRestrictionAssessment" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Qualification of a ROUTE LINK resulting from the analysis of restrictions concerning the related INFRASTRUCTURE LINKs  +v1.2.2.
 </xsd:documentation>
@@ -513,7 +513,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ModeRestrictionAssessment_VersionStructure" abstract="false">
+	<xsd:complexType name="ModeRestrictionAssessment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for MODE RESTRICTION ASSESSMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -549,7 +549,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== ROUTE VIEW ====================================================== -->
-	<xsd:element name="RouteView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="RouteView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Annotated reference to a ROUTE.</xsd:documentation>
 		</xsd:annotation>
@@ -610,7 +610,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== DIRECTION VIEW ========================================================== -->
-	<xsd:element name="DirectionView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="DirectionView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified View of DIRECTION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_vehicleAndCrewPoint_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_vehicleAndCrewPoint_version.xsd
@@ -124,7 +124,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==Activation============================================================ -->
-	<xsd:element name="CrewBase" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="CrewBase" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A place where operating EMPLOYEEs (e.g. drivers) report on and register their worK.</xsd:documentation>
 		</xsd:annotation>
@@ -152,7 +152,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CrewBase_VersionStructure" abstract="false">
+	<xsd:complexType name="CrewBase_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for CREW BASE.</xsd:documentation>
 		</xsd:annotation>
@@ -181,7 +181,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>A TIMING POINT where a relief is possible, i.e. a driver may take on or hand over a vehicle. The vehicle may sometimes be left unattended.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ReliefPoint" abstract="false" substitutionGroup="ReliefPoint_">
+	<xsd:element name="ReliefPoint" substitutionGroup="ReliefPoint_">
 		<xsd:annotation>
 			<xsd:documentation>A TIMING POINT where a relief is possible, i.e. a driver may take on or hand over a vehicle. The vehicle may sometimes be left unattended.</xsd:documentation>
 		</xsd:annotation>
@@ -240,7 +240,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>A TIMING POINT where vehicles may stay unattended for a long time. A vehicle's return to park at a PARKING POINT marks the end of a BLOCK.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ParkingPoint" abstract="false" substitutionGroup="ReliefPoint_">
+	<xsd:element name="ParkingPoint" substitutionGroup="ReliefPoint_">
 		<xsd:annotation>
 			<xsd:documentation>A TIMING POINT where vehicles may stay unattended for a long time. A vehicle's return to park at a PARKING POINT marks the end of a BLOCK.</xsd:documentation>
 		</xsd:annotation>
@@ -303,7 +303,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GaragePoint" abstract="false" substitutionGroup="ParkingPoint_">
+	<xsd:element name="GaragePoint" substitutionGroup="ParkingPoint_">
 		<xsd:annotation>
 			<xsd:documentation>A subtype of PARKING POINT located in a GARAGE.</xsd:documentation>
 		</xsd:annotation>
@@ -353,7 +353,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="Garage" abstract="false" substitutionGroup="Place">
+	<xsd:element name="Garage" substitutionGroup="Place">
 		<xsd:annotation>
 			<xsd:documentation>A facility used for parking and maintaining vehicles. PARKING POINTs in a GARAGE are called GARAGE POINTs.</xsd:documentation>
 		</xsd:annotation>
@@ -393,7 +393,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Garage_VersionStructure" abstract="false">
+	<xsd:complexType name="Garage_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for GARAGE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_commonSection_support.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_commonSection_support.xsd
@@ -58,7 +58,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="SectionIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="CommonSectionRef" type="CommonSectionRefStructure" abstract="false" substitutionGroup="SectionRef">
+	<xsd:element name="CommonSectionRef" type="CommonSectionRefStructure" substitutionGroup="SectionRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a COMMON SECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -77,7 +77,7 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<xsd:element name="ParentCommonSectionRef" type="CommonSectionRefStructure" abstract="false" substitutionGroup="SectionRef">
+	<xsd:element name="ParentCommonSectionRef" type="CommonSectionRefStructure" substitutionGroup="SectionRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a COMMON SECTION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_commonSection_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_commonSection_version.xsd
@@ -86,7 +86,7 @@ Rail transport, Roads and Road transport
 	<!-- ========= ============================================================== -->
 	<!-- ==COMMON SECTION=========================================================== -->
 	<!-- ======================================================================= -->
-	<xsd:element name="CommonSection" abstract="false" substitutionGroup="Section_">
+	<xsd:element name="CommonSection" substitutionGroup="Section_">
 		<xsd:annotation>
 			<xsd:documentation>A shared set of LINKS or POINTs. A part of a public transport network where the ROUTEs of several JOURNEY PATTERNs are going in parallel and where the synchronisation of SERVICE JOURNEYs may be planned and controlled with respect to commonly used LINKs and STOP POINTs. COMMON SECTIONs are defined arbitrarily and need not cover the total lengths of topologically bundled sections.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_fareZone_support.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_fareZone_support.xsd
@@ -109,12 +109,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TimingPointIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="BorderPointRef" type="BorderPointRefStructure" abstract="false" substitutionGroup="TimingPointRef">
+	<xsd:element name="BorderPointRef" type="BorderPointRefStructure" substitutionGroup="TimingPointRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a BORDER POINT. (TAP TSI B.1.3 Border Boint Code).</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="BorderPointRefStructure" abstract="false">
+	<xsd:complexType name="BorderPointRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a BORDER POINT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_fareZone_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_fareZone_version.xsd
@@ -151,7 +151,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="FareScheduledStopPoint" abstract="false" substitutionGroup="Point">
+	<xsd:element name="FareScheduledStopPoint" substitutionGroup="Point">
 		<xsd:annotation>
 			<xsd:documentation> A POINT where passengers can board or alight from vehicles.</xsd:documentation>
 		</xsd:annotation>
@@ -183,7 +183,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="FareScheduledStopPoint_VersionStructure" abstract="false">
+	<xsd:complexType name="FareScheduledStopPoint_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for FARE SCHEDULED STOP POINT restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -218,7 +218,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="BorderPoint" abstract="false" substitutionGroup="Point">
+	<xsd:element name="BorderPoint" substitutionGroup="Point">
 		<xsd:annotation>
 			<xsd:documentation>Designated BORDER POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -260,7 +260,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="BorderPoint_ValueStructure" abstract="false">
+	<xsd:complexType name="BorderPoint_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a BORDER POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -418,7 +418,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareSection" abstract="false" substitutionGroup="Section_">
+	<xsd:element name="FareSection" substitutionGroup="Section_">
 		<xsd:annotation>
 			<xsd:documentation>A subdivision of a JOURNEY PATTERN consisting of consecutive POINTs IN JOURNEY PATTERN, used to define an element of the fare structure.</xsd:documentation>
 		</xsd:annotation>
@@ -484,7 +484,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="FareZone" abstract="false" substitutionGroup="TariffZone_">
+	<xsd:element name="FareZone" substitutionGroup="TariffZone_">
 		<xsd:annotation>
 			<xsd:documentation>A specialization of TARIFF ZONE to include FARE SECTIONs.</xsd:documentation>
 		</xsd:annotation>
@@ -550,7 +550,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="FareZone_VersionStructure" abstract="false">
+	<xsd:complexType name="FareZone_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a FARE ZONE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPatternTimings_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPatternTimings_version.xsd
@@ -105,7 +105,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyPatternWaitTime" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="JourneyPatternWaitTime" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>The time a vehicle has to wait at a specific TIMING POINT IN JOURNEY PATTERN, for a specified TIME DEMAND TYPE. This wait time can be superseded by a VEHICLE JOURNEY WAIT TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -172,7 +172,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyPatternRunTime" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="JourneyPatternRunTime" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>The time taken to traverse a TIMING LINK in a particular JOURNEY PATTERN, for a specified TIME DEMAND TYPE If it exists, it will override the DEFAULT SERVICE JOURNEY RUN TIME and DEFAULT DEAD RUN RUN TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -199,7 +199,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="JourneyPatternRunTime_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="JourneyPatternRunTime_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for JOURNEY PATTERN RUN TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -234,7 +234,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyPatternLayover" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="JourneyPatternLayover" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Time allowance at the end of each journey on a specified JOURNEY PATTERN, to allow for delays and for other purposes. This layover supersedes any global layover and may be superseded by a specific VEHICLE JOURNEY LAYOVER.</xsd:documentation>
 		</xsd:annotation>
@@ -297,7 +297,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyPatternHeadway" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="JourneyPatternHeadway" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Headway interval information that is available for all the VEHICLE JOURNEYs running on the JOURNEY PATTERN. This is a default value that can be superseded by the VEHICLE JOURNEY HEADWAY on a specific journey. This information must be consistent with HEADWAY JOURNEY GROUP if available (HEADWAY JOURNEY GROUP being a more detailed way of describing headway services).</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPattern_support.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPattern_support.xsd
@@ -182,7 +182,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfJourneyPatternRef" type="TypeOfJourneyPatternRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfJourneyPatternRef" type="TypeOfJourneyPatternRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPattern_version.xsd
@@ -96,7 +96,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy Supertype for JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="JourneyPattern" abstract="false" substitutionGroup="JourneyPattern_">
+	<xsd:element name="JourneyPattern" substitutionGroup="JourneyPattern_">
 		<xsd:annotation>
 			<xsd:documentation>An ordered list of SCHEDULED STOP POINTs and TIMING POINTs on a single ROUTE, describing the pattern of working for public transport vehicles. A JOURNEY PATTERN may pass through the same POINT more than once. The first point of a JOURNEY PATTERN is the origin. The last point is the destination.</xsd:documentation>
 		</xsd:annotation>
@@ -234,7 +234,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="DeadRunJourneyPattern" abstract="false" substitutionGroup="JourneyPattern_">
+	<xsd:element name="DeadRunJourneyPattern" substitutionGroup="JourneyPattern_">
 		<xsd:annotation>
 			<xsd:documentation>A JOURNEY PATTERN to be used for DEAD RUNs.</xsd:documentation>
 		</xsd:annotation>
@@ -269,7 +269,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:complexType name="pointsInJourneyPattern_RelStructure" abstract="false">
+	<xsd:complexType name="pointsInJourneyPattern_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for POINT IN JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -283,7 +283,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PointInJourneyPattern" abstract="false" substitutionGroup="PointInLinkSequence">
+	<xsd:element name="PointInJourneyPattern" substitutionGroup="PointInLinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>A STOP POINT or TIMING POINT in a JOURNEY PATTERN with its order in that JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -309,7 +309,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PointInJourneyPattern_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="PointInJourneyPattern_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for POINT IN JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -372,7 +372,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:complexType name="linksInJourneyPattern_RelStructure" abstract="false">
+	<xsd:complexType name="linksInJourneyPattern_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for LINK IN JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -385,7 +385,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="LinkInJourneyPattern" abstract="false" substitutionGroup="LinkInLinkSequence">
+	<xsd:element name="LinkInJourneyPattern" substitutionGroup="LinkInLinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>A SERVICE LINK or TIMING LINK in a JOURNEY PATTERN with its order in that JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -415,7 +415,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="LinkInJourneyPattern_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="LinkInJourneyPattern_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for LINK IN JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -437,7 +437,7 @@ Rail transport, Roads and Road transport
 		</xsd:choice>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="JourneyPatternView" type="JourneyPattern_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="JourneyPatternView" type="JourneyPattern_DerivedViewStructure" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of a JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -457,7 +457,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<!-- ======================================================================= -->
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfJourneyPattern" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfJourneyPattern" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of JOURNEY PATTERNs according to their functional purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -480,7 +480,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfJourneyPattern_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfJourneyPattern_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyTiming_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyTiming_version.xsd
@@ -114,7 +114,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyWaitTime" abstract="false" substitutionGroup="JourneyTiming">
+	<xsd:element name="JourneyWaitTime" substitutionGroup="JourneyTiming">
 		<xsd:annotation>
 			<xsd:documentation>The time a vehicle has to wait at a specific TIMING POINT IN JOURNEY PATTERN, for a specified TIME DEMAND TYPE. This wait time can be superseded by a VEHICLE JOURNEY WAIT TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -178,7 +178,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyRunTime" abstract="false" substitutionGroup="JourneyTiming">
+	<xsd:element name="JourneyRunTime" substitutionGroup="JourneyTiming">
 		<xsd:annotation>
 			<xsd:documentation>The time taken to traverse a TIMING LINK in a particular JOURNEY PATTERN, for a specified TIME DEMAND TYPE. If it exists, it will override the DEFAULT SERVICE JOURNEY RUN TIME and DEFAULT DEAD RUN RUN TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -242,7 +242,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyLayover" abstract="false" substitutionGroup="JourneyTiming">
+	<xsd:element name="JourneyLayover" substitutionGroup="JourneyTiming">
 		<xsd:annotation>
 			<xsd:documentation>Time allowance at the end of each journey on a specified JOURNEY PATTERN, to allow for delays and for other purposes. This layover supersedes any global layover and may be superseded by a specific VEHICLE JOURNEY LAYOVER.</xsd:documentation>
 		</xsd:annotation>
@@ -306,7 +306,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TurnaroundTimeLimitTime" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="TurnaroundTimeLimitTime" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>The maximum time for which a vehicle may be scheduled to wait at a particular TIMING POINT (often included in a TURN STATION) without being returned to a PARKING POINT. A minimum time for a vehicle to turn its direction may also be recorded. This may be superseded by a DEAD RUN.</xsd:documentation>
 		</xsd:annotation>
@@ -374,7 +374,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyHeadway" abstract="false" substitutionGroup="JourneyTiming">
+	<xsd:element name="JourneyHeadway" substitutionGroup="JourneyTiming">
 		<xsd:annotation>
 			<xsd:documentation>Headway interval information that is available for all the VEHICLE JOURNEYs running on the JOURNEY PATTERN  for a given TIME DEMAND TYPE,  at a given TIMING POINT.  This is a default value that can be superseded by VEHICLE JOURNEY HEADWAY. This information must be consistent with HEADWAY JOURNEY GROUP if available (HEADWAY JOURNEY GROUP being a more detailed way of describing headway services).</xsd:documentation>
 		</xsd:annotation>
@@ -400,7 +400,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="JourneyHeadway_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="JourneyHeadway_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a JOURNEY HEADWAY Interval.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_passengerInformationEquipment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_passengerInformationEquipment_version.xsd
@@ -126,7 +126,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="LogicalDisplay" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="LogicalDisplay" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Represents a set of data that can be assembled for assignment to a physical PASSENGER INFORMATION EQUIPMENT or to a logical channel such as web or media. It is independent of any physical embodiment 
 
@@ -186,7 +186,7 @@ LOGICAL DISPLAY corresponds to a SIRI STOP MONITORING point.</xsd:documentation>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="PassengerInformationEquipment" abstract="false" substitutionGroup="PassengerEquipment">
+	<xsd:element name="PassengerInformationEquipment" substitutionGroup="PassengerEquipment">
 		<xsd:annotation>
 			<xsd:documentation>A public transport information facility, as for instance terminals (on street, at information desks, telematic, ...) or printed material (leaflets displayed at stops, booklets, ...).</xsd:documentation>
 		</xsd:annotation>
@@ -280,7 +280,7 @@ LOGICAL DISPLAY corresponds to a SIRI STOP MONITORING point.</xsd:documentation>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DisplayAssignment" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="DisplayAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of one STOP POINT and one JOURNEY PATTERN to a PASSENGER INFORMATION EQUIPMENT, specifying that information on this STOP POINT and this JOURNEY PATTERN will be provided (e.g. displayed, printed).</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_pathAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_pathAssignment_version.xsd
@@ -56,7 +56,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>PATH ASSIGNMENT types for NeTEx.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<xsd:element name="NavigationPathAssignment" abstract="false" substitutionGroup="StopAssignment">
+	<xsd:element name="NavigationPathAssignment" substitutionGroup="StopAssignment">
 		<xsd:annotation>
 			<xsd:documentation>Assignment of a CONNECTION link to a NAVIGATION PATH.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_routingConstraint_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_routingConstraint_version.xsd
@@ -184,7 +184,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================== =============================================== -->
-	<xsd:element name="ServiceExclusion" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="ServiceExclusion" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>A constraint on the use of a service. The service, on this specific JOURNEY PATTERN (usually a FTS JOURNEY PATTERN) cannot operate when another (regular) service operates. This may occur only on subpart of the JOURNEY PATTERN, or only on one or some specific SCHEDULED STOP POINTs within the pattern.</xsd:documentation>
 		</xsd:annotation>
@@ -212,7 +212,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ServiceExclusion_VersionStructure" abstract="false">
+	<xsd:complexType name="ServiceExclusion_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for SERVICE EXCLUSION.</xsd:documentation>
 		</xsd:annotation>
@@ -257,7 +257,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TransferRestriction" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="TransferRestriction" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>A CONSTRAINT that can be applied on a CONNECTION or INTERCHANGE between two SCHEDULED STOP POINT, preventing or forbidding the passenger to use it.</xsd:documentation>
 		</xsd:annotation>
@@ -289,7 +289,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TransferRestriction_VersionStructure" abstract="false">
+	<xsd:complexType name="TransferRestriction_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TRANSFER RESTRICTION.</xsd:documentation>
 		</xsd:annotation>
@@ -330,7 +330,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================== =============================================== -->
-	<xsd:element name="RoutingConstraintZone" abstract="false" substitutionGroup="Zone">
+	<xsd:element name="RoutingConstraintZone" substitutionGroup="Zone">
 		<xsd:annotation>
 			<xsd:documentation>A constraint on the use of a service. The service, on this specific JOURNEY PATTERN (usually a FTS JOURNEY PATTERN) cannot operate when another (regular) service operates. This may occur only on subpart of the JOURNEY PATTERN, or only on one or some specific SCHEDULED STOP POINTs within the pattern.</xsd:documentation>
 		</xsd:annotation>
@@ -366,7 +366,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RoutingConstraintZone_VersionStructure" abstract="false">
+	<xsd:complexType name="RoutingConstraintZone_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for ROUTING CONSTRAINT ZONE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
@@ -177,7 +177,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ScheduledStopPoint" abstract="false" substitutionGroup="Point">
+	<xsd:element name="ScheduledStopPoint" substitutionGroup="Point">
 		<xsd:annotation>
 			<xsd:documentation> A POINT where passengers can board or alight from vehicles. It is open, which hierarchical level such a point has. It can represent a single door (BoardingPosition) or a whole ZONE. The association to the physical model is done with STOP ASSIGNMENTs.</xsd:documentation>
 		</xsd:annotation>
@@ -206,7 +206,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ScheduledStopPoint_VersionStructure" abstract="false">
+	<xsd:complexType name="ScheduledStopPoint_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for SCHEDULED STOP POINT restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -389,7 +389,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="ServiceLink" abstract="false" substitutionGroup="Link">
+	<xsd:element name="ServiceLink" substitutionGroup="Link">
 		<xsd:annotation>
 			<xsd:documentation>A LINK between an ordered pair of STOP POINTs.  Service links are directional - there will be separate links for each direction of a route.</xsd:documentation>
 		</xsd:annotation>
@@ -415,7 +415,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ServiceLink_VersionStructure" abstract="false">
+	<xsd:complexType name="ServiceLink_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for SERVICE LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -447,7 +447,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="StopArea" abstract="false" substitutionGroup="Zone">
+	<xsd:element name="StopArea" substitutionGroup="Zone">
 		<xsd:annotation>
 			<xsd:documentation>A group of STOP POINTs close to each other.</xsd:documentation>
 		</xsd:annotation>
@@ -513,7 +513,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="Connection" abstract="false" substitutionGroup="Transfer">
+	<xsd:element name="Connection" substitutionGroup="Transfer">
 		<xsd:annotation>
 			<xsd:documentation>The physical (spatial) possibility for a passenger to change from one public transport vehicle to another to continue the trip. Different times may be necessary to cover this link, depending on the kind of passenger.</xsd:documentation>
 		</xsd:annotation>
@@ -539,7 +539,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Connection_VersionStructure" abstract="false">
+	<xsd:complexType name="Connection_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a CONNECTION link restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -578,12 +578,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="ConnectionEnd" type="ConnectionEndStructure" abstract="false">
+	<xsd:element name="ConnectionEnd" type="ConnectionEndStructure">
 		<xsd:annotation>
 			<xsd:documentation>One end of a CONNECTION.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ConnectionEndStructure" abstract="false">
+	<xsd:complexType name="ConnectionEndStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a CONNECTION END.</xsd:documentation>
 		</xsd:annotation>
@@ -618,7 +618,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:complexType>
 	<!-- ===SERVICE PATTERN===================================================== -->
-	<xsd:element name="ServicePattern" abstract="false" substitutionGroup="LinkSequence">
+	<xsd:element name="ServicePattern" substitutionGroup="LinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>The subset of a JOURNEY PATTERN made up only of STOP POINTs IN JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -644,7 +644,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ServicePattern_VersionStructure" abstract="false">
+	<xsd:complexType name="ServicePattern_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SERVICE PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -689,7 +689,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="ServiceJourneyPattern" abstract="false" substitutionGroup="JourneyPattern_">
+	<xsd:element name="ServiceJourneyPattern" substitutionGroup="JourneyPattern_">
 		<xsd:annotation>
 			<xsd:documentation>The JOURNEY PATTERN for a (passenger carrying) SERVICE JOURNEY.</xsd:documentation>
 		</xsd:annotation>
@@ -772,7 +772,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="StopPointInJourneyPattern" abstract="false" substitutionGroup="PointInLinkSequence">
+	<xsd:element name="StopPointInJourneyPattern" substitutionGroup="PointInLinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>The use of a SCHEDULED STOP POINT in a specified order. within a JOURNEY PATTERN or SERVICE PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -810,7 +810,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="StopPointInJourneyPattern_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="StopPointInJourneyPattern_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a STOP POINT IN JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -951,12 +951,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ServiceLinkInJourneyPattern" type="ServiceLinkInJourneyPattern_VersionedChildStructure" abstract="false" substitutionGroup="LinkInLinkSequence">
+	<xsd:element name="ServiceLinkInJourneyPattern" type="ServiceLinkInJourneyPattern_VersionedChildStructure" substitutionGroup="LinkInLinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>The use of a SERVICE LINK in a specified order. within a JOURNEY PATTERN or SERVICE PATTERN.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ServiceLinkInJourneyPattern_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="ServiceLinkInJourneyPattern_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SERVICE LINK IN JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -978,12 +978,12 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="ScheduledStopPointView" type="ScheduledStopPoint_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="ScheduledStopPointView" type="ScheduledStopPoint_DerivedViewStructure" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of SCHEDULED STOP POINT. Includes derived some propertries of a stop.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ScheduledStopPoint_DerivedViewStructure" abstract="false">
+	<xsd:complexType name="ScheduledStopPoint_DerivedViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for SCHEDULED STOP POINT VIEW.</xsd:documentation>
 		</xsd:annotation>
@@ -1003,7 +1003,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="OnwardServiceLinkView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="OnwardServiceLinkView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Information about an onwards SERVICE LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -1042,12 +1042,12 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="StopPointInJourneyPatternView" type="StopPointInJourneyPattern_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="StopPointInJourneyPatternView" type="StopPointInJourneyPattern_DerivedViewStructure" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified STOP POINT IN JOURNEY PATTERN. Assumes single time demand.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="StopPointInJourneyPattern_DerivedViewStructure" abstract="false">
+	<xsd:complexType name="StopPointInJourneyPattern_DerivedViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for STOP POINT IN JOURNEY PATTERN VIEW.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_siteConnection_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_siteConnection_version.xsd
@@ -69,7 +69,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>neTEX: SITE CONNECTION types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<xsd:element name="SiteConnection" abstract="false" substitutionGroup="Transfer">
+	<xsd:element name="SiteConnection" substitutionGroup="Transfer">
 		<xsd:annotation>
 			<xsd:documentation> The physical (spatial) possibility to connect from one point to another in a SITE.</xsd:documentation>
 		</xsd:annotation>
@@ -95,7 +95,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="SiteConnection_VersionStructure" abstract="false">
+	<xsd:complexType name="SiteConnection_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SITE CONNECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -129,7 +129,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:complexType name="SiteConnectionEndStructure" abstract="false">
+	<xsd:complexType name="SiteConnectionEndStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SITE CONNECTION End.</xsd:documentation>
 		</xsd:annotation>
@@ -207,7 +207,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="DefaultConnection" abstract="false" substitutionGroup="Transfer">
+	<xsd:element name="DefaultConnection" substitutionGroup="Transfer">
 		<xsd:annotation>
 			<xsd:documentation>Specifies the default transfer times to transfer between MODEs and / or OPERATORs within a region.</xsd:documentation>
 		</xsd:annotation>
@@ -231,7 +231,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="DefaultConnection_VersionStructure" abstract="false">
+	<xsd:complexType name="DefaultConnection_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for DEFAULT TRANSFER.</xsd:documentation>
 		</xsd:annotation>
@@ -265,7 +265,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="SiteElementRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:complexType name="DefaultConnectionEndStructure" abstract="false">
+	<xsd:complexType name="DefaultConnectionEndStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a DEFAULT TRANSFER.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
@@ -179,7 +179,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======PASSENGER STOP ASSIGNMENT.=========================================== -->
-	<xsd:element name="PassengerStopAssignment" abstract="false" substitutionGroup="StopAssignment">
+	<xsd:element name="PassengerStopAssignment" substitutionGroup="StopAssignment">
 		<xsd:annotation>
 			<xsd:documentation>The default allocation of a SCHEDULED STOP POINT to a specific STOP PLACE, and also possibly a QUAY and BOARDING POSITION.
 </xsd:documentation>
@@ -432,7 +432,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======PASSENGER STOP ASSIGNMENT VIEW================================================== -->
-	<xsd:element name="PassengerStopAssignmentView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="PassengerStopAssignmentView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>View of an assignment of a SCHEDULED STOP POINT to a STOP PLACE and quay. etc.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_timeDemandType_support.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_timeDemandType_support.xsd
@@ -167,7 +167,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a TYPE OF TIME DEMAND TYPE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfTimeDemandTypeRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfTimeDemandTypeRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF TIME DEMAND TYPE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_timeDemandType_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_timeDemandType_version.xsd
@@ -125,7 +125,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- === TIME DEMAND TYPE ========================================================= -->
-	<xsd:element name="TimeDemandType" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="TimeDemandType" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>An indicator of traffic conditions or other factors which may affect vehicle run or wait times. It may be entered directly by the scheduler or defined by the use of TIME BANDs.</xsd:documentation>
 		</xsd:annotation>
@@ -222,7 +222,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TimeDemandTypeAssignment" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="TimeDemandTypeAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a TIME DEMAND TYPE to a TIME BAND depending on the DAY TYPE and GROUP OF TIMING LINKS.</xsd:documentation>
 		</xsd:annotation>
@@ -273,7 +273,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfTimeDemandType" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfTimeDemandType" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>Classification of a TIME DEMAND TYPE.</xsd:documentation>
 		</xsd:annotation>
@@ -296,7 +296,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfTimeDemandTypeStructure" abstract="false">
+	<xsd:complexType name="TypeOfTimeDemandTypeStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF TIME DEMAND TYPE.</xsd:documentation>
 		</xsd:annotation>
@@ -317,7 +317,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleTypePreference" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="VehicleTypePreference" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>The preference for the use of a particular VEHICLE TYPE for a SERVICE JOURNEY PATTERN, depending on the DAY TYPE and TIME DEMAND TYPE. The rank of preferences must be recorded. Different VEHICLE TYPEs may be given the same rank.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
@@ -158,7 +158,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>A POINT against which the timing information necessary to build schedules may be recorded.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="TimingPoint" abstract="false" substitutionGroup="TimingPoint_">
+	<xsd:element name="TimingPoint" substitutionGroup="TimingPoint_">
 		<xsd:annotation>
 			<xsd:documentation>A POINT against which the timing information necessary to build schedules may be recorded.</xsd:documentation>
 		</xsd:annotation>
@@ -184,7 +184,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TimingPoint_VersionStructure" abstract="false">
+	<xsd:complexType name="TimingPoint_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TIMING POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -226,7 +226,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TimingLink" abstract="false" substitutionGroup="Link">
+	<xsd:element name="TimingLink" substitutionGroup="Link">
 		<xsd:annotation>
 			<xsd:documentation>An ordered pair of TIMING POINTs for which run times may be recorded.  Timing links are directional - there will be separate links for each direction of a route.</xsd:documentation>
 		</xsd:annotation>
@@ -288,7 +288,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===TIMING PATTERN===================================================== -->
-	<xsd:element name="TimingPattern" abstract="false" substitutionGroup="LinkSequence">
+	<xsd:element name="TimingPattern" substitutionGroup="LinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>The subset of a JOURNEY PATTERN made up only of TIMING POINTs IN JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -378,7 +378,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TimingPointInJourneyPattern" abstract="false" substitutionGroup="PointInLinkSequence">
+	<xsd:element name="TimingPointInJourneyPattern" substitutionGroup="PointInLinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>A NODE in a JOURNEY PATTERN which is a TIMING POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -404,7 +404,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TimingPointInJourneyPattern_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="TimingPointInJourneyPattern_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TIMING POINT IN JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -436,7 +436,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======Link in pattern ========================================================= -->
-	<xsd:element name="TimingLinkInJourneyPattern" abstract="false" substitutionGroup="LinkInLinkSequence">
+	<xsd:element name="TimingLinkInJourneyPattern" substitutionGroup="LinkInLinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>The position of a TIMING LINK in a JOURNEY PATTERN. This ENTITY is needed if a TIMING LINK is repeated in the same JOURNEY PATTERN, and separate information is to be stored about each iteration of the TIMING LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -462,7 +462,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TimingLinkInJourneyPattern_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="TimingLinkInJourneyPattern_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TIMING LINK IN JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -488,7 +488,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==GROUP OF OPERATORss============================================================ -->
-	<xsd:element name="GroupOfTimingLinks" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfTimingLinks" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A set of TIMING LINKs grouped together according to the similarity of TIME BANDs which are relevant to them. There may be a GROUP OF TIMING LINKS which covers all TIMING LINKs, for use when different GROUPs OF TIMING LINKS are not needed.</xsd:documentation>
 		</xsd:annotation>
@@ -539,7 +539,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="OnwardTimingLinkView" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="OnwardTimingLinkView" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Information about onwards TIMING LINK.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_frames/netex_serviceFrame_version.xsd
+++ b/xsd/netex_part_2/part2_frames/netex_serviceFrame_version.xsd
@@ -60,7 +60,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="ServiceFrameRef" type="ServiceFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="ServiceFrameRef" type="ServiceFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a SERVICE FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -80,7 +80,7 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ServiceFrame" abstract="false" substitutionGroup="CommonFrame">
+	<xsd:element name="ServiceFrame" substitutionGroup="CommonFrame">
 		<xsd:annotation>
 			<xsd:documentation>A coherent set of Service data to which the same frame VALIDITY CONDITIONs have been assigned.</xsd:documentation>
 		</xsd:annotation>
@@ -111,7 +111,7 @@ Rail transport, Roads and Road transport
 			<xsd:field xpath="Id"/>
 		</xsd:unique> -->
 	</xsd:element>
-	<xsd:complexType name="Service_VersionFrameStructure" abstract="false">
+	<xsd:complexType name="Service_VersionFrameStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a SERVICE FRAME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_frames/netex_timetableFrame_support.xsd
+++ b/xsd/netex_part_2/part2_frames/netex_timetableFrame_support.xsd
@@ -59,7 +59,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEx: TIMETABLE FRAME identifier types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<xsd:element name="TimetableFrameRef" type="TimetableFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="TimetableFrameRef" type="TimetableFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TIMETABLE FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -70,7 +70,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:complexType name="TimetableFrameRefStructure" abstract="false">
+	<xsd:complexType name="TimetableFrameRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Reference to a TIMETABLE FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -85,7 +85,7 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="VehicleScheduleFrameRef" type="VehicleScheduleFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="VehicleScheduleFrameRef" type="VehicleScheduleFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a VEHICLE SCHEDULE FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -96,7 +96,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:complexType name="VehicleScheduleFrameRefStructure" abstract="false">
+	<xsd:complexType name="VehicleScheduleFrameRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Reference to a VEHICLE SCHEDULE FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -107,7 +107,7 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="DriverScheduleFrameRef" type="DriverScheduleFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="DriverScheduleFrameRef" type="DriverScheduleFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a DRIVER SCHEDULE FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -118,7 +118,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:complexType name="DriverScheduleFrameRefStructure" abstract="false">
+	<xsd:complexType name="DriverScheduleFrameRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Reference to a DRIVER SCHEDULE FRAME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_call_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_call_version.xsd
@@ -80,17 +80,12 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="Call_" minOccurs="2" maxOccurs="unbounded"/>
+					<xsd:element ref="Call" minOccurs="2" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Call_" type="VersionedChildStructure" abstract="true">
-		<xsd:annotation>
-			<xsd:documentation>Dummy CALL.</xsd:documentation>
-		</xsd:annotation>
-	</xsd:element>
-	<xsd:element name="Call" substitutionGroup="Call_">
+	<xsd:element name="Call">
 		<xsd:annotation>
 			<xsd:documentation>A visit to a SCHEDULED STOP POINT as part of a VEHICLE JOURNEY. A CALL is a view of a POINT IN JOURNEY PATTERN that adds in derived data.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_coupledJourney_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_coupledJourney_support.xsd
@@ -199,7 +199,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a PURPOSE OF JOURNEY PARTITION.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="PurposeOfJourneyPartitionRefStructure" abstract="false">
+	<xsd:complexType name="PurposeOfJourneyPartitionRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PURPOSE OF JOURNEY PARTITION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_coupledJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_coupledJourney_version.xsd
@@ -131,7 +131,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyPart" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="JourneyPart" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A part of a VEHICLE JOURNEY created according to a specific functional purpose, for instance in situations when vehicle coupling or separating occurs.</xsd:documentation>
 		</xsd:annotation>
@@ -282,7 +282,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyPartPosition" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="JourneyPartPosition" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Position in train of JOURNEY PART from a given stop. +v1.1.</xsd:documentation>
 		</xsd:annotation>
@@ -521,7 +521,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="PurposeOfJourneyPartition" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="PurposeOfJourneyPartition" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>An operational purpose changing within a JOURNEY PATTERN and with this subdividing the SERVICE JOURNEY into JOURNEY PARTs.</xsd:documentation>
 		</xsd:annotation>
@@ -544,7 +544,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PurposeOfJourneyPartition_ValueStructure" abstract="false">
+	<xsd:complexType name="PurposeOfJourneyPartition_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PURPOSE OF JOURNEY PARTITION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedPassingTimes_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedPassingTimes_version.xsd
@@ -62,7 +62,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEx: DATED PASSING TIME types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<xsd:element name="DatedPassingTime" type="DatedPassingTime_VersionedChildStructure" abstract="false" substitutionGroup="PassingTime">
+	<xsd:element name="DatedPassingTime" type="DatedPassingTime_VersionedChildStructure" substitutionGroup="PassingTime">
 		<xsd:annotation>
 			<xsd:documentation>DATED PASSING TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -104,7 +104,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TargetPassingTime" abstract="false" substitutionGroup="DatedPassingTime">
+	<xsd:element name="TargetPassingTime" substitutionGroup="DatedPassingTime">
 		<xsd:annotation>
 			<xsd:documentation>TARGET PASSING TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -255,7 +255,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TimetabledPassingTimeView" type="TimetabledPassingTime_ViewStructure" abstract="false">
+	<xsd:element name="TimetabledPassingTimeView" type="TimetabledPassingTime_ViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Simplified TIMETABLED PASSING TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -301,7 +301,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TargetPassingTimeView" abstract="false">
+	<xsd:element name="TargetPassingTimeView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified TARGET PASSING TIME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -118,7 +118,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="DatedVehicleJourney" abstract="false" substitutionGroup="Journey_">
+	<xsd:element name="DatedVehicleJourney" substitutionGroup="Journey_">
 		<xsd:annotation>
 			<xsd:documentation>A particular journey of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff.</xsd:documentation>
 		</xsd:annotation>
@@ -246,7 +246,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====DATED SERVICE JOURNEY====================================-->
-	<xsd:element name="DatedServiceJourney" abstract="false" substitutionGroup="ServiceJourney_">
+	<xsd:element name="DatedServiceJourney" substitutionGroup="ServiceJourney_">
 		<xsd:annotation>
 			<xsd:documentation>A particular SERVICE JOURNEY of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff. 
 
@@ -276,7 +276,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="DatedServiceJourney_VersionStructure" abstract="false">
+	<xsd:complexType name="DatedServiceJourney_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Data type for Planned VEHICLE JOURNEY (Production Timetable Service).</xsd:documentation>
 		</xsd:annotation>
@@ -297,7 +297,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="NormalDatedVehicleJourney" abstract="false" substitutionGroup="Journey_">
+	<xsd:element name="NormalDatedVehicleJourney" substitutionGroup="Journey_">
 		<xsd:annotation>
 			<xsd:documentation>A DATED VEHICLE JOURNEY identical to a long-term planned VEHICLE JOURNEY, possibly updated according to short-term modifications of the PRODUCTION PLAN decided by the control staff.</xsd:documentation>
 		</xsd:annotation>
@@ -344,7 +344,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="DatedSpecialService" abstract="false" substitutionGroup="Journey_">
+	<xsd:element name="DatedSpecialService" substitutionGroup="Journey_">
 		<xsd:annotation>
 			<xsd:documentation>A particular journey of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_flexibleService_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_flexibleService_support.xsd
@@ -123,7 +123,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a TYPE OF FLEXIBLE SERVICE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfFlexibleServiceRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfFlexibleServiceRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF FLEXIBLE SERVICE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_flexibleService_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_flexibleService_version.xsd
@@ -95,7 +95,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FlexibleServiceProperties" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="FlexibleServiceProperties" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Additional characteristics of a FLEXIBLE SERVICE. A service may be partly fixed, partly flexible.</xsd:documentation>
 		</xsd:annotation>
@@ -118,7 +118,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="FlexibleServiceProperties_VersionStructure" abstract="false">
+	<xsd:complexType name="FlexibleServiceProperties_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for FLEXIBLE SERVICE PROPERTies.</xsd:documentation>
 		</xsd:annotation>
@@ -174,7 +174,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="FlexibleStopAssignment" abstract="false" substitutionGroup="StopAssignment">
+	<xsd:element name="FlexibleStopAssignment" substitutionGroup="StopAssignment">
 		<xsd:annotation>
 			<xsd:documentation>Assignment of a SCHEDULED STOP POINT to a FLEXIBLE STOP PLACE and quay. etc.</xsd:documentation>
 		</xsd:annotation>
@@ -227,7 +227,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TypeOfFlexibleService" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfFlexibleService" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of FLEXIBLE SERVICEs according to their functional purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -250,7 +250,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfFlexibleService_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfFlexibleService_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF FLEXIBLE SERVICE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_interchangeRule_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_interchangeRule_version.xsd
@@ -122,7 +122,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="InterchangeRule" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="InterchangeRule" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Conditions for considering journeys to meet or not to meet, specified indirectly: by a particular MODE, DIRECTION or LINE. Such conditions may alternatively be specified directly, indicating the corresponding services. In this case they are either a SERVICE JOURNEY PATTERN INTERCHANGE or a SERVICE JOURNEY INTERCHANGE.</xsd:documentation>
 		</xsd:annotation>
@@ -148,7 +148,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="InterchangeRule_VersionStructure" abstract="false">
+	<xsd:complexType name="InterchangeRule_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for INTERCHANGE RULE.</xsd:documentation>
 		</xsd:annotation>
@@ -206,7 +206,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:complexType name="InterchangeRuleParameterStructure" abstract="false">
+	<xsd:complexType name="InterchangeRuleParameterStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for INTERCHANGE RULE PARAMETER.</xsd:documentation>
 		</xsd:annotation>
@@ -311,7 +311,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Filter for  INTERCHANGE RULE Filter.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="InterchangeRuleFilter_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="InterchangeRuleFilter_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for INTERCHANGE RULE PARAMETER.</xsd:documentation>
 		</xsd:annotation>
@@ -381,7 +381,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="InterchangeRuleTiming" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="InterchangeRuleTiming" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Conditions for considering journeys to meet or not to meet, specified indirectly: by a particular MODE, DIRECTION or LINE. Such conditions may alternatively be specified directly, indicating the corresponding services. In this case they are either a SERVICE JOURNEY PATTERN INTERCHANGE or a SERVICE JOURNEY INTERCHANGE.</xsd:documentation>
 		</xsd:annotation>
@@ -407,7 +407,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="InterchangeRuleTiming_VersionStructure" abstract="false">
+	<xsd:complexType name="InterchangeRuleTiming_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for INTERCHANGE RULE TIMING.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
@@ -109,7 +109,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="JourneyMeeting" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="JourneyMeeting" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A time constraint for one or several SERVICE JOURNEYs fixing interchanges between them and/or an external event (e.g. arrival or departure of a feeder line, opening time of the theatre, etc.).</xsd:documentation>
 		</xsd:annotation>
@@ -347,7 +347,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="DefaultInterchange" abstract="false" substitutionGroup="Interchange_">
+	<xsd:element name="DefaultInterchange" substitutionGroup="Interchange_">
 		<xsd:annotation>
 			<xsd:documentation>A quality parameter fixing the acceptable duration (standard and maximum) for an INTERCHANGE to be planned between two SCHEDULED STOP POINTs. This parameter will be used to control whether any two SERVICE JOURNEYs serving those points may be in connection.</xsd:documentation>
 		</xsd:annotation>
@@ -589,7 +589,7 @@ Default is false.</xsd:documentation>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ServiceJourneyInterchange" abstract="false" substitutionGroup="Interchange_">
+	<xsd:element name="ServiceJourneyInterchange" substitutionGroup="Interchange_">
 		<xsd:annotation>
 			<xsd:documentation>The scheduled possibility for transfer of passengers between two SERVICE JOURNEYs at the same or different STOP POINTs.</xsd:documentation>
 		</xsd:annotation>
@@ -615,7 +615,7 @@ Default is false.</xsd:documentation>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ServiceJourneyInterchange_VersionStructure" abstract="false">
+	<xsd:complexType name="ServiceJourneyInterchange_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for SERVICE JOURNEY INTERCHANGE.</xsd:documentation>
 		</xsd:annotation>
@@ -663,7 +663,7 @@ Default is false.</xsd:documentation>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="ServiceJourneyPatternInterchange" abstract="false" substitutionGroup="Interchange_">
+	<xsd:element name="ServiceJourneyPatternInterchange" substitutionGroup="Interchange_">
 		<xsd:annotation>
 			<xsd:documentation>A recognised/organised possibility for passengers to change public transport vehicles using two STOP POINTs (which may be identical) on two particular SERVICE JOURNEY PATTERNs, including the maximum wait duration allowed and the standard to be aimed at. These may supersede the times given for the DEFAULT INTERCHANGE. Schedulers may use this entity for synchronisation of journeys.</xsd:documentation>
 		</xsd:annotation>
@@ -745,7 +745,7 @@ Default is false.</xsd:documentation>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyMeetingView" type="JourneyMeeting_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="JourneyMeetingView" type="JourneyMeeting_DerivedViewStructure" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified  view of JOURNEY MEETING.</xsd:documentation>
 		</xsd:annotation>
@@ -778,7 +778,7 @@ Default is false.</xsd:documentation>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ServiceJourneyInterchangeView" type="ServiceJourneyInterchange_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="ServiceJourneyInterchangeView" type="ServiceJourneyInterchange_DerivedViewStructure" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified  view of SERVICE JOURNEY INTERCHANGE.</xsd:documentation>
 		</xsd:annotation>
@@ -836,12 +836,12 @@ Default is false.</xsd:documentation>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ConnectingJourneyView" type="ConnectingServiceJourney_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="ConnectingJourneyView" type="ConnectingServiceJourney_DerivedViewStructure" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of CONNECTING JOURNEY.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ConnectingServiceJourneyView" type="ConnectingServiceJourney_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="ConnectingServiceJourneyView" type="ConnectingServiceJourney_DerivedViewStructure" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified view of CONNECTING SERVICE JOURNEY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_journey_facility_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_journey_facility_support.xsd
@@ -42,7 +42,7 @@
 			<xsd:documentation>Reference to a restricted SERVICE FACILITY SET.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="RestrictedServiceFacilitySet" abstract="false" substitutionGroup="FacilitySet">
+	<xsd:element name="RestrictedServiceFacilitySet" substitutionGroup="FacilitySet">
 		<xsd:annotation>
 			<xsd:documentation>Restricted Service FACILITY. The restriction can be an AvailabilityCondition and/or a From - To relation. +v2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_passengerAtStopTime_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_passengerAtStopTime_version.xsd
@@ -85,7 +85,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PassengerAtStopTime" abstract="false" substitutionGroup="PassingTime">
+	<xsd:element name="PassengerAtStopTime" substitutionGroup="PassingTime">
 		<xsd:annotation>
 			<xsd:documentation>Time at which a passenger should be at a stop to commence or finish a process. +v2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_passingTimes_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_passingTimes_version.xsd
@@ -111,7 +111,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TimetabledPassingTime" abstract="false" substitutionGroup="PassingTime">
+	<xsd:element name="TimetabledPassingTime" substitutionGroup="PassingTime">
 		<xsd:annotation>
 			<xsd:documentation>TIMETABLED PASSING TIME at TIMING POINT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_version.xsd
@@ -91,7 +91,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy SERVICE JOURNEY Supertype.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ServiceJourney" abstract="false" substitutionGroup="VehicleJourney_">
+	<xsd:element name="ServiceJourney" substitutionGroup="VehicleJourney_">
 		<xsd:annotation>
 			<xsd:documentation>A passenger carrying VEHICLE JOURNEY for one specified DAY TYPE. The pattern of working is in principle defined by a SERVICE JOURNEY PATTERN.
 
@@ -294,7 +294,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 		</xsd:sequence>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TemplateServiceJourney" abstract="false" substitutionGroup="ServiceJourney_">
+	<xsd:element name="TemplateServiceJourney" substitutionGroup="ServiceJourney_">
 		<xsd:annotation>
 			<xsd:documentation>A VEHICLE JOURNEY with a set of frequencies that may be used to represent a set of similar journeys differing only by their time of departure.</xsd:documentation>
 		</xsd:annotation>
@@ -348,7 +348,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SpecialService" abstract="false" substitutionGroup="Journey_">
+	<xsd:element name="SpecialService" substitutionGroup="Journey_">
 		<xsd:annotation>
 			<xsd:documentation>A passenger carrying VEHICLE JOURNEY for one specified DAY TYPE. The pattern of working is in principle defined by a SERVICE JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -430,7 +430,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==Group of Services============================================================ -->
-	<xsd:element name="GroupOfServices" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfServices" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A group of SERVICEs, often known to its users by a name or a number.</xsd:documentation>
 		</xsd:annotation>
@@ -528,7 +528,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:complexType name="GroupOfServicesEndPoint_DerivedViewStructure" abstract="false">
+	<xsd:complexType name="GroupOfServicesEndPoint_DerivedViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for SIMPLE SCHEDULED STOP POINT VIEW.</xsd:documentation>
 		</xsd:annotation>
@@ -668,7 +668,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="DeadRun" abstract="false" substitutionGroup="VehicleJourney_">
+	<xsd:element name="DeadRun" substitutionGroup="VehicleJourney_">
 		<xsd:annotation>
 			<xsd:documentation>A non-service VEHICLE JOURNEY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_timeDemandProfile_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_timeDemandProfile_version.xsd
@@ -61,7 +61,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEx: TIME DEMAND PROFILE types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- === TIme Demand ========================================================= -->
-	<xsd:element name="TimeDemandProfile" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="TimeDemandProfile" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>TIME DEMAND PROFILE.</xsd:documentation>
 		</xsd:annotation>
@@ -128,7 +128,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TimeDemandProfileMember" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="TimeDemandProfileMember" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>TIME DEMAND PROFILE member.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_timeDemandTimes_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_timeDemandTimes_version.xsd
@@ -78,7 +78,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DefaultServiceJourneyRunTime" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="DefaultServiceJourneyRunTime" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>The default time taken by a vehicle to traverse a TIMING LINK during a SERVICE JOURNEY, for a specified TIME DEMAND TYPE. This time may be superseded by the JOURNEY PATTERN RUN TIME or VEHICLE JOURNEY RUN TIME if these exist.</xsd:documentation>
 		</xsd:annotation>
@@ -104,7 +104,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="DefaultServiceJourneyRunTime_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="DefaultServiceJourneyRunTime_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for DEFAULT SERVICE JOURNEY / RUN TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -143,7 +143,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DefaultDeadRunRunTime" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="DefaultDeadRunRunTime" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>The time taken to traverse a TIMING LINK during a DEAD RUN, for a specified TIME DEMAND TYPE. This time may be superseded by the JOURNEY PATTERN RUN TIME or VEHICLE JOURNEY RUN TIME if these exist.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourneyFrequency_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourneyFrequency_support.xsd
@@ -110,7 +110,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="JourneyFrequencyGroupRef" type="JourneyFrequencyGroupRefStructure" abstract="false" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="JourneyFrequencyGroupRef" type="JourneyFrequencyGroupRefStructure" substitutionGroup="GroupOfEntitiesRef_">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a JOURNEY FREQUENCY GROUP.</xsd:documentation>
 		</xsd:annotation>
@@ -158,7 +158,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="JourneyFrequencyGroupIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="HeadwayJourneyGroupRef" type="HeadwayJourneyGroupRefStructure" abstract="false" substitutionGroup="JourneyFrequencyGroupRef">
+	<xsd:element name="HeadwayJourneyGroupRef" type="HeadwayJourneyGroupRefStructure" substitutionGroup="JourneyFrequencyGroupRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a HEADWAY JOURNEY GROUP.</xsd:documentation>
 		</xsd:annotation>
@@ -184,7 +184,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="JourneyFrequencyGroupIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="RhythmicalJourneyGroupRef" type="RhythmicalJourneyGroupRefStructure" abstract="false" substitutionGroup="JourneyFrequencyGroupRef">
+	<xsd:element name="RhythmicalJourneyGroupRef" type="RhythmicalJourneyGroupRefStructure" substitutionGroup="JourneyFrequencyGroupRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a RHYTHMICAL JOURNEY GROUP.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourneyFrequency_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourneyFrequency_version.xsd
@@ -122,7 +122,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleJourneyHeadway" abstract="false" substitutionGroup="JourneyTiming">
+	<xsd:element name="VehicleJourneyHeadway" substitutionGroup="JourneyTiming">
 		<xsd:annotation>
 			<xsd:documentation>Headway interval information that is available for a VEHICLE JOURNEY (to be understood as the delay between the previous and the next VEHICLE JOURNEY). This information must be consistent with HEADWAY JOURNEY GROUP if available (HEADWAY JOURNEY GROUP being a more detailed way of describing headway services).</xsd:documentation>
 		</xsd:annotation>
@@ -271,7 +271,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="HeadwayJourneyGroup" abstract="false" substitutionGroup="JourneyFrequencyGroup">
+	<xsd:element name="HeadwayJourneyGroup" substitutionGroup="JourneyFrequencyGroup">
 		<xsd:annotation>
 			<xsd:documentation>A group of VEHICLE JOURNEYs following the same JOURNEY PATTERN and having the same headway interval between a specified start and end time (for example, ‘every 10 minutes’). This is especially useful for presenting passenger information.</xsd:documentation>
 		</xsd:annotation>
@@ -296,7 +296,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="HeadwayJourneyGroup_VersionStructure" abstract="false">
+	<xsd:complexType name="HeadwayJourneyGroup_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for   HEADWAY JOURNEY GROUP.</xsd:documentation>
 		</xsd:annotation>
@@ -320,7 +320,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="RhythmicalJourneyGroup" abstract="false" substitutionGroup="JourneyFrequencyGroup">
+	<xsd:element name="RhythmicalJourneyGroup" substitutionGroup="JourneyFrequencyGroup">
 		<xsd:annotation>
 			<xsd:documentation>A group of VEHICLE JOURNEYS following  the same JOURNEY PATTERN having the same "rhythm" every hour (for example runs all xxh10, xxh25 and xxh45... e) between a specified start and end time.</xsd:documentation>
 		</xsd:annotation>
@@ -345,7 +345,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RhythmicalJourneyGroup_VersionStructure" abstract="false">
+	<xsd:complexType name="RhythmicalJourneyGroup_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for   Rhythmical JOURNEY GROUP.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourneyStopAssignment_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourneyStopAssignment_version.xsd
@@ -96,7 +96,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleTypeStopAssignment" abstract="false" substitutionGroup="StopAssignment">
+	<xsd:element name="VehicleTypeStopAssignment" substitutionGroup="StopAssignment">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a stopping position of a VEHICLE TYPE for a particular VEHICLE JOURNEY.</xsd:documentation>
 		</xsd:annotation>
@@ -168,7 +168,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleJourneyStopAssignment" abstract="false" substitutionGroup="StopAssignment">
+	<xsd:element name="VehicleJourneyStopAssignment" substitutionGroup="StopAssignment">
 		<xsd:annotation>
 			<xsd:documentation>Change to a PASSENGER STOP ASSIGNMENT for a specific VEHICLE JOURNEY +v1.1</xsd:documentation>
 		</xsd:annotation>
@@ -241,7 +241,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TrainComponentLabelAssignment" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="TrainComponentLabelAssignment" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of an advertised designation for a vehicle or vehicle element for passengers.</xsd:documentation>
 		</xsd:annotation>
@@ -296,7 +296,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======DYNAMIC STOP ASSIGNMENT.=========================================== -->
-	<xsd:element name="DynamicStopAssignment" abstract="false" substitutionGroup="StopAssignment">
+	<xsd:element name="DynamicStopAssignment" substitutionGroup="StopAssignment">
 		<xsd:annotation>
 			<xsd:documentation>Change to a PASSENGER STOP ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourneyTimes_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourneyTimes_version.xsd
@@ -75,7 +75,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleJourneyWaitTime" abstract="false" substitutionGroup="JourneyTiming">
+	<xsd:element name="VehicleJourneyWaitTime" substitutionGroup="JourneyTiming">
 		<xsd:annotation>
 			<xsd:documentation>The time for a vehicle to wait at a particular TIMING POINT IN JOURNEY PATTERN on a specified VEHICLE JOURNEY. This wait time will override the JOURNEY PATTERN WAIT TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -142,7 +142,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleJourneyRunTime" abstract="false" substitutionGroup="JourneyTiming">
+	<xsd:element name="VehicleJourneyRunTime" substitutionGroup="JourneyTiming">
 		<xsd:annotation>
 			<xsd:documentation>The time taken to traverse a specified TIMING LINK IN JOURNEY PATTERN on a specified VEHICLE JOURNEY. This gives the most detailed control over times and overrides the DEFAULT SERVICE JOURNEY RUN TIME and JOURNEY PATTERN RUN TIME and the DEFAULT DEAD RUN RUN TIME. There may be different times for different TIME DEMAND TYPES.</xsd:documentation>
 		</xsd:annotation>
@@ -169,7 +169,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleJourneyRunTime_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="VehicleJourneyRunTime_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE JOURNEY RUN TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -204,7 +204,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleJourneyLayover" abstract="false" substitutionGroup="JourneyTiming">
+	<xsd:element name="VehicleJourneyLayover" substitutionGroup="JourneyTiming">
 		<xsd:annotation>
 			<xsd:documentation>A time allowance at the end of a specified VEHICLE JOURNEY. This time supersedes any global layover or JOURNEY PATTERN LAYOVER.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourney_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourney_support.xsd
@@ -223,7 +223,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TimingAlgorithmTypeRef" type="TimingAlgorithmTypeRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="TimingAlgorithmTypeRef" type="TimingAlgorithmTypeRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TIMING ALGORITHM TYPE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourney_version.xsd
@@ -112,7 +112,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy VEHICLE JOURNEY supertype.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="VehicleJourney" abstract="false" substitutionGroup="VehicleJourney_" id="VehicleJourney">
+	<xsd:element name="VehicleJourney" substitutionGroup="VehicleJourney_" id="VehicleJourney">
 		<xsd:annotation>
 			<xsd:documentation>The planned movement of a public transport vehicle on a DAY TYPE from the start point to the end point of a JOURNEY PATTERN on a specified ROUTE.</xsd:documentation>
 		</xsd:annotation>
@@ -305,7 +305,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- =====TEMPLATE VEHICLE JOURNEY=========================================== -->
-	<xsd:element name="TemplateVehicleJourney" abstract="false" substitutionGroup="VehicleJourney_" id="TemplateTemplateVehicleJourney">
+	<xsd:element name="TemplateVehicleJourney" substitutionGroup="VehicleJourney_" id="TemplateTemplateVehicleJourney">
 		<xsd:annotation>
 			<xsd:documentation>A repeating VEHICLE JOURNEY for which a frequency has been specified, either as a HEADWAY JOURNEY GROUP (e.g. every 20 minutes) or a RHYTHMICAL JOURNEY GROUP  (e.g. at 15, 27 and 40 minutes past the hour). It may thus represent multiple journeys.</xsd:documentation>
 		</xsd:annotation>
@@ -362,7 +362,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== TRAIN NUMBER ============================================================== -->
-	<xsd:element name="TrainNumber" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="TrainNumber" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Specification of codes assigned to particular VEHICLE JOURNEYs when operated by TRAINs of COMPOUND TRAINs according to a functional purpose (passenger information, operation follow-up, etc).</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_occupancy/netex_oc_occupancy_version.xsd
+++ b/xsd/netex_part_2/part2_occupancy/netex_oc_occupancy_version.xsd
@@ -129,7 +129,7 @@ More accurate data can be provided by the individual occupancies or capacities b
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="OccupancyView_VersionStructure" abstract="false">
+	<xsd:complexType name="OccupancyView_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for an Occupancy.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_vehicleService/netex_duty_version.xsd
+++ b/xsd/netex_part_2/part2_vehicleService/netex_duty_version.xsd
@@ -131,7 +131,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- === DUTY ================================================== -->
-	<xsd:element name="Duty" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="Duty" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>The work to be performed by a driver on a particular DAY TYPE.</xsd:documentation>
 		</xsd:annotation>
@@ -195,7 +195,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- === ACCOUNTABLE ELEMENT ================================================================== -->
-	<xsd:element name="AccountableElement" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="AccountableElement" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A period of a driver's DUTY during which (s)he is continuously working without a BREAK. PAUSEs during which (the)he remains responsible for the vehicle may be included.</xsd:documentation>
 		</xsd:annotation>
@@ -277,7 +277,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DutyPart" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="DutyPart" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A continuous part of a driver DUTY during which (s)he is under the management of the company. A DUTY PART may include BREAKs.
 .</xsd:documentation>
@@ -365,7 +365,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== DRIVER TRIP ================================================== -->
-	<xsd:element name="DriverTrip" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="DriverTrip" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A planned non-driving movement of a driver within a DUTY PART. This may be necessary to reach the first SPELL in a STRETCH, between two SPELLs or after the last SPELL in a STRETCH. It may be entirely on foot or may use a VEHICLE JOURNEY on a vehicle driven by another driver.</xsd:documentation>
 		</xsd:annotation>
@@ -455,7 +455,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DriverTripTime" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="DriverTripTime" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A part of a BLOCK composed of consecutive VEHICLE JOURNEYs defined for the same DAY TYPE, all operated on the same LINE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_vehicleService/netex_vehicleRechargingPlan_version.xsd
+++ b/xsd/netex_part_2/part2_vehicleService/netex_vehicleRechargingPlan_version.xsd
@@ -90,7 +90,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RechargingPlan" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="RechargingPlan" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A plan for periodically charging a VEHICLE while executing a BLOCK or BLOCKs. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -180,7 +180,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RechargingStep" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="RechargingStep" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>The planned charging of a VEHICLE at a PARKING POINT on a specific VEHICLE JOURNEY. +v2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_vehicleService/netex_vehicleService_version.xsd
+++ b/xsd/netex_part_2/part2_vehicleService/netex_vehicleService_version.xsd
@@ -147,7 +147,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ===Block=================================================== -->
-	<xsd:element name="Block" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="Block" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>The work of a vehicle from the time it leaves a PARKING POINT after parking until its next return to park at a PARKING POINT. Any subsequent departure from a PARKING POINT after parking marks the start of a new BLOCK. The period of a BLOCK has to be covered by DUTies.</xsd:documentation>
 		</xsd:annotation>
@@ -309,7 +309,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TrainBlock" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="TrainBlock" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>The vehicle work required by a train-based JOURNEY or sequence of JOURNEYs, from the time it leaves a PARKING POINT after parking until its next return to park at a PARKING POINT.</xsd:documentation>
 		</xsd:annotation>
@@ -374,7 +374,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="BlockPart" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="BlockPart" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A part of a BLOCK.</xsd:documentation>
 		</xsd:annotation>
@@ -443,7 +443,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="CompoundBlock" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="CompoundBlock" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A composite BLOCK formed of several BLOCKs coupled together during a certain period. Any coupling or separation action marks the start of a new COMPOUND BLOCK.</xsd:documentation>
 		</xsd:annotation>
@@ -512,7 +512,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TrainBlockPart" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="TrainBlockPart" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Part of a TRAIN BLOCK corresponding to a specific JOURNEY PART of the relevant JOURNEY of a TRAIN BLOCK. Note: Any train reversal, splitting, or joining operation marks the start of a new TRAIN BLOCK PART.</xsd:documentation>
 		</xsd:annotation>
@@ -584,7 +584,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ======================================================================= -->
-	<xsd:element name="VehicleService" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="VehicleService" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A work plan for a vehicle for a whole day, planned for a specific DAY TYPE. A VEHICLE SERVICE includes one or several VEHICLE SERVICE PARTs.</xsd:documentation>
 		</xsd:annotation>
@@ -655,7 +655,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleServicePart" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="VehicleServicePart" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A part of a VEHICLE SERVICE composed of one or more BLOCKs and limited by periods spent at the GARAGE managing the vehicle in question.</xsd:documentation>
 		</xsd:annotation>
@@ -724,7 +724,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CourseOfJourneys" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="CourseOfJourneys" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A part of a BLOCK composed of consecutive VEHICLE JOURNEYs defined for the same DAY TYPE, all operated on the same LINE.</xsd:documentation>
 		</xsd:annotation>
@@ -827,7 +827,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ReliefOpportunity" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="ReliefOpportunity" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A time in a BLOCK where a vehicle passes a RELIEF POINT. This opportunity may or may not be actually used for a relief.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_PiQuery/netex_piRequest_support.xsd
+++ b/xsd/netex_part_3/part3_PiQuery/netex_piRequest_support.xsd
@@ -95,7 +95,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PassengerInformationRequestIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TripPlanRequestRef" type="TripPlanRequestRefStructure" abstract="false" substitutionGroup="PassengerInformationRequestRef">
+	<xsd:element name="TripPlanRequestRef" type="TripPlanRequestRefStructure" substitutionGroup="PassengerInformationRequestRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TRIP PLAN REQUEST.</xsd:documentation>
 		</xsd:annotation>
@@ -121,7 +121,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PassengerInformationRequestIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="ScheduleRequestRef" type="ScheduleRequestRefStructure" abstract="false" substitutionGroup="PassengerInformationRequestRef">
+	<xsd:element name="ScheduleRequestRef" type="ScheduleRequestRefStructure" substitutionGroup="PassengerInformationRequestRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a SCHEDULE REQUEST.</xsd:documentation>
 		</xsd:annotation>
@@ -147,7 +147,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PassengerInformationRequestIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="StopEventRequestRef" type="StopEventRequestRefStructure" abstract="false" substitutionGroup="PassengerInformationRequestRef">
+	<xsd:element name="StopEventRequestRef" type="StopEventRequestRefStructure" substitutionGroup="PassengerInformationRequestRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a STOP EVENT REQUEST.</xsd:documentation>
 		</xsd:annotation>
@@ -173,7 +173,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PassengerInformationRequestIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="StopFinderRequestRef" type="StopFinderRequestRefStructure" abstract="false" substitutionGroup="PassengerInformationRequestRef">
+	<xsd:element name="StopFinderRequestRef" type="StopFinderRequestRefStructure" substitutionGroup="PassengerInformationRequestRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a STOP FINDER REQUEST.</xsd:documentation>
 		</xsd:annotation>
@@ -199,7 +199,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PassengerInformationRequestIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="FareRequestRef" type="FareRequestRefStructure" abstract="false" substitutionGroup="PassengerInformationRequestRef">
+	<xsd:element name="FareRequestRef" type="FareRequestRefStructure" substitutionGroup="PassengerInformationRequestRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a FARE REQUEST.</xsd:documentation>
 		</xsd:annotation>
@@ -225,7 +225,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="FareRequestIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="SingleTripFareRequestRef" type="SingleTripFareRequestRefStructure" abstract="false" substitutionGroup="FareRequestRef">
+	<xsd:element name="SingleTripFareRequestRef" type="SingleTripFareRequestRefStructure" substitutionGroup="FareRequestRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a SINGLE TRIP FARE REQUEST.</xsd:documentation>
 		</xsd:annotation>
@@ -251,7 +251,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="FareRequestIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="RepeatedTripFareRequestRef" type="RepeatedTripFareRequestRefStructure" abstract="false" substitutionGroup="FareRequestRef">
+	<xsd:element name="RepeatedTripFareRequestRef" type="RepeatedTripFareRequestRefStructure" substitutionGroup="FareRequestRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a REPEATED TRIP FARE REQUEST.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -219,7 +219,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>The assignment of a fare parameter (referring to geography, time, quality or usage) to an element of a fare system (access right, validated access, control mean, etc.).</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="AccessRightParameterAssignment" type="AccessRightParameterAssignment_VersionStructure" abstract="false" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="AccessRightParameterAssignment" type="AccessRightParameterAssignment_VersionStructure" substitutionGroup="AccessRightParameterAssignment_">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a fare parameter (referring to geography, time, quality or usage) to an element of a fare system (access right, validated access, control mean, etc.).</xsd:documentation>
 		</xsd:annotation>
@@ -773,7 +773,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ValidityParameterAssignment" abstract="false" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="ValidityParameterAssignment" substitutionGroup="AccessRightParameterAssignment_">
 		<xsd:annotation>
 			<xsd:documentation>An ACCESS RIGHT PARAMETER ASSIGNMENT relating a fare collection parameter to a theoretical FARE PRODUCT (or one of its components) or a SALES OFFER PACKAGE.</xsd:documentation>
 		</xsd:annotation>
@@ -804,7 +804,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ValidityParameterAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="ValidityParameterAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VALIDITY PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -868,7 +868,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GenericParameterAssignment" abstract="false" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="GenericParameterAssignment" substitutionGroup="AccessRightParameterAssignment_">
 		<xsd:annotation>
 			<xsd:documentation>A VALIDITY PARAMETER ASSIGNMENT specifying practical parameters during a TRAVEL GenericATION, within a given fare structure (e.g. the origin or destination zone in a zone-counting system).</xsd:documentation>
 		</xsd:annotation>
@@ -902,7 +902,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="GenericParameterAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="GenericParameterAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Generic PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -943,7 +943,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="GenericParameterAssignmentInContext" abstract="false" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="GenericParameterAssignmentInContext" substitutionGroup="AccessRightParameterAssignment_">
 		<xsd:annotation>
 			<xsd:documentation>Optimisation: Can be used without id constraintA VALIDITY PARAMETER ASSIGNMENT specifying practical parameters during a TRAVEL GenericATION, within a given fare structure (e.g. the origin or destination zone in a zone-counting system).</xsd:documentation>
 		</xsd:annotation>
@@ -996,7 +996,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfAccessRightAssignment" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfAccessRightAssignment" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of ACCESS RIGHT ASSIGNMENTs expressing their general functionalities and local functional characteristics specific to the operator. Types of ACCESS RIGHT ASSIGNMENTs like e.g. throw-away ticket, throw-away ticket unit, value card, electronic purse allowing access, public transport credit card etc. may be used to define these categories.
 </xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
@@ -172,7 +172,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PriceUnit" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="PriceUnit" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>A unit to express prices: amount of currency, abstract fare unit, ticket unit or token etc.</xsd:documentation>
 		</xsd:annotation>
@@ -795,7 +795,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexType>
 	</xsd:element>
 	<!-- ==== TYPE OF PRICING RULE. ================================== -->
-	<xsd:element name="TypeOfPricingRule" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfPricingRule" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Classification of pricing rule. Can be used for VAT categories, etc.  +v1.1</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_version.xsd
@@ -129,7 +129,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GroupOfDistanceMatrixElements" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfDistanceMatrixElements" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A group of DISTANCE MATRIX ELEMENTs; may set common properties for a given set of origin and destination pairs.</xsd:documentation>
 		</xsd:annotation>
@@ -229,7 +229,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy SERVICE JOURNEY supertype.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="DistanceMatrixElement" abstract="false" substitutionGroup="DistanceMatrixElement_">
+	<xsd:element name="DistanceMatrixElement" substitutionGroup="DistanceMatrixElement_">
 		<xsd:annotation>
 			<xsd:documentation>A cell of an origin-destination matrix for TARIFF ZONEs or STOP POINTs, expressing a fare distance for the corresponding trip: value in km, number of fare units etc.</xsd:documentation>
 		</xsd:annotation>
@@ -494,7 +494,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- === DYNAMIC DISTANCE MATRIX ELEMENT  ================================================= -->
-	<xsd:element name="DynamicDistanceMatrixElement" abstract="false" substitutionGroup="DistanceMatrixElement_">
+	<xsd:element name="DynamicDistanceMatrixElement" substitutionGroup="DistanceMatrixElement_">
 		<xsd:annotation>
 			<xsd:documentation>A dynamic free-standing distance matrix element. Used when a pre-computed distance matrix element is not feasible.</xsd:documentation>
 		</xsd:annotation>
@@ -530,7 +530,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- == DISTANCE MATRIX ELEMENT View-->
-	<xsd:element name="DistanceMatrixElementView" type="DistanceMatrixElement_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
+	<xsd:element name="DistanceMatrixElementView" type="DistanceMatrixElement_DerivedViewStructure" substitutionGroup="DerivedView">
 		<xsd:annotation>
 			<xsd:documentation>Simplified  view of CONNECTING JOURNEY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
@@ -237,7 +237,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="FarePrice_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="FarePrice_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for FARE PRICE.</xsd:documentation>
 		</xsd:annotation>
@@ -371,7 +371,7 @@ The RULE STEP RESULT  Adjustment Amount is  the difference beteen the original i
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:complexType name="PriceRuleStepResultStructure" abstract="false">
+	<xsd:complexType name="PriceRuleStepResultStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for FARE STEP RESULT.</xsd:documentation>
 		</xsd:annotation>
@@ -477,7 +477,7 @@ The RULE STEP RESULT  Adjustment Amount is  the difference beteen the original i
 </xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="PriceGroup" abstract="false" substitutionGroup="PriceGroup_">
+	<xsd:element name="PriceGroup" substitutionGroup="PriceGroup_">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of prices, allowing the grouping of numerous possible consumption elements into a limited number of price references, or to apply grouped increase, in value or percentage.
 </xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_fareProduct_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareProduct_support.xsd
@@ -620,7 +620,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a CHARGING MOMENT. +v1.1</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ChargingMomentRefStructure" abstract="false">
+	<xsd:complexType name="ChargingMomentRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a CHARGING MOMENT. +v1.1</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
@@ -119,13 +119,13 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====FARE PRODUCT=================================================== -->
-	<xsd:element name="ServiceAccessRight_" type="DataManagedObjectStructure" abstract="false" substitutionGroup="PriceableObject_">
+	<xsd:element name="ServiceAccessRight_" type="DataManagedObjectStructure" substitutionGroup="PriceableObject_">
 		<xsd:annotation>
 			<xsd:documentation>An immaterial marketable element 
 </xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ServiceAccessRight" abstract="false" substitutionGroup="ServiceAccessRight_">
+	<xsd:element name="ServiceAccessRight" substitutionGroup="ServiceAccessRight_">
 		<xsd:annotation>
 			<xsd:documentation>An immaterial marketable element dedicated to accessing some services.
 </xsd:documentation>
@@ -342,7 +342,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfFareProduct" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfFareProduct" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of FARE PRODUCTs expressing their general functionalities and local functional characteristics specific to the operator. Types of FARE PRODUCTs like e.g. throw-away ticket, throw-away ticket unit, value card, electronic purse allowing access, public transport credit card etc. may be used to define these categories.
 </xsd:documentation>
@@ -384,7 +384,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== SALES DISCOUNT RIGHT.=============================================== -->
-	<xsd:element name="SaleDiscountRight" abstract="false" substitutionGroup="FareProduct_">
+	<xsd:element name="SaleDiscountRight" substitutionGroup="FareProduct_">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT allowing a customer to benefit from discounts when purchasing SALES OFFER PACKAGEs.
 </xsd:documentation>
@@ -456,7 +456,7 @@ Rail transport, Roads and Road transport
 		</xsd:choice>
 	</xsd:group>
 	<!-- ==== ENTITLEMENT PRODUCT.=============================================== -->
-	<xsd:element name="EntitlementProduct" abstract="false" substitutionGroup="ServiceAccessRight_">
+	<xsd:element name="EntitlementProduct" substitutionGroup="ServiceAccessRight_">
 		<xsd:annotation>
 			<xsd:documentation>A precondition to access a service or to purchase a FARE PRODUCT issued by an organisation that may not be a PT operator (e.g. military card). 
 
@@ -513,7 +513,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== THIRD PARTY PRODUCT.=============================================== -->
-	<xsd:element name="ThirdPartyProduct" abstract="false" substitutionGroup="FareProduct_">
+	<xsd:element name="ThirdPartyProduct" substitutionGroup="FareProduct_">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT that is marketed together with a Public Transport Fare Product.</xsd:documentation>
 		</xsd:annotation>
@@ -566,7 +566,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== USAGE DISCOUNT RIGHT.=============================================== -->
-	<xsd:element name="UsageDiscountRight" abstract="false" substitutionGroup="FareProduct_">
+	<xsd:element name="UsageDiscountRight" substitutionGroup="FareProduct_">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT allowing a customer to benefit from discounts when consuming VALIDABLE ELEMENTs.
 </xsd:documentation>
@@ -612,7 +612,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== CAPPED DISCOUNT RIGHT.=============================================== -->
-	<xsd:element name="CappedDiscountRight" abstract="false" substitutionGroup="FareProduct_">
+	<xsd:element name="CappedDiscountRight" substitutionGroup="FareProduct_">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT allowing a customer to benefit from discounts when consuming VALIDABLE ELEMENTs.
 </xsd:documentation>
@@ -685,7 +685,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CappingRule" abstract="false" substitutionGroup="PriceableObject_">
+	<xsd:element name="CappingRule" substitutionGroup="PriceableObject_">
 		<xsd:annotation>
 			<xsd:documentation>Rule about capping for a mode.</xsd:documentation>
 		</xsd:annotation>
@@ -809,7 +809,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="AmountOfPriceUnitProduct" abstract="false" substitutionGroup="FareProduct_">
+	<xsd:element name="AmountOfPriceUnitProduct" substitutionGroup="FareProduct_">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT consisting in a stored value of PRICE UNITs: an amount of money on an electronic purse, amount of units on a value card etc.
 
@@ -874,7 +874,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== PREASSIGNED FARE PRODUC=============================================== -->
-	<xsd:element name="PreassignedFareProduct" abstract="false" substitutionGroup="FareProduct_">
+	<xsd:element name="PreassignedFareProduct" substitutionGroup="FareProduct_">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT consisting of one or several VALIDABLE ELEMENTs, specific to a CHARGING MOMENT.
 </xsd:documentation>
@@ -932,7 +932,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== PREASSIGNED FARE PRODUC=============================================== -->
-	<xsd:element name="SupplementProduct" abstract="false" substitutionGroup="FareProduct_">
+	<xsd:element name="SupplementProduct" substitutionGroup="FareProduct_">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT consisting of one or several VALIDABLE ELEMENTs, specific to a CHARGING MOMENT.
 </xsd:documentation>
@@ -1021,7 +1021,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="AccessRightInProduct" type="AccessRightInProduct_VersionedChildStructure" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="AccessRightInProduct" type="AccessRightInProduct_VersionedChildStructure" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>A VALIDABLE ELEMENT as a part of a PRE-ASSIGNED FARE PRODUCT, including its possible order in the set of all VALIDABLE ELEMENTs grouped together to define the access right assigned to that PRE-ASSIGNED FARE PRODUCT.
 </xsd:documentation>
@@ -1049,7 +1049,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="ChargingMoment" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="ChargingMoment" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>A classification of FARE PRODUCTs according to the payment method and the account location: pre-payment with cancellation (throw-away), pre-payment with debit on a value card, pre-payment without consumption registration (pass), post-payment etc.
 </xsd:documentation>
@@ -1077,7 +1077,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ChargingMoment_ValueStructure" abstract="false">
+	<xsd:complexType name="ChargingMoment_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a CHARGING MOMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -1100,7 +1100,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareProductPrice" abstract="false" substitutionGroup="FarePrice_">
+	<xsd:element name="FareProductPrice" substitutionGroup="FarePrice_">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a FARE PRODUCT default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>
@@ -1162,7 +1162,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CappingRulePrice" abstract="false" substitutionGroup="FarePrice_">
+	<xsd:element name="CappingRulePrice" substitutionGroup="FarePrice_">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a CAPPING RULE default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
@@ -119,7 +119,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====FARE PRODUCT=================================================== -->
-	<xsd:element name="ServiceAccessRight_" type="DataManagedObjectStructure" substitutionGroup="PriceableObject_">
+	<xsd:element name="ServiceAccessRight_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="PriceableObject_">
 		<xsd:annotation>
 			<xsd:documentation>An immaterial marketable element 
 </xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_fareSeries_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareSeries_version.xsd
@@ -105,7 +105,7 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SeriesConstraint" abstract="false" substitutionGroup="PriceableObject_">
+	<xsd:element name="SeriesConstraint" substitutionGroup="PriceableObject_">
 		<xsd:annotation>
 			<xsd:documentation>A particular tariff, described by a combination of parameters.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_fareStructureElement_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareStructureElement_support.xsd
@@ -182,7 +182,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a TYPE OF TARIFF. (TAP TSI)</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfTariffRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfTariffRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF TARIFF.</xsd:documentation>
 		</xsd:annotation>
@@ -284,7 +284,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a TYPE OF FARE STRUCTURE ELEMENT.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfFareStructureElementRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfFareStructureElementRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF TARIFF.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_fareStructureElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareStructureElement_version.xsd
@@ -123,7 +123,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====FARE STRUCTURE=================================================== -->
-	<xsd:element name="Tariff" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="Tariff" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A particular tariff, described by a combination of parameters.</xsd:documentation>
 		</xsd:annotation>
@@ -353,7 +353,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==TYPE OF TARIFF======================================================= -->
-	<xsd:element name="TypeOfTariff" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfTariff" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of TARIFFs according to their functional purpose.</xsd:documentation>
 		</xsd:annotation>
@@ -381,7 +381,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfTariff_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfTariff_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF TARIFF.</xsd:documentation>
 		</xsd:annotation>
@@ -407,7 +407,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareStructureElement" abstract="false" substitutionGroup="PriceableObject">
+	<xsd:element name="FareStructureElement" substitutionGroup="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>A sequence or set of CONTROLLABLE ELEMENTs to which rules for limitation of access rights and calculation of prices (fare structure) are applied.</xsd:documentation>
 		</xsd:annotation>
@@ -552,7 +552,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareStructureElementInSequence" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="FareStructureElementInSequence" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>A FARE STRUCTURE ELEMENT as a part of a VALIDABLE ELEMENT, including its possible order in the sequence of FARE STRUCTURE ELEMENTs forming that VALIDABLE ELEMENT, and its possible quantitative limitation.</xsd:documentation>
 		</xsd:annotation>
@@ -660,7 +660,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====TYPE OF FARE STRUCTURE ELEMENT======================================= -->
-	<xsd:element name="TypeOfFareStructureElement" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfFareStructureElement" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of FARE STRUCTURE ELEMENTs expressing their general functionalities .
 </xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_fareStructure_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareStructure_support.xsd
@@ -194,7 +194,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a TYPE OF FARE STRUCTURE FACTOR.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfFareStructureFactorRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfFareStructureFactorRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF TARIFF.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_fareStructure_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareStructure_version.xsd
@@ -65,7 +65,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: FARE STRUCTURE Common  types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- === FARE ELEMENT IN SEQUENCE.=================================== -->
-	<xsd:element name="FareElementInSequence" abstract="false" substitutionGroup="VersionedChild" id="FareElementInSequence">
+	<xsd:element name="FareElementInSequence" substitutionGroup="VersionedChild" id="FareElementInSequence">
 		<xsd:annotation>
 			<xsd:documentation>A FARE STRUCTURE ELEMENT as a part of a VALIDABLE ELEMENT, including its possible order in the sequence of FARE STRUCTURE ELEMENTs forming that VALIDABLE ELEMENT, and its possible quantitative limitation.</xsd:documentation>
 		</xsd:annotation>
@@ -170,7 +170,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareStructureFactor" abstract="false" substitutionGroup="PriceableObject">
+	<xsd:element name="FareStructureFactor" substitutionGroup="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>A factor influencing access rights definition or calculation of prices.</xsd:documentation>
 		</xsd:annotation>
@@ -235,7 +235,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====TYPE OF FARE STRUCTURE FACTOR======================================= -->
-	<xsd:element name="TypeOfFareStructureFactor" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfFareStructureFactor" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of FARE STRUCTURE FACTORs expressing their general functionalities .
 </xsd:documentation>
@@ -277,7 +277,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ====FARE INTERVAL ============================================ -->
-	<xsd:element name="FareInterval" abstract="false" substitutionGroup="PriceableObject">
+	<xsd:element name="FareInterval" substitutionGroup="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>A factor influencing access rights definition or calculation of prices.</xsd:documentation>
 		</xsd:annotation>
@@ -315,7 +315,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====FARE UNIT ============================================ -->
-	<xsd:element name="FareUnit" abstract="false" substitutionGroup="PriceableObject">
+	<xsd:element name="FareUnit" substitutionGroup="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>A factor influencing access rights definition or calculation of prices.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
@@ -492,7 +492,7 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="CellHeadingsGroup"/>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="Cell" abstract="false" substitutionGroup="Cell_">
+	<xsd:element name="Cell" substitutionGroup="Cell_">
 		<xsd:annotation>
 			<xsd:documentation>An individual combination of  features in a FARE TABLE, used to associate a FARE PRICE.</xsd:documentation>
 		</xsd:annotation>
@@ -512,7 +512,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Cell_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="Cell_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a CELL.</xsd:documentation>
 		</xsd:annotation>
@@ -947,7 +947,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- === TYPE OF FARE TABLE======================================= -->
-	<xsd:element name="TypeOfFareTable" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfFareTable" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Category of FARE TABLE.
 </xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_geographicStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_geographicStructureFactor_version.xsd
@@ -107,7 +107,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GeographicalUnit" abstract="false" substitutionGroup="PriceableObject">
+	<xsd:element name="GeographicalUnit" substitutionGroup="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>A factor influencing access rights definition or calculation of prices.</xsd:documentation>
 		</xsd:annotation>
@@ -189,7 +189,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GeographicalInterval" abstract="false" substitutionGroup="PriceableObject_">
+	<xsd:element name="GeographicalInterval" substitutionGroup="PriceableObject_">
 		<xsd:annotation>
 			<xsd:documentation>A factor influencing access rights definition or calculation of prices.</xsd:documentation>
 		</xsd:annotation>
@@ -275,7 +275,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GeographicalStructureFactor" abstract="false" substitutionGroup="PriceableObject">
+	<xsd:element name="GeographicalStructureFactor" substitutionGroup="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>The value of a GEOGRAPHICAL INTERVAL or a DISTANCE MATRIX ELEMENT expressed by a GEOGRAPHICAL UNIT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_qualityStructureFactor_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_qualityStructureFactor_support.xsd
@@ -173,7 +173,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a QUALITY STRUCTURE FACTOR PRICE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="QualityStructureFactorPriceRefStructure" abstract="false">
+	<xsd:complexType name="QualityStructureFactorPriceRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Reference to a QUALITY STRUCTURE FACTOR PRICE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_qualityStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_qualityStructureFactor_version.xsd
@@ -101,7 +101,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy type.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="QualityStructureFactor" abstract="false" substitutionGroup="QualityStructureFactor_">
+	<xsd:element name="QualityStructureFactor" substitutionGroup="QualityStructureFactor_">
 		<xsd:annotation>
 			<xsd:documentation>The value of a QUALITY INTERVAL or a DISTANCE MATRIX ELEMENT expressed by a QUALITY UNIT.</xsd:documentation>
 		</xsd:annotation>
@@ -248,7 +248,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareDemandFactor" abstract="false" substitutionGroup="QualityStructureFactor_">
+	<xsd:element name="FareDemandFactor" substitutionGroup="QualityStructureFactor_">
 		<xsd:annotation>
 			<xsd:documentation>The value of a QUALITY INTERVAL or a DISTANCE MATRIX ELEMENT expressed by a QUALITY UNIT.</xsd:documentation>
 		</xsd:annotation>
@@ -339,7 +339,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareQuotaFactor" abstract="false" substitutionGroup="QualityStructureFactor_">
+	<xsd:element name="FareQuotaFactor" substitutionGroup="QualityStructureFactor_">
 		<xsd:annotation>
 			<xsd:documentation>A named set of parameters defining the number of quota fares available. of a given denomination.</xsd:documentation>
 		</xsd:annotation>
@@ -419,7 +419,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="StartTimeAtStopPoint" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="StartTimeAtStopPoint" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>A time at which a Fare demand  time band ( peak, off peak, etc  ) is deemed to begin  or end for trips at a particular SCHEDULED STOP POINT.
 </xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_salesDistribution_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesDistribution_version.xsd
@@ -125,7 +125,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====DISTRIBUTION CHANNEL=================================================== -->
-	<xsd:element name="DistributionChannel" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="DistributionChannel" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A type of outlet for selling a product.
 </xsd:documentation>
@@ -240,7 +240,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====GROUP OF DISTRIBUTION CHANNELs=================================================== -->
-	<xsd:element name="GroupOfDistributionChannels" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfDistributionChannels" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A package to be sold as a whole, consisting of one or several FARE PRODUCTs materialised thanks to one or several TRAVEL DOCUMENTs. The FARE PRODUCTs may be either directly attached to the TRAVEL DOCUMENTs, or may be reloadable on the TRAVEL DOCUMENTs.
 </xsd:documentation>
@@ -310,7 +310,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FulfilmentMethod" abstract="false" substitutionGroup="PriceableObject_">
+	<xsd:element name="FulfilmentMethod" substitutionGroup="PriceableObject_">
 		<xsd:annotation>
 			<xsd:documentation>The means by which the ticket is delivered to the Customer. e.g. online, collection, etc.
 </xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackageEntitlement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackageEntitlement_version.xsd
@@ -61,7 +61,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: SALES OFFER ENTITLEMENT  USAGE PARAMETER  types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====SALES OFFER PACKAGE ENTITLEMENT GIVEN================================================= -->
-	<xsd:element name="SalesOfferPackageEntitlementGiven" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="SalesOfferPackageEntitlementGiven" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>A right to a SALES OFFER PACKAGE    given by a SALES OFFER PACKAGE .</xsd:documentation>
 		</xsd:annotation>
@@ -117,7 +117,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====SALES OFFER PACKAGE ENTITLEMENT REQUIRED================================================= -->
-	<xsd:element name="SalesOfferPackageEntitlementRequired" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="SalesOfferPackageEntitlementRequired" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>A rerirement to a SALES OFFER PACKAGE  in order to purchase or use PRODUCT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
@@ -168,7 +168,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====SALES OFFER PACKAGE=================================================== -->
-	<xsd:element name="SalesOfferPackage" abstract="false" substitutionGroup="PriceableObject_">
+	<xsd:element name="SalesOfferPackage" substitutionGroup="PriceableObject_">
 		<xsd:annotation>
 			<xsd:documentation>A package to be sold as a whole, consisting of one or several FARE PRODUCTs materialised thanks to one or several TRAVEL DOCUMENTs. The FARE PRODUCTs may be either directly attached to the TRAVEL DOCUMENTs, or may be reloadable on the TRAVEL DOCUMENTs.
 </xsd:documentation>
@@ -286,7 +286,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SalesOfferPackageElement" abstract="false" substitutionGroup="PriceableObject">
+	<xsd:element name="SalesOfferPackageElement" substitutionGroup="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a FARE PRODUCT to a TYPE OF TRAVEL DOCUMENT in order to define a SALES OFFER PACKAGE, realised as a fixed assignment (printing, magnetic storage etc.) or by the possibility for the FARE PRODUCT to be reloaded on the TYPE OF TRAVEL DOCUMENT.
 </xsd:documentation>
@@ -436,7 +436,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SalesOfferPackageSubstitution" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="SalesOfferPackageSubstitution" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>A particular tariff, described by a combination of parameters.
 </xsd:documentation>
@@ -491,7 +491,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====GROUP OF SALES OFFER PACKAGEs=================================================== -->
-	<xsd:element name="GroupOfSalesOfferPackages" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="GroupOfSalesOfferPackages" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A package to be sold as a whole, consisting of one or several FARE PRODUCTs materialised thanks to one or several TRAVEL DOCUMENTs. The FARE PRODUCTs may be either directly attached to the TRAVEL DOCUMENTs, or may be reloadable on the TRAVEL DOCUMENTs.
 </xsd:documentation>
@@ -556,7 +556,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====SALES NOTICE ASSIGNMENT ================================================= -->
-	<xsd:element name="SalesNoticeAssignment" abstract="false" substitutionGroup="NoticeAssignment_">
+	<xsd:element name="SalesNoticeAssignment" substitutionGroup="NoticeAssignment_">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a NOTICE to a SALES OFFER PACKAGE or a GROUP OF SALES OFFER PACKAGEs.
 </xsd:documentation>
@@ -624,7 +624,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DistributionAssignment" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="DistributionAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>An assignment  of the  COUNTRY and/or  DISTRIBUTION CHANNEL through which a product may or may not be distributed.
 
@@ -799,7 +799,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfSalesOfferPackage" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfSalesOfferPackage" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of SALES OFFER PACKAGEs expressing their general functionalities and local functional characteristics specific to the operator. Types of SALES OFFER PACKAGEs like e.g. throw-away ticket, throw-away ticket unit, value card, electronic purse allowing access, public transport credit card etc. may be used to define these categories.
 </xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_timeStructureFactor_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_timeStructureFactor_support.xsd
@@ -160,7 +160,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a TIME UNIT PRICE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TimeUnitPriceRefStructure" abstract="false">
+	<xsd:complexType name="TimeUnitPriceRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Reference to a TIME UNIT PRICE.</xsd:documentation>
 		</xsd:annotation>
@@ -186,7 +186,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a TIME INTERVAL PRICE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TimeIntervalPriceRefStructure" abstract="false">
+	<xsd:complexType name="TimeIntervalPriceRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for Reference to a TIME INTERVAL PRICE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_timeStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_timeStructureFactor_version.xsd
@@ -105,7 +105,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TimeUnit" abstract="false" substitutionGroup="PriceableObject">
+	<xsd:element name="TimeUnit" substitutionGroup="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>A factor influencing access rights definition or calculation of prices.</xsd:documentation>
 		</xsd:annotation>
@@ -192,7 +192,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TimeInterval" abstract="false" substitutionGroup="PriceableObject_">
+	<xsd:element name="TimeInterval" substitutionGroup="PriceableObject_">
 		<xsd:annotation>
 			<xsd:documentation>A factor influencing access rights definition or calculation of prices.</xsd:documentation>
 		</xsd:annotation>
@@ -285,7 +285,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TimeStructureFactor" abstract="false" substitutionGroup="PriceableObject">
+	<xsd:element name="TimeStructureFactor" substitutionGroup="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>The value of a TIME INTERVAL or a DISTANCE MATRIX ELEMENT expressed by a TIME UNIT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_typeOfTravelDocument_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_typeOfTravelDocument_version.xsd
@@ -108,7 +108,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfTravelDocument" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfTravelDocument" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of TRAVEL DOCUMENTs expressing their general functionalities and local functional characteristics specific to the operator. Types of TRAVEL DOCUMENTs like e.g. throw-away ticket, throw-away ticket unit, value card, electronic purse allowing access, public transport credit card etc. may be used to define these categories.
 </xsd:documentation>
@@ -234,7 +234,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfMachineReadability" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfMachineReadability" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>A classification of MACHINE REDABILITY capabailities, used for example to indicate how a TRAVEL DOCUMENT may be read. 
 </xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
@@ -75,7 +75,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: After Sales USAGE PARAMETER  types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====RESELLING=================================================== -->
-	<xsd:element name="Reselling" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="Reselling" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Common resale conditions (i.e. for exchange or refund)  attaching to the product</xsd:documentation>
 		</xsd:annotation>
@@ -251,7 +251,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====EXCHANGING=================================================== -->
-	<xsd:element name="Exchanging" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="Exchanging" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer.</xsd:documentation>
 		</xsd:annotation>
@@ -323,7 +323,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== REFUNDING================================================= -->
-	<xsd:element name="Refunding" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="Refunding" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Whether and how the product may be refunded.</xsd:documentation>
 		</xsd:annotation>
@@ -396,7 +396,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ==== REPLACING ================================================== -->
-	<xsd:element name="Replacing" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="Replacing" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Whether the product can be replaced if lost or stolen.</xsd:documentation>
 		</xsd:annotation>
@@ -448,7 +448,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ====TRANSFERABILITY=================================================== -->
-	<xsd:element name="Transferability" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="Transferability" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterBooking_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterBooking_version.xsd
@@ -75,7 +75,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Booking USAGE PARAMETER  types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====  PURCHASE  WINDOW================================================ -->
-	<xsd:element name="PurchaseWindow" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="PurchaseWindow" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer.</xsd:documentation>
 		</xsd:annotation>
@@ -219,7 +219,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====RESERVING=================================================== -->
-	<xsd:element name="Reserving" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="Reserving" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer.</xsd:documentation>
 		</xsd:annotation>
@@ -346,7 +346,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====RESERVING=================================================== -->
-	<xsd:element name="Cancelling" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="Cancelling" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_version.xsd
@@ -67,7 +67,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Charging USAGE PARAMETER  types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ==== CHARGING POLICY USER PARAMETER ================================================ -->
-	<xsd:element name="ChargingPolicy" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="ChargingPolicy" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Policy regarding different aspects of charging such as credit limits.</xsd:documentation>
 		</xsd:annotation>
@@ -141,7 +141,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== PENALTY POLICY USER PARAMETER ================================================ -->
-	<xsd:element name="PenaltyPolicy" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="PenaltyPolicy" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Policy regarding different aspects of penalty charges, for example  repeated entry at the same station, no ticket etc.</xsd:documentation>
 		</xsd:annotation>
@@ -210,7 +210,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== SUBSCRIBING USER PARAMETER ================================================ -->
-	<xsd:element name="Subscribing" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="Subscribing" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Parameters relating to paying by Subscribing for a product. +v1.1</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_support.xsd
@@ -388,12 +388,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfProofRef" type="TypeOfProofRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="TypeOfProofRef" type="TypeOfProofRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF PROOF. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfProofRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfProofRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a TYPE OF PROOF.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
@@ -73,7 +73,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Eligibility USAGE PARAMETER   types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====USER PROFILE================================================= -->
-	<xsd:element name="UserProfile" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="UserProfile" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>The social profile of a passenger, based on age group, education, profession, social status, sex etc., often used for allowing discounts: 18-40 years old, graduates, drivers, unemployed, women etc.</xsd:documentation>
 		</xsd:annotation>
@@ -205,7 +205,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====COMMERCIAL PROFILE=================================================== -->
-	<xsd:element name="CommercialProfile" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="CommercialProfile" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>A category of users depending on their commercial relations with the operator (frequency of use, amount of purchase etc.), often used for allowing discounts.</xsd:documentation>
 		</xsd:annotation>
@@ -266,7 +266,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====GROUP TICKET=================================================== -->
-	<xsd:element name="GroupTicket" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="GroupTicket" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to travel including the holder of the access right.</xsd:documentation>
 		</xsd:annotation>
@@ -418,7 +418,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CompanionProfile" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="CompanionProfile" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics (weight, volume) of luggage that a holder of an access right is entitled to carry.</xsd:documentation>
 		</xsd:annotation>
@@ -510,7 +510,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ResidentialQualification" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="ResidentialQualification" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics (weight, volume) of luggage that a holder of an access right is entitled to carry.</xsd:documentation>
 		</xsd:annotation>
@@ -601,7 +601,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfConcession" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfConcession" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Category of concession user</xsd:documentation>
 		</xsd:annotation>
@@ -652,7 +652,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== TYPE OF PROOF REQUIRED ========================================================== -->
-	<xsd:element name="TypeOfProof" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfProof" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>TYPE of PROOF of identity required. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -679,7 +679,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfProof_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfProof_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF PROOF.</xsd:documentation>
 		</xsd:annotation>
@@ -690,7 +690,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<!-- ======================================================================= -->
 	<!-- ==== ELIGIBILITY CHANGE POLICY QUALIFICATION. ================================================== -->
-	<xsd:element name="EligibilityChangePolicy" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="EligibilityChangePolicy" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>The policy to apply  if ta user's eligibility as a USER PROFILE changes.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEntitlement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEntitlement_version.xsd
@@ -64,7 +64,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Entitlement USAGE PARAMETER  types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====ENTITLEMENT GIVEN================================================= -->
-	<xsd:element name="EntitlementGiven" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="EntitlementGiven" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>A right to a SERVICE ACCESS RIGHT is given by a FARE  PRODUCT.</xsd:documentation>
 		</xsd:annotation>
@@ -120,7 +120,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====ENTITLEMENT REQUIRED================================================= -->
-	<xsd:element name="EntitlementRequired" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="EntitlementRequired" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>A rerirement to a SERVICE ACCESS RIGHT in order to purchase or use PRODUCT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterLuggage_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterLuggage_version.xsd
@@ -61,7 +61,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Luggage USAGE PARAMETER  types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====LUGGAGE ALLOWANCE=================================================== -->
-	<xsd:element name="LuggageAllowance" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="LuggageAllowance" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics (weight, volume) of luggage that a holder of an access right is entitled to carry.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_version.xsd
@@ -78,7 +78,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Travel USAGE PARAMETER  types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ==== ROUND TRIP ================================================ -->
-	<xsd:element name="RoundTrip" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="RoundTrip" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Properties relating to single or return trip use of a fare.</xsd:documentation>
 		</xsd:annotation>
@@ -147,7 +147,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== ROUTING ================================================ -->
-	<xsd:element name="Routing" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="Routing" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Limitations on routing of a fare.</xsd:documentation>
 		</xsd:annotation>
@@ -216,7 +216,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== STEP LIMIT ================================================ -->
-	<xsd:element name="StepLimit" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="StepLimit" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Geographical parameter limiting the access rights by counts of stops, sections or zones.</xsd:documentation>
 		</xsd:annotation>
@@ -290,7 +290,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== FREQUENCY OF USE ================================================= -->
-	<xsd:element name="FrequencyOfUse" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="FrequencyOfUse" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>The limits of usage frequency for a FARE PRODUCT (or one of its components) or a SALES OFFER PACKAGE during a specific VALIDITY PERIOD. There may be different tariffs depending on how often the right is consumed during the period.</xsd:documentation>
 		</xsd:annotation>
@@ -365,7 +365,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====USAGE VALIDITY PERIOD.================================================ -->
-	<xsd:element name="UsageValidityPeriod" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="UsageValidityPeriod" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>A time limitation for validity of a FARE PRODUCT or a SALES OFFER PACKAGE. It may be composed of a standard duration (e.g. 3 days, 1 month) and/or fixed start/end dates and times.</xsd:documentation>
 		</xsd:annotation>
@@ -535,7 +535,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:complexType>
 	<!-- ====SUSPENDING.================================================ -->
-	<xsd:element name="Suspending" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="Suspending" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Conditions governing suspension of a FARE PRODUCT, e.g.  period pass or subscription.
 </xsd:documentation>
@@ -615,7 +615,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== INTERCHANGING ================================================ -->
-	<xsd:element name="Interchanging" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="Interchanging" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Limitations on making changes within a trip.</xsd:documentation>
 		</xsd:annotation>
@@ -704,7 +704,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== MINIMUM STAY ================================================ -->
-	<xsd:element name="MinimumStay" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="MinimumStay" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Details of any minimum stay at the destination  required  to use the product.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameter_version.xsd
@@ -222,7 +222,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfUsageParameter" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfUsageParameter" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Category of USAGE PARAMETER user
 </xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_validableElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_validableElement_version.xsd
@@ -103,7 +103,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ValidableElement" abstract="false" substitutionGroup="PriceableObject_">
+	<xsd:element name="ValidableElement" substitutionGroup="PriceableObject_">
 		<xsd:annotation>
 			<xsd:documentation>A sequence or set of FARE STRUCTURE ELEMENTs, grouped together to be validated in one go.</xsd:documentation>
 		</xsd:annotation>
@@ -218,7 +218,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ValidableElementPrice" abstract="false" substitutionGroup="FarePrice_">
+	<xsd:element name="ValidableElementPrice" substitutionGroup="FarePrice_">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a VALIDABLE ELEMENT ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>
@@ -291,7 +291,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ControllableElement" abstract="false" substitutionGroup="PriceableObject_">
+	<xsd:element name="ControllableElement" substitutionGroup="PriceableObject_">
 		<xsd:annotation>
 			<xsd:documentation>The smallest controllable element of public transport consumption, all along which any VALIDITY PARAMETER ASSIGNMENT remains valid.</xsd:documentation>
 		</xsd:annotation>
@@ -365,7 +365,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ControllableElementInSequence" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="ControllableElementInSequence" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>A CONTROLLABLE ELEMENT as a part of a FARE STRUCTURE ELEMENT, including its possible order in the sequence of CONTROLLABLE ELEMENTs grouped together to form that FARE STRUCTURE ELEMENT, and its possible quantitative limitation.</xsd:documentation>
 		</xsd:annotation>
@@ -436,7 +436,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ControllableElementPrice" abstract="false" substitutionGroup="FarePrice_">
+	<xsd:element name="ControllableElementPrice" substitutionGroup="FarePrice_">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a CONTROLLABLE ELEMENT ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_frames/netex_fareFrame_version.xsd
+++ b/xsd/netex_part_3/part3_frames/netex_fareFrame_version.xsd
@@ -71,7 +71,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="FareFrameRef" type="FareFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="FareFrameRef" type="FareFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a FARE FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -201,7 +201,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="FarePriceFrameRef" type="FarePriceFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="FarePriceFrameRef" type="FarePriceFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a FARE PRICE FRAME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_frames/netex_salesTransactionFrame_version.xsd
+++ b/xsd/netex_part_3/part3_frames/netex_salesTransactionFrame_version.xsd
@@ -78,7 +78,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="SalesTransactionFrameRef" type="SalesTransactionFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="SalesTransactionFrameRef" type="SalesTransactionFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a SALES TRANSACTION FRAME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_monitoring/netex_monitoredCall_version.xsd
+++ b/xsd/netex_part_3/part3_monitoring/netex_monitoredCall_version.xsd
@@ -62,7 +62,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEx: MONITORED CALL   types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====MonitoredCall=========================================-->
-	<xsd:complexType name="monitoredCalls_RelStructure" abstract="false">
+	<xsd:complexType name="monitoredCalls_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for List of MONITORED CALLs.</xsd:documentation>
 		</xsd:annotation>
@@ -141,7 +141,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====onwards=========================================-->
-	<xsd:complexType name="onwardCalls_RelStructure" abstract="false">
+	<xsd:complexType name="onwardCalls_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for List of ONWARD CALLs.</xsd:documentation>
 		</xsd:annotation>
@@ -210,7 +210,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====previous=========================================-->
-	<xsd:complexType name="previousCalls_RelStructure" abstract="false">
+	<xsd:complexType name="previousCalls_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for List of PREVIOUS CALLs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_monitoring/netex_monitoredPassingTimes_version.xsd
+++ b/xsd/netex_part_3/part3_monitoring/netex_monitoredPassingTimes_version.xsd
@@ -75,7 +75,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ObservedPassingTime" abstract="false" substitutionGroup="DatedPassingTime">
+	<xsd:element name="ObservedPassingTime" substitutionGroup="DatedPassingTime">
 		<xsd:annotation>
 			<xsd:documentation>OBSERVED PASSING TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -189,7 +189,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="EstimatedPassingTime" abstract="false" substitutionGroup="DatedPassingTime">
+	<xsd:element name="EstimatedPassingTime" substitutionGroup="DatedPassingTime">
 		<xsd:annotation>
 			<xsd:documentation>Estimated PASSING TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -291,7 +291,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===Observed================================================= -->
-	<xsd:element name="ObservedPassingTimeView" type="ObservedPassingTime_ViewStructure" abstract="false">
+	<xsd:element name="ObservedPassingTimeView" type="ObservedPassingTime_ViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Simplified OBSERVED PASSING TIME.</xsd:documentation>
 		</xsd:annotation>
@@ -308,7 +308,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="EstimatedPassingTimeView" type="EstimatedPassingTime_ViewStructure" abstract="false">
+	<xsd:element name="EstimatedPassingTimeView" type="EstimatedPassingTime_ViewStructure">
 		<xsd:annotation>
 			<xsd:documentation>Simplified ESTIMATED PASSING TIME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerEligibility_version.xsd
@@ -103,7 +103,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== USER PROFILE ELIGIBILITY ======================================== -->
-	<xsd:element name="UserProfileEligibility" abstract="false" substitutionGroup="CustomerEligibility_">
+	<xsd:element name="UserProfileEligibility" substitutionGroup="CustomerEligibility_">
 		<xsd:annotation>
 			<xsd:documentation>Whether a specific TRANSPORT CUSTOMER is eligible for a FARE PRODUCT with a specific USER PROFILE as a validity parameter.</xsd:documentation>
 		</xsd:annotation>
@@ -154,7 +154,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== COMMERCIAL PROFILE ELIGIBILITY ======================================== -->
-	<xsd:element name="CommercialProfileEligibility" abstract="false" substitutionGroup="CustomerEligibility_">
+	<xsd:element name="CommercialProfileEligibility" substitutionGroup="CustomerEligibility_">
 		<xsd:annotation>
 			<xsd:documentation>Whether a specific TRANSPORT CUSTOMER is eligible for a FARE PRODUCT with a specific COMMERCIAL PROFILE as a validity parameter.</xsd:documentation>
 		</xsd:annotation>
@@ -205,7 +205,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== RESIDENTIAL QUALIFICATION ELIGIBILITY ======================================== -->
-	<xsd:element name="ResidentialQualificationEligibility" abstract="false" substitutionGroup="CustomerEligibility_">
+	<xsd:element name="ResidentialQualificationEligibility" substitutionGroup="CustomerEligibility_">
 		<xsd:annotation>
 			<xsd:documentation>Whether a specific TRANSPORT CUSTOMER is eligible for a FARE PRODUCT with a specific RESIDENTIAL QUALIFICATION as a validity parameter.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPaymentMeans_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPaymentMeans_version.xsd
@@ -78,7 +78,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerPaymentMeans" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="CustomerPaymentMeans" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>A registered means with which a TRANSPORT CUSTOMER wishes to make payments for a CUSTOMER ACCOUNT, e.g. by nominated EMV card. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -105,7 +105,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CustomerPaymentMeans_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="CustomerPaymentMeans_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for CUSTOMER PAYMENT MEANS restricts id.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
@@ -85,7 +85,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="FareContractEntryIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TravelSpecificationRef" type="TravelSpecificationRefStructure" abstract="false" substitutionGroup="FareContractEntryRef">
+	<xsd:element name="TravelSpecificationRef" type="TravelSpecificationRefStructure" substitutionGroup="FareContractEntryRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TRAVEL SPECIFICATION.</xsd:documentation>
 		</xsd:annotation>
@@ -111,7 +111,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TravelSpecificationIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="RequestedTravelSpecificationRef" type="RequestedTravelSpecificationRefStructure" abstract="false" substitutionGroup="TravelSpecificationRef">
+	<xsd:element name="RequestedTravelSpecificationRef" type="RequestedTravelSpecificationRefStructure" substitutionGroup="TravelSpecificationRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a REQUESTED TRAVEL SPECIFICATION.</xsd:documentation>
 		</xsd:annotation>
@@ -137,7 +137,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TravelSpecificationIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="OfferedTravelSpecificationRef" type="OfferedTravelSpecificationRefStructure" abstract="false" substitutionGroup="TravelSpecificationRef">
+	<xsd:element name="OfferedTravelSpecificationRef" type="OfferedTravelSpecificationRefStructure" substitutionGroup="TravelSpecificationRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an OFFERED TRAVEL SPECIFICATION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -167,7 +167,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TravelSpecification_" type="DataManagedObjectStructure" substitutionGroup="FareContractEntry_">
+	<xsd:element name="TravelSpecification_" abstract="true" type="DataManagedObjectStructure" substitutionGroup="FareContractEntry_">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type for FARE CONTRACT ENTRY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -172,7 +172,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy type for FARE CONTRACT ENTRY.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="TravelSpecification" abstract="false" substitutionGroup="TravelSpecification_">
+	<xsd:element name="TravelSpecification" substitutionGroup="TravelSpecification_">
 		<xsd:annotation>
 			<xsd:documentation>The recording of a specification by a customer of parameters giving details of an intended consumption (e.g. origin and destination of a travel).</xsd:documentation>
 		</xsd:annotation>
@@ -265,7 +265,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====  REQUESTED TRAVEL SPECIFICATION  ================================================ -->
-	<xsd:element name="RequestedTravelSpecification" abstract="false" substitutionGroup="TravelSpecification_">
+	<xsd:element name="RequestedTravelSpecification" substitutionGroup="TravelSpecification_">
 		<xsd:annotation>
 			<xsd:documentation>The recording of a specification by a customer of parameters giving details of an intended consumption (e.g. origin and destination of a travel).</xsd:documentation>
 		</xsd:annotation>
@@ -329,7 +329,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="OfferedTravelSpecification" abstract="false" substitutionGroup="TravelSpecification_">
+	<xsd:element name="OfferedTravelSpecification" substitutionGroup="TravelSpecification_">
 		<xsd:annotation>
 			<xsd:documentation>A set of parameters giving details of the intended  consumption of access rights associated with an offer or a purchase. (e.g. origin and destination of a travel, class of travel, etc.).
 .</xsd:documentation>
@@ -393,7 +393,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SpecificParameterAssignment" abstract="false" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="SpecificParameterAssignment" substitutionGroup="AccessRightParameterAssignment_">
 		<xsd:annotation>
 			<xsd:documentation>A VALIDITY PARAMETER ASSIGNMENT specifying practical parameters during a TRAVEL SPECIFICATION, within a given fare structure (e.g. the origin or destination zone in a zone-counting system).</xsd:documentation>
 		</xsd:annotation>
@@ -494,7 +494,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerPurchasePackage" abstract="false" substitutionGroup="PriceableObject_">
+	<xsd:element name="CustomerPurchasePackage" substitutionGroup="PriceableObject_">
 		<xsd:annotation>
 			<xsd:documentation>A purchase of a SALES OFFER PACKAGE by a CUSTOMER, giving access rights to one or several FARE PRODUCTs materialised as one or several TRAVEL DOCUMENTs.</xsd:documentation>
 		</xsd:annotation>
@@ -668,7 +668,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerPurchasePackageElement" abstract="false" substitutionGroup="PriceableObject">
+	<xsd:element name="CustomerPurchasePackageElement" substitutionGroup="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a  SALES OFFER PACKAGE ELEMENT, for use in a CUSTOMER SALES PACKAGE.</xsd:documentation>
 		</xsd:annotation>
@@ -762,7 +762,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerPurchasePackageElementAccess" abstract="false">
+	<xsd:element name="CustomerPurchasePackageElementAccess">
 		<xsd:annotation>
 			<xsd:documentation>Access to a VALIDABLE ELEMENT by a specific CUSTOMER PURCHASE PACKAGE  through use of CUSTOMER PURCHASE PACKAGE. This is needed for validation of complex SALES OFFER PACKAGEs containing tariffs structures that have FARE STRUCTURE ELEMENTs IN SEQUENCE, in such a case a given SALES PACKAGE ELEMENT may have multiple VALIDABLE ELEMENTs associated with it, each of which can be separately validated and marked. +v1.1
 </xsd:documentation>
@@ -914,7 +914,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerPurchaseParameterAssignment" abstract="false" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="CustomerPurchaseParameterAssignment" substitutionGroup="AccessRightParameterAssignment_">
 		<xsd:annotation>
 			<xsd:documentation>A VALIDITY PARAMETER ASSIGNMENT specifying practical parameters for use in a  CUSTOMER PURCHASE PACKAGE.</xsd:documentation>
 		</xsd:annotation>
@@ -948,7 +948,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CustomerPurchaseParameterAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="CustomerPurchaseParameterAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for CustomerPurchase PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_fareDebit_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_fareDebit_support.xsd
@@ -77,7 +77,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="LogEntryIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="FareDebitRef" type="FareDebitRefStructure" abstract="false" substitutionGroup="LogEntryRef">
+	<xsd:element name="FareDebitRef" type="FareDebitRefStructure" substitutionGroup="LogEntryRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a FARE DEBIT.</xsd:documentation>
 		</xsd:annotation>
@@ -103,7 +103,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="FareDebitIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="OtherDebitRef" type="OtherDebitRefStructure" abstract="false" substitutionGroup="FareDebitRef">
+	<xsd:element name="OtherDebitRef" type="OtherDebitRefStructure" substitutionGroup="FareDebitRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an OTHER DEBIT.</xsd:documentation>
 		</xsd:annotation>
@@ -129,7 +129,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="FareDebitIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="BookingDebitRef" type="BookingDebitRefStructure" abstract="false" substitutionGroup="FareDebitRef">
+	<xsd:element name="BookingDebitRef" type="BookingDebitRefStructure" substitutionGroup="FareDebitRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a BOOKING DEBIT.</xsd:documentation>
 		</xsd:annotation>
@@ -155,7 +155,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="FareDebitIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TripDebitRef" type="TripDebitRefStructure" abstract="false" substitutionGroup="FareDebitRef">
+	<xsd:element name="TripDebitRef" type="TripDebitRefStructure" substitutionGroup="FareDebitRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TRIP DEBIT.</xsd:documentation>
 		</xsd:annotation>
@@ -181,7 +181,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="FareDebitIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="FareProductSaleDebitRef" type="FareProductSaleDebitRefStructure" abstract="false" substitutionGroup="FareDebitRef">
+	<xsd:element name="FareProductSaleDebitRef" type="FareProductSaleDebitRefStructure" substitutionGroup="FareDebitRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a FARE PRODUCT SALES DEBIT.</xsd:documentation>
 		</xsd:annotation>
@@ -207,7 +207,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="FareDebitIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="OffenceDebitRef" type="OffenceDebitRefStructure" abstract="false" substitutionGroup="FareDebitRef">
+	<xsd:element name="OffenceDebitRef" type="OffenceDebitRefStructure" substitutionGroup="FareDebitRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a OFFENCE DEBIT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_fareDebit_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_fareDebit_version.xsd
@@ -138,7 +138,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== BOOKING DEBIT ================================================ -->
-	<xsd:element name="BookingDebit" abstract="false" substitutionGroup="FareDebit_DummyType">
+	<xsd:element name="BookingDebit" substitutionGroup="FareDebit_DummyType">
 		<xsd:annotation>
 			<xsd:documentation>A LOG ENTRY recording data about a debiting action for a booking fee.</xsd:documentation>
 		</xsd:annotation>
@@ -180,7 +180,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== TRIP  DEBIT ================================================ -->
-	<xsd:element name="TripDebit" abstract="false" substitutionGroup="FareDebit_DummyType">
+	<xsd:element name="TripDebit" substitutionGroup="FareDebit_DummyType">
 		<xsd:annotation>
 			<xsd:documentation>A LOG ENTRY recording data about a debiting action for post-payment for a specific trip.</xsd:documentation>
 		</xsd:annotation>
@@ -222,7 +222,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== OTHER   DEBIT ================================================ -->
-	<xsd:element name="OtherDebit" abstract="false" substitutionGroup="FareDebit_DummyType">
+	<xsd:element name="OtherDebit" substitutionGroup="FareDebit_DummyType">
 		<xsd:annotation>
 			<xsd:documentation>A LOG ENTRY recording data about a debiting action for a payment type other than a FARE PRODUCT SALE DEBIT, TRIP DEBIT, OFFENCE DEBIT or BOOKING DEBIT.</xsd:documentation>
 		</xsd:annotation>
@@ -264,7 +264,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== FARE PRODUCT SALES DEBIT ================================================ -->
-	<xsd:element name="FareProductSaleDebit" abstract="false" substitutionGroup="FareDebit_DummyType">
+	<xsd:element name="FareProductSaleDebit" substitutionGroup="FareDebit_DummyType">
 		<xsd:annotation>
 			<xsd:documentation>A LOG ENTRY recording data about a debiting action made to purchase a FARE PRODUCT.</xsd:documentation>
 		</xsd:annotation>
@@ -306,7 +306,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== OFFENCE  DEBIT ================================================ -->
-	<xsd:element name="OffenceDebit" abstract="false" substitutionGroup="FareDebit_DummyType">
+	<xsd:element name="OffenceDebit" substitutionGroup="FareDebit_DummyType">
 		<xsd:annotation>
 			<xsd:documentation>A LOG ENTRY recording data about a debiting action for a fine for an OFFENCE or penalty fare.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_mediumApplication_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_mediumApplication_support.xsd
@@ -218,12 +218,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfMediumAccessDeviceRef" type="TypeOfMediumAccessDeviceRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="TypeOfMediumAccessDeviceRef" type="TypeOfMediumAccessDeviceRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF MEDIUM ACCESS DEVICE. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="TypeOfMediumAccessDeviceRefStructure" abstract="false">
+	<xsd:complexType name="TypeOfMediumAccessDeviceRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a TYPE OF MEDIUM ACCESS DEVICE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_mediumApplication_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_mediumApplication_version.xsd
@@ -102,7 +102,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexType>
 	</xsd:element>
 	<!-- ====== MEDIUM ACCESS DEVICE ========================================== -->
-	<xsd:element name="MediumAccessDevice" abstract="false" substitutionGroup="netex:DataManagedObject">
+	<xsd:element name="MediumAccessDevice" substitutionGroup="netex:DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A component (mobile phone, smart card, etc) with the necessary facilities (hardware and software) to host a MEDIUM APPLICATION INSTANCE and communicate with a control device. +v1.2.2.
 </xsd:documentation>
@@ -130,7 +130,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="MediumAccessDevice_VersionStructure" abstract="false">
+	<xsd:complexType name="MediumAccessDevice_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for MEDIUM ACCESS DEVICE restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -168,7 +168,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== MOBILE DEVICE ========================================== -->
-	<xsd:element name="MobileDevice" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="MobileDevice" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A mobile device (mobile phone, tablet, etc) with the necessary facilities (hardware and software) to host a MEDIUM APPLICATION INSTANCE and communicate with a control device.
   +v1.2.2</xsd:documentation>
@@ -196,7 +196,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="MobileDevice_VersionStructure" abstract="false">
+	<xsd:complexType name="MobileDevice_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for MOBILE DEVICE restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -205,7 +205,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====== EMV CARD ========================================== -->
-	<xsd:element name="EmvCard" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="EmvCard" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A standardised payment card (Europay MasterCard Visa etc) , capable of being used as token for an ABT system +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -232,7 +232,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="EmvCard_VersionStructure" abstract="false">
+	<xsd:complexType name="EmvCard_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for EMV CARD restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -241,7 +241,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====== SMART CARD ========================================== -->
-	<xsd:element name="Smartcard" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="Smartcard" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A  smart card with the necessary facilities (hardware and software) are) to host a  MEDIUM APPLICATION INSTANCE and communicate with a control device. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -271,7 +271,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Smartcard_VersionStructure" abstract="false">
+	<xsd:complexType name="Smartcard_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for SMARTCARD restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -307,7 +307,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="MediumApplicationInstance" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="MediumApplicationInstance" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Initialized instance of a software  application that runs on a MEDIUM ACCESS DEVICE. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -334,7 +334,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="MediumApplicationInstance_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="MediumApplicationInstance_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for MEDIUM APPLICATION INSTANCE restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -369,7 +369,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====  MEDIUM ACCESS DEVICE SECURITY LISTING ======================================== -->
-	<xsd:element name="MediumAccessDeviceSecurityListing" abstract="false" substitutionGroup="SecurityListing_">
+	<xsd:element name="MediumAccessDeviceSecurityListing" substitutionGroup="SecurityListing_">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a MEDIUM ACCESS DEVICE on a SECURITY LIST. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -424,7 +424,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== TYPE OF MEDIUM ACCESS DEVICE ============================================================ -->
-	<xsd:element name="TypeOfMediumAccessDevice" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfMediumAccessDevice" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>A classification for a TYPE OF MEDIUM ACCESS DEVICE.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -454,7 +454,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfMediumAccessDevice_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfMediumAccessDevice_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF MEDIUM ACCESS DEVICE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_retailConsortium_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_retailConsortium_version.xsd
@@ -129,7 +129,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RetailConsortium" abstract="false" substitutionGroup="Organisation_">
+	<xsd:element name="RetailConsortium" substitutionGroup="Organisation_">
 		<xsd:annotation>
 			<xsd:documentation>A group of ORGANISATIONs formally incorporated as a retailer of fare products.</xsd:documentation>
 		</xsd:annotation>
@@ -217,7 +217,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RetailDevice" abstract="false" substitutionGroup="InstalledEquipment">
+	<xsd:element name="RetailDevice" substitutionGroup="InstalledEquipment">
 		<xsd:annotation>
 			<xsd:documentation>A retail device used to sell fare products. Can be used to record fulfilment.</xsd:documentation>
 		</xsd:annotation>
@@ -295,7 +295,7 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="TypeOfEntity_VersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfRetailDevice" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfRetailDevice" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of RETAIL DEVICEs.</xsd:documentation>
 		</xsd:annotation>
@@ -319,7 +319,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexType>
 	</xsd:element>
 	<!-- ====CUSTOMER SECURITY LISTING ======================================== -->
-	<xsd:element name="RetailDeviceSecurityListing" abstract="false" substitutionGroup="SecurityListing_">
+	<xsd:element name="RetailDeviceSecurityListing" substitutionGroup="SecurityListing_">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a RETAIL DEVICE on a sSECURITY LIST.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
@@ -171,7 +171,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Customer" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="Customer" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>An identified person or organisation involved in a fare process. There may be a FARE CONTRACT between the CUSTOMER and the OPERATOR or the AUTHORITY ruling the consumption of services.
  		</xsd:documentation>
@@ -337,7 +337,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareContract" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="FareContract" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A contract with a particular (but possibly anonymous) customer, ruling the consumption of transport services (and joint services). A FARE CONTRACT may be designed for a fixed SALES OFFER PACKAGE (e.g. ticket) or to allow successive purchases of SALES OFFER PACKAGEs.
 
@@ -520,7 +520,7 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="TypeOfEntity_VersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfFareContract" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfFareContract" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of FARE CONTRACT.</xsd:documentation>
 		</xsd:annotation>
@@ -562,7 +562,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfFareContractEntry" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfFareContractEntry" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of a FARE CONTRACT ENTRY.</xsd:documentation>
 		</xsd:annotation>
@@ -607,7 +607,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerAccount" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="CustomerAccount" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A contract with a particular (but possibly anonymous) customer, ruling the consumption of transport services (and joint services). A CUSTOMER ACCOUNT may be designed for a fixed SALES OFFER PACKAGE (e.g. ticket) or to allow successive purchases of SALES OFFER PACKAGEs.
 
@@ -740,7 +740,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TypeOfCustomerAccount" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfCustomerAccount" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of a CUSTOMER ACCOUNT.</xsd:documentation>
 		</xsd:annotation>
@@ -785,7 +785,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerAccountStatus" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="CustomerAccountStatus" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of a CUSTOMER ACCOUNT.</xsd:documentation>
 		</xsd:annotation>
@@ -817,7 +817,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==== CUSTOMER ACCOUNT SECURITY LISTING ======================================== -->
-	<xsd:element name="CustomerAccountSecurityListing" abstract="false" substitutionGroup="SecurityListing_">
+	<xsd:element name="CustomerAccountSecurityListing" substitutionGroup="SecurityListing_">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a CUSTOMER ACCOUNT on a SECURITY LIST.</xsd:documentation>
 		</xsd:annotation>
@@ -872,7 +872,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== CUSTOMER SECURITY LISTING ======================================== -->
-	<xsd:element name="CustomerSecurityListing" abstract="false" substitutionGroup="SecurityListing_">
+	<xsd:element name="CustomerSecurityListing" substitutionGroup="SecurityListing_">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a CUSTOMER on a SECURITY LIST.</xsd:documentation>
 		</xsd:annotation>
@@ -927,7 +927,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== FARE CONTRACT SECURITY LISTING ======================================== -->
-	<xsd:element name="FareContractSecurityListing" abstract="false" substitutionGroup="SecurityListing_">
+	<xsd:element name="FareContractSecurityListing" substitutionGroup="SecurityListing_">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a FARE CONTRACT on a SECURITY LIST.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
@@ -433,16 +433,14 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareContractEntry_" type="DataManagedObjectStructure" substitutionGroup="DataManagedObject">
+	<xsd:element name="FareContractEntry_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type for FARE CONTRACT ENTRY.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:element name="FareContractEntry" abstract="true" substitutionGroup="FareContractEntry_">
 		<xsd:annotation>
-			<xsd:documentation>A log entry describing an event referring to the life of a FARE CONTRACT: initial contracting, sales, validation entries, etc. A subset of a FARE CONTRACT ENTRY is often materialised on a TRAVEL DOCUMENT.
-
-</xsd:documentation>
+			<xsd:documentation>A log entry describing an event referring to the life of a FARE CONTRACT: initial contracting, sales, validation entries, etc. A subset of a FARE CONTRACT ENTRY is often materialised on a TRAVEL DOCUMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_salesTransaction_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_salesTransaction_support.xsd
@@ -88,7 +88,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="FareContractEntryIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="SalesTransactionRef" type="SalesTransactionRefStructure" abstract="false" substitutionGroup="FareContractEntryRef">
+	<xsd:element name="SalesTransactionRef" type="SalesTransactionRefStructure" substitutionGroup="FareContractEntryRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a SALES TRANSACTION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_salesTransaction_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_salesTransaction_version.xsd
@@ -128,7 +128,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SalesTransaction" abstract="false" substitutionGroup="FareContractEntry_">
+	<xsd:element name="SalesTransaction" substitutionGroup="FareContractEntry_">
 		<xsd:annotation>
 			<xsd:documentation>A SALE OF a FIXED PACKAGE or a SALE OF a RELOADABLE PACKAGE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_spotAllocation_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_spotAllocation_version.xsd
@@ -78,7 +78,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== VEHICLE JOURNEY SPOT ALLOCATION  ==== -->
-	<xsd:element name="VehicleJourneySpotAllocation" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="VehicleJourneySpotAllocation" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>An identified person or organisation involved in a fare process. There may be a FARE CONTRACT between the VEHICLE JOURNEY SPOT ALLOCATION and the OPERATOR or the AUTHORITY ruling the consumption of services. +v2.0
  		</xsd:documentation>
@@ -162,7 +162,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PassengerSpotAllocation" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="PassengerSpotAllocation" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Whether a specific TRANSPORT CUSTOMER is eligible for a FARE PRODUCT with a specific validity Parameter. This may be subject to a particular VALIDITY CONDITION. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -189,7 +189,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PassengerSpotAllocation_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="PassengerSpotAllocation_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for PASSENGER SPOT ALLOCATION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_travelDocument_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_travelDocument_version.xsd
@@ -104,7 +104,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====TRAVEL DOCUMENT=================================================== -->
-	<xsd:element name="TravelDocument" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="TravelDocument" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A particular physical support (ticket, card...) to be held by a customer, allowing the right to travel or to consume joint-services, to proof a payment (including possible discount rights), to store a subset of the FARE CONTRACT liabilities or a combination of those.
 </xsd:documentation>
@@ -170,7 +170,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====FARE CONTRACT SECURITY LISTING ======================================== -->
-	<xsd:element name="TravelDocumentSecurityListing" abstract="false" substitutionGroup="SecurityListing_">
+	<xsd:element name="TravelDocumentSecurityListing" substitutionGroup="SecurityListing_">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a TRAVEL DOCUMENT on a SECURITY LIST.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_fm/netex_nm_accessCredentialsAssignment_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_accessCredentialsAssignment_version.xsd
@@ -65,7 +65,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation> VEHICLE ACCESS CREDENTIALs ASSIGNMENT data types</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======SERVICE ACCESS CODE. ========================================== -->
-	<xsd:element name="ServiceAccessCode" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="ServiceAccessCode" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Code to access a service, can be numerical code, barcode, flashcode, etc.
  +v1.2.2</xsd:documentation>
@@ -96,7 +96,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ServiceAccessCode_VersionStructure" abstract="false">
+	<xsd:complexType name="ServiceAccessCode_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for SERVICE ACCESS CODE restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -139,7 +139,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleAccessCredentialsAssignment" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleAccessCredentialsAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a MEDIUM ACCESS DEVICE to a specific VEHICLE, to allow the user (TRANSPORT CUSTOMER) to access the vehicle (tyically for VEHICLE SHARING or VEHICLE RENTAL). This allocation may have validity limitations. +V1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -171,7 +171,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleAccessCredentialsAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleAccessCredentialsAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE ACCESS CREDENTIALs ASSIGNMENT restricts id.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_fm/netex_nm_individualTraveller_support.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_individualTraveller_support.xsd
@@ -76,7 +76,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="IndividualTravellerRef" type="IndividualTravellerRefStructure" abstract="false" substitutionGroup="VersionOfObjectRef">
+	<xsd:element name="IndividualTravellerRef" type="IndividualTravellerRefStructure" substitutionGroup="VersionOfObjectRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a INDIVIDUAL TRAVELLER. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -114,7 +114,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="VehiclePoolingDriverInfoRef" type="VehiclePoolingDriverInfoRefStructure" abstract="false" substitutionGroup="VersionOfObjectRef">
+	<xsd:element name="VehiclePoolingDriverInfoRef" type="VehiclePoolingDriverInfoRefStructure" substitutionGroup="VersionOfObjectRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a VEHICLE POOLING DRIVER INFO. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -163,7 +163,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="IndividualPassengerInfoRef" type="IndividualPassengerInfoRefStructure" abstract="false" substitutionGroup="VersionOfObjectRef">
+	<xsd:element name="IndividualPassengerInfoRef" type="IndividualPassengerInfoRefStructure" substitutionGroup="VersionOfObjectRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a INDIVIDUAL PASSENGER  INFO. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_fm/netex_nm_individualTraveller_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_individualTraveller_version.xsd
@@ -99,7 +99,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="IndividualTraveller" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="IndividualTraveller" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Individual travelling person. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -200,7 +200,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehiclePoolingDriverInfo" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="VehiclePoolingDriverInfo" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Information characterising an INDIVIDUAL TRAVELLER as a driver of a VEHICLE POOLING SERVICE. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -307,7 +307,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="IndividualPassengerInfo" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="IndividualPassengerInfo" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Information characterising an INDIVIDUAL TRAVELLER as a driver of a VEHICLE POOLING SERVICE. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_fm/netex_nm_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_usageParameterEligibility_version.xsd
@@ -59,7 +59,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: New Modes Eligibility USAGE PARAMETER   types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ==== VEHICLE POOLER PROFILE================================================= -->
-	<xsd:element name="VehiclePoolerProfile" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="VehiclePoolerProfile" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>A set of USER PARAMETERS characterising access rights to VEHICLE POOLING SERVICE. +v1.2.2
 </xsd:documentation>

--- a/xsd/netex_part_5/part5_fm/netex_nm_usageParameterRental_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_usageParameterRental_version.xsd
@@ -59,7 +59,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: RENTAL USAGE PARAMETER  types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ==== RENTAL PENALTY POLICY USER PARAMETER ================================================ -->
-	<xsd:element name="RentalPenaltyPolicy" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="RentalPenaltyPolicy" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Policy regarding different aspects of RENTAL service penalty charges, for example loss of vehicle. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -133,7 +133,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== RENTAL OPTION ================================================ -->
-	<xsd:element name="RentalOption" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="RentalOption" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Parameters relating to paying by RentalOption for a product. +v1.1</xsd:documentation>
 		</xsd:annotation>
@@ -175,7 +175,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==== RENTAL OPTION ================================================ -->
-	<xsd:element name="AdditionalDriverOption" abstract="false" substitutionGroup="UsageParameter_">
+	<xsd:element name="AdditionalDriverOption" substitutionGroup="UsageParameter_">
 		<xsd:annotation>
 			<xsd:documentation>Parameters relating to paying by AdditionalDriverOption for a product. +v1.1</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_frames/netex_nm_mobilityJourneyFrame_version.xsd
+++ b/xsd/netex_part_5/part5_frames/netex_nm_mobilityJourneyFrame_version.xsd
@@ -73,12 +73,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="MobilityJourneyFrameRef" type="MobilityJourneyFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="MobilityJourneyFrameRef" type="MobilityJourneyFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a MOBILITY JOURNEY FRAME.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="MobilityJourneyFrameRefStructure" abstract="false">
+	<xsd:complexType name="MobilityJourneyFrameRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a MOBILITY JOURNEY FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -89,7 +89,7 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="MobilityJourneyFrame" abstract="false" substitutionGroup="CommonFrame">
+	<xsd:element name="MobilityJourneyFrame" substitutionGroup="CommonFrame">
 		<xsd:annotation>
 			<xsd:documentation>A coherent set of MOBILITY JOURNEY data to which the same frame VALIDITY CONDITIONs have been assigned. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -115,7 +115,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="MobilityJourney_VersionFrameStructure" abstract="false">
+	<xsd:complexType name="MobilityJourney_VersionFrameStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a MOBILITY JOURNEY FRAME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_frames/netex_nm_mobilityServiceFrame_version.xsd
+++ b/xsd/netex_part_5/part5_frames/netex_nm_mobilityServiceFrame_version.xsd
@@ -77,12 +77,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VersionFrameIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="MobilityServiceFrameRef" type="MobilityServiceFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+	<xsd:element name="MobilityServiceFrameRef" type="MobilityServiceFrameRefStructure" substitutionGroup="VersionFrameRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a MOBILITY SERVICE FRAME.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="MobilityServiceFrameRefStructure" abstract="false">
+	<xsd:complexType name="MobilityServiceFrameRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a MOBILITY SERVICE FRAME.</xsd:documentation>
 		</xsd:annotation>
@@ -93,7 +93,7 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="MobilityServiceFrame" abstract="false" substitutionGroup="CommonFrame">
+	<xsd:element name="MobilityServiceFrame" substitutionGroup="CommonFrame">
 		<xsd:annotation>
 			<xsd:documentation>A coherent set of MOBILITY SERVICE data to which the same frame VALIDITY CONDITIONs have been assigned. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -119,7 +119,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="MobilityService_VersionFrameStructure" abstract="false">
+	<xsd:complexType name="MobilityService_VersionFrameStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a MOBILITY SERVICE FRAME.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_mobilityServiceConstraintZone_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_mobilityServiceConstraintZone_version.xsd
@@ -64,7 +64,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="MobilityServiceConstraintZone" abstract="false" substitutionGroup="Zone">
+	<xsd:element name="MobilityServiceConstraintZone" substitutionGroup="Zone">
 		<xsd:annotation>
 			<xsd:documentation>ZONE defining a restriction on used of a MOBILITY SERVICE, e.g. no entry, no drop off, etc, etc   +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -96,7 +96,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="MobilityServiceConstraintZone_VersionStructure" abstract="false">
+	<xsd:complexType name="MobilityServiceConstraintZone_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for MOBILITY SERVICE CONSTRAINT ZONE restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -149,7 +149,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleTypeZoneRestriction" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="VehicleTypeZoneRestriction" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Restriction on use of a MOBILITY SERVICE CONSTRAINT ZONE for a specific TRANSPORT TYPE. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -172,7 +172,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleTypeZoneRestriction_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleTypeZoneRestriction_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE TYPE ZONE RESTRICTION restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -226,7 +226,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PoolOfVehicles" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="PoolOfVehicles" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A set of vehicles assigned to a specific PARKING, PARKING AREAs, PARKING BAYs, p lace  or MOBILITY CONSTRAINT ZONE that must be  picked up and returned to the same area.
   +v1.2.2</xsd:documentation>
@@ -253,7 +253,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="PoolOfVehicles_VersionStructure" abstract="false">
+	<xsd:complexType name="PoolOfVehicles_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for POOL OF VEHICLEs restricts id.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPlace_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPlace_version.xsd
@@ -76,7 +76,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>DUMMY type to workaround SG limitation.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="VehicleMeetingPlace" abstract="false" substitutionGroup="Place">
+	<xsd:element name="VehicleMeetingPlace" substitutionGroup="Place">
 		<xsd:annotation>
 			<xsd:documentation>A place where vehicles/passengers meet to change mode of transportation, for boarding, alighting, pick-up, drop-off, etc.  +v1.2.2
 </xsd:documentation>
@@ -117,7 +117,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleMeetingPlace_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleMeetingPlace_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE MEETING PLACE.</xsd:documentation>
 		</xsd:annotation>
@@ -139,7 +139,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== VEHICLE MEETING PLACE ======================================================== -->
-	<xsd:element name="VehiclePoolingMeetingPlace" abstract="false" substitutionGroup="VehicleMeetingPlace_">
+	<xsd:element name="VehiclePoolingMeetingPlace" substitutionGroup="VehicleMeetingPlace_">
 		<xsd:annotation>
 			<xsd:documentation>A place where  vehicles/passengers meet to change mode of transportation, for boarding, alighting, pick-up, drop-off, etc.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -179,7 +179,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehiclePoolingMeetingPlace_VersionStructure" abstract="false">
+	<xsd:complexType name="VehiclePoolingMeetingPlace_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE POOLING MEETING PLACE.</xsd:documentation>
 		</xsd:annotation>
@@ -194,7 +194,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== VEHICLE SHARING PARKING AREA  ============================================================ -->
-	<xsd:element name="VehicleSharingParkingArea" abstract="false" substitutionGroup="ParkingArea_">
+	<xsd:element name="VehicleSharingParkingArea" substitutionGroup="ParkingArea_">
 		<xsd:annotation>
 			<xsd:documentation>A dedicated part of the PARKING AREA for vehicle sharing or rental which is composed of one or more VEHICLE SHARING PARKING BAYs. +v1.2.2
 </xsd:documentation>
@@ -245,7 +245,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleSharingParkingArea_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleSharingParkingArea_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE SHARING PARKING AREA.</xsd:documentation>
 		</xsd:annotation>
@@ -264,7 +264,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== VEHICLE POOLING PARKING AREA  ============================================================ -->
-	<xsd:element name="VehiclePoolingParkingArea" abstract="false" substitutionGroup="ParkingArea_">
+	<xsd:element name="VehiclePoolingParkingArea" substitutionGroup="ParkingArea_">
 		<xsd:annotation>
 			<xsd:documentation> A dedicated space of a PARKING AREA for either vehicles active in a pooling service or  vehicles of a pooling service users  where vehicles are left for a longer time.  +v1.2.2
 </xsd:documentation>
@@ -315,7 +315,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehiclePoolingParkingArea_VersionStructure" abstract="false">
+	<xsd:complexType name="VehiclePoolingParkingArea_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE POOLING PARKING AREA.</xsd:documentation>
 		</xsd:annotation>
@@ -334,7 +334,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== VEHICLE SHARING PARKING BAY  ============================================================ -->
-	<xsd:element name="VehicleSharingParkingBay" abstract="false" substitutionGroup="ParkingBay_">
+	<xsd:element name="VehicleSharingParkingBay" substitutionGroup="ParkingBay_">
 		<xsd:annotation>
 			<xsd:documentation>A spot in the PARKING AREA dedicated to vehicle sharing or rental.	+v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -384,7 +384,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleSharingParkingBay_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleSharingParkingBay_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE SHARING PARKING BAY.</xsd:documentation>
 		</xsd:annotation>
@@ -403,7 +403,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== VEHICLE POOLING PARKING BAY  ============================================================ -->
-	<xsd:element name="VehiclePoolingParkingBay" abstract="false" substitutionGroup="ParkingBay_">
+	<xsd:element name="VehiclePoolingParkingBay" substitutionGroup="ParkingBay_">
 		<xsd:annotation>
 			<xsd:documentation>A dedicated space of a PARKING AREA for either vehicles active in a pooling service or  vehicles of a pooling service users  where vehicles are left for a longer time.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -453,7 +453,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehiclePoolingParkingBay_VersionStructure" abstract="false">
+	<xsd:complexType name="VehiclePoolingParkingBay_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE POOLING PARKING BAY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPlace_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPlace_version.xsd
@@ -71,7 +71,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleMeetingPlace_" type="AddressablePlace_VersionStructure" abstract="false" substitutionGroup="Place">
+	<xsd:element name="VehicleMeetingPlace_" type="AddressablePlace_VersionStructure" abstract="true" substitutionGroup="Place">
 		<xsd:annotation>
 			<xsd:documentation>DUMMY type to workaround SG limitation.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPointAssignment_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPointAssignment_version.xsd
@@ -88,7 +88,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleMeetingPointAssignment_" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleMeetingPointAssignment_" abstract="true" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Type to work round SG restrictions.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPointAssignment_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPointAssignment_version.xsd
@@ -115,7 +115,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:element name="VehicleMeetingPointAssignment" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleMeetingPointAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a VEHICLE MEETING POINT to a SITE COMPONENT  or ADDRESSABLE PLACE (for vehicle pooling or vehicle sharing purposes).  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -147,7 +147,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleMeetingPointAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleMeetingPointAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE MEETING POINT ASSIGNMENT restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -170,7 +170,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== DYNAMIC VEHICLE MEETING POINT ASSIGNMENT ========================================== -->
-	<xsd:element name="DynamicVehicleMeetingPointAssignment" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="DynamicVehicleMeetingPointAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>Dynamic allocation of a VEHICLE MEETING ASSIGNMENT. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -205,7 +205,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="DynamicVehicleMeetingPointAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="DynamicVehicleMeetingPointAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for DYNAMIC VEHICLE MEETING POINT ASSIGNMENT restricts id.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPoint_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPoint_version.xsd
@@ -85,7 +85,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleMeetingPoint" abstract="false" substitutionGroup="Point">
+	<xsd:element name="VehicleMeetingPoint" substitutionGroup="Point">
 		<xsd:annotation>
 			<xsd:documentation> A POINT where passengers can board or alight from vehicles.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -111,7 +111,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleMeetingPoint_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleMeetingPoint_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE MEETING POINT restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -142,7 +142,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleMeetingLink" abstract="false" substitutionGroup="Link">
+	<xsd:element name="VehicleMeetingLink" substitutionGroup="Link">
 		<xsd:annotation>
 			<xsd:documentation>A LINK between an ordered pair of STOP POINTs.  VEHICLE MEETING LINKs are directional - there will be separate links for each direction of a route.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -168,7 +168,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleMeetingLink_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleMeetingLink_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE MEETING LINK.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleParkingAreaInformation_support.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleParkingAreaInformation_support.xsd
@@ -93,12 +93,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="ParkingBayStatusRef" type="ParkingBayStatusRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="ParkingBayStatusRef" type="ParkingBayStatusRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PARKING BAY STATUS. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ParkingBayStatusRefStructure" abstract="false">
+	<xsd:complexType name="ParkingBayStatusRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a PARKING BAY STATUS.</xsd:documentation>
 		</xsd:annotation>
@@ -131,12 +131,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="RentalAvailabilityRef" type="ParkingBayStatusRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="RentalAvailabilityRef" type="ParkingBayStatusRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a RENTAL AVAILABILITY. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="RentalAvailabilityRefStructure" abstract="false">
+	<xsd:complexType name="RentalAvailabilityRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a RENTAL AVAILABILITY.</xsd:documentation>
 		</xsd:annotation>
@@ -157,12 +157,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="LogEntryIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="ParkingBayConditionRef" type="ParkingBayStatusRefStructure" abstract="false" substitutionGroup="TypeOfValueRef">
+	<xsd:element name="ParkingBayConditionRef" type="ParkingBayStatusRefStructure" substitutionGroup="TypeOfValueRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PARKING BAY CONDITION. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ParkingBayConditionRefStructure" abstract="false">
+	<xsd:complexType name="ParkingBayConditionRefStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a PPARKING BAY CONDITION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleParkingAreaInformation_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleParkingAreaInformation_version.xsd
@@ -105,7 +105,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==== VEHICLE SHARING PARKING BAY  ============================================================ -->
-	<xsd:element name="MonitoredVehicleSharingParkingBay" abstract="false" substitutionGroup="ParkingBay_">
+	<xsd:element name="MonitoredVehicleSharingParkingBay" substitutionGroup="ParkingBay_">
 		<xsd:annotation>
 			<xsd:documentation>A spot in the PARKING AREA dedicated to MONITORED VEHICLE SHARING  or rental. 	+v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -158,7 +158,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="MonitoredVehicleSharingParkingBay_VersionStructure" abstract="false">
+	<xsd:complexType name="MonitoredVehicleSharingParkingBay_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for MONITORED VEHICLE SHARING  PARKING BAY.</xsd:documentation>
 		</xsd:annotation>
@@ -184,7 +184,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== PARKING BAY STATUS ============================================================ -->
-	<xsd:element name="ParkingBayStatus" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="ParkingBayStatus" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation> A categorisation of the  availability of the parking spot, such as being temporarily closed, unavailable, available. +v1.2.2
 
@@ -220,7 +220,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ParkingBayStatus_ValueStructure" abstract="false">
+	<xsd:complexType name="ParkingBayStatus_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PARKING BAY STATUS.</xsd:documentation>
 		</xsd:annotation>
@@ -243,7 +243,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====RENTAL AVAILABILITY ============================================================ -->
-	<xsd:element name="RentalAvailability" abstract="false" substitutionGroup="ParkingLogEntry_">
+	<xsd:element name="RentalAvailability" substitutionGroup="ParkingLogEntry_">
 		<xsd:annotation>
 			<xsd:documentation>A summary of the status of the rental at a  SITE  at a given point on time.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -271,7 +271,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="RentalAvailability_VersionStructure" abstract="false">
+	<xsd:complexType name="RentalAvailability_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a RENTAL AVAILABILITY.</xsd:documentation>
 		</xsd:annotation>
@@ -325,7 +325,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== PARKING BAY STATUS ============================================================ -->
-	<xsd:element name="ParkingBayCondition" abstract="false" substitutionGroup="ParkingLogEntry_">
+	<xsd:element name="ParkingBayCondition" substitutionGroup="ParkingLogEntry_">
 		<xsd:annotation>
 			<xsd:documentation>A record of the status of the PARKING BAY at a given moment in time.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -355,7 +355,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ParkingBayCondition_VersionStructure" abstract="false">
+	<xsd:complexType name="ParkingBayCondition_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PARKING BAY CONDITION..</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleServicePlaceAssignment_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleServicePlaceAssignment_version.xsd
@@ -103,7 +103,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:element name="VehicleServicePlaceAssignment" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleServicePlaceAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a place to a MOBILITY SERVICE. +V1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -135,7 +135,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleServicePlaceAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleServicePlaceAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE SERVICE PLACE ASSIGNMENT restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -154,7 +154,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ====== TAXI SERVICE PLACE ASSIGNMENT ========================================== -->
-	<xsd:element name="TaxiServicePlaceAssignment" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="TaxiServicePlaceAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a TAXI SERVICE to a TAXI PARKING or a TAXI STAND.  +V1.2.2
 
@@ -192,7 +192,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TaxiServicePlaceAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="TaxiServicePlaceAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TAXI SERVICE PLACE ASSIGNMENT restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -216,7 +216,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== VEHICLE POOLING PLACE ASSIGNMENT ========================================== -->
-	<xsd:element name="VehiclePoolingPlaceAssignment" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="VehiclePoolingPlaceAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a VEHICLE POOLING SERVICE to a VEHICLE POOLING PARKING AREA or a VEHICLE POOLING MEETING PLACE.  +V1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -251,7 +251,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehiclePoolingPlaceAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="VehiclePoolingPlaceAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE POOLING PLACE ASSIGNMENT restricts id.</xsd:documentation>
 		</xsd:annotation>
@@ -277,7 +277,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== VEHICLE POOLING PLACE ASSIGNMENT ========================================== -->
-	<xsd:element name="VehicleSharingPlaceAssignment" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleSharingPlaceAssignment" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a VEHICLE SHARING AREA to any vehicle sharing or rental service. +V1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -312,7 +312,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleSharingPlaceAssignment_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleSharingPlaceAssignment_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE SHARING PLACE ASSIGNMENT restricts id.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleServicePlaceAssignment_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleServicePlaceAssignment_version.xsd
@@ -76,7 +76,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleServicePlaceAssignment_" abstract="false" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleServicePlaceAssignment_" abstract="true" substitutionGroup="Assignment_">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Type to work round SG restrfictions.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd
+++ b/xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd
@@ -179,7 +179,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CommonVehicleService_VersionStructure" abstract="false">
+	<xsd:complexType name="CommonVehicleService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for COMMON VEHICLE SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -251,7 +251,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehiclePoolingService_VersionStructure" abstract="false">
+	<xsd:complexType name="VehiclePoolingService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE POOLING SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -321,7 +321,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TaxiService_VersionStructure" abstract="false">
+	<xsd:complexType name="TaxiService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for TAXI SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -383,7 +383,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CarPoolingService_VersionStructure" abstract="false">
+	<xsd:complexType name="CarPoolingService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for CAR POOLING SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -445,7 +445,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ChauffeuredVehicleService_VersionStructure" abstract="false">
+	<xsd:complexType name="ChauffeuredVehicleService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for ChauffeuredVehicle SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -496,7 +496,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleSharingService_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleSharingService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE SHARING SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -578,7 +578,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="VehicleRentalService_VersionStructure" abstract="false">
+	<xsd:complexType name="VehicleRentalService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for VEHICLE RENTAL SERVICE.</xsd:documentation>
 		</xsd:annotation>
@@ -619,7 +619,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== TYPE OF MOBILITY SERVICE ======================================== -->
-	<xsd:element name="TypeOfMobilityService" abstract="false" substitutionGroup="TypeOfEntity">
+	<xsd:element name="TypeOfMobilityService" substitutionGroup="TypeOfEntity">
 		<xsd:annotation>
 			<xsd:documentation>A classification of a MOBILITY SERVICE according to its functional purpose.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -642,7 +642,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfMobilityService_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfMobilityService_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF MobilityService.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_rc/netex_nm_onlineService_version.xsd
+++ b/xsd/netex_part_5/part5_rc/netex_nm_onlineService_version.xsd
@@ -195,7 +195,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="OnlineService_VersionStructure" abstract="false">
+	<xsd:complexType name="OnlineService_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for ONLINE SERVICE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_sj/netex_nm_singleJourneyPath_version.xsd
+++ b/xsd/netex_part_5/part5_sj/netex_nm_singleJourneyPath_version.xsd
@@ -73,7 +73,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SingleJourneyPath" abstract="false" substitutionGroup="LinkSequence" id="SingleJourneyPath">
+	<xsd:element name="SingleJourneyPath" substitutionGroup="LinkSequence" id="SingleJourneyPath">
 		<xsd:annotation>
 			<xsd:documentation>The planned movement of a public transport vehicle on a DAY TYPE from the start point to the end point of a JOURNEY PATTERN on a specified ROUTE.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -141,7 +141,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleMeetingPointInPath" abstract="false" substitutionGroup="PointInLinkSequence" id="VehicleMeetingPointInPath">
+	<xsd:element name="VehicleMeetingPointInPath" substitutionGroup="PointInLinkSequence" id="VehicleMeetingPointInPath">
 		<xsd:annotation>
 			<xsd:documentation>The planned movement of a public transport vehicle on a DAY TYPE from the start point to the end point of a JOURNEY PATTERN on a specified ROUTE.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_sj/netex_nm_singleJourneyService_version.xsd
+++ b/xsd/netex_part_5/part5_sj/netex_nm_singleJourneyService_version.xsd
@@ -81,7 +81,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SingleJourney" abstract="false" substitutionGroup="Journey_" id="SingleJourney">
+	<xsd:element name="SingleJourney" substitutionGroup="Journey_" id="SingleJourney">
 		<xsd:annotation>
 			<xsd:documentation>The planned movement of a public transport vehicle on a DAY TYPE from the start point to the end point of a JOURNEY PATTERN on a specified ROUTE.  +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -177,7 +177,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GroupOfSingleJourneys" abstract="false" substitutionGroup="GroupOfEntities">
+	<xsd:element name="GroupOfSingleJourneys" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A GROUP OF SINGLE JOURNEYs, often known to its users by a name or a number. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/siri/siri_request_errorConditions-v2.0.xsd
+++ b/xsd/siri/siri_request_errorConditions-v2.0.xsd
@@ -120,7 +120,7 @@ Rail transport, Roads and road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="ErrorConditionElement" type="ErrorConditionElementStructure" abstract="false">
+	<xsd:element name="ErrorConditionElement" type="ErrorConditionElementStructure">
 		<xsd:annotation>
 			<xsd:documentation>Element fror an erroc condition  (for use in WSDL.)</xsd:documentation>
 		</xsd:annotation>
@@ -173,7 +173,7 @@ Rail transport, Roads and road transport
 		</xsd:attribute>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ServiceDeliveryErrorConditionElement" type="ServiceDeliveryErrorConditionStructure" abstract="false">
+	<xsd:element name="ServiceDeliveryErrorConditionElement" type="ServiceDeliveryErrorConditionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Element fror an erroc condition for use in WSDL.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/ynotation/netex_subThing_version.xsd
+++ b/xsd/ynotation/netex_subThing_version.xsd
@@ -5,7 +5,7 @@
 	<!-- === NOTATION EXAMPLE E==== =================================================== -->
 	<!-- ======================================================================= -->
 	<!-- ==== ANCESTOR A ========================================================= -->
-	<xsd:element name="AncestorA" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="AncestorA" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A ANCESTOR A</xsd:documentation>
 		</xsd:annotation>
@@ -55,7 +55,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== ANCESTOR B ========================================================= -->
-	<xsd:element name="AncestorB" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="AncestorB" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A ANCESTOR B</xsd:documentation>
 		</xsd:annotation>
@@ -120,7 +120,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== SUB A ========================================================= -->
-	<xsd:element name="SubA" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="SubA" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A SUB A</xsd:documentation>
 		</xsd:annotation>
@@ -172,7 +172,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== SUB SUB A ========================================================= -->
-	<xsd:element name="SubSubA" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="SubSubA" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A SUB SUB A</xsd:documentation>
 		</xsd:annotation>
@@ -229,7 +229,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== SUB AB ========================================================= -->
-	<xsd:element name="SubAB" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="SubAB" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A SUB AB</xsd:documentation>
 		</xsd:annotation>
@@ -281,7 +281,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== SUB ABC ========================================================= -->
-	<xsd:element name="SubABC" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="SubABC" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A SUB ABC</xsd:documentation>
 		</xsd:annotation>
@@ -337,7 +337,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== SUB SUB ABC ========================================================= -->
-	<xsd:element name="SubSubABC" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="SubSubABC" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A SUB SUB ABC</xsd:documentation>
 		</xsd:annotation>
@@ -395,7 +395,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== SUB AC ========================================================= -->
-	<xsd:element name="SubAC" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="SubAC" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A SUB AC</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/ynotation/netex_thing_support.xsd
+++ b/xsd/ynotation/netex_thing_support.xsd
@@ -95,7 +95,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="TypeOfValueIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TypeOfThingRef" type="TypeOfThingRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+	<xsd:element name="TypeOfThingRef" type="TypeOfThingRefStructure" substitutionGroup="TypeOfEntityRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TYPE OF THING</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/ynotation/netex_thing_version.xsd
+++ b/xsd/ynotation/netex_thing_version.xsd
@@ -5,7 +5,7 @@
 	<!-- === NOTATION EXAMPLE E==== =================================================== -->
 	<!-- ======================================================================= -->
 	<!-- ==== Thing ========================================================= -->
-	<xsd:element name="Thing" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="Thing" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A THING.</xsd:documentation>
 		</xsd:annotation>
@@ -86,12 +86,12 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ChildThing" type="ChildThing_VersionedChildStructure" abstract="false" substitutionGroup="VersionedChild">
+	<xsd:element name="ChildThing" type="ChildThing_VersionedChildStructure" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>A CHILD THING.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="ChildThing_VersionedChildStructure" abstract="false">
+	<xsd:complexType name="ChildThing_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a CHILD THING.</xsd:documentation>
 		</xsd:annotation>
@@ -122,7 +122,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== Type of Thing ================================================= -->
-	<xsd:element name="TypeOfThing" abstract="false" substitutionGroup="TypeOfValue">
+	<xsd:element name="TypeOfThing" substitutionGroup="TypeOfValue">
 		<xsd:annotation>
 			<xsd:documentation>Classification of a THING.</xsd:documentation>
 		</xsd:annotation>
@@ -155,7 +155,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="TypeOfThing_ValueStructure" abstract="false">
+	<xsd:complexType name="TypeOfThing_ValueStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a TYPE OF THING</xsd:documentation>
 		</xsd:annotation>
@@ -180,7 +180,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===== SomethingElse =============================================== -->
-	<xsd:element name="SomethingElse" abstract="false" substitutionGroup="DataManagedObject">
+	<xsd:element name="SomethingElse" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>A SOMETHING ELSE.</xsd:documentation>
 		</xsd:annotation>


### PR DESCRIPTION
Based on the discussion in #918 this implements the following (per commit):

1. cdeb8c67203a20466159559b3ef8930bbf304aa3 and 4913f4ad220e44f9cf6db7d5d49f5cf79e6403f8 cause Dummy types to be abstract, hence cannot be used to create (or parse) elements.
2. abstract="false" is the default, removed everything that is the default, cleans up the schema
3. Call_ dummy type was not required. There is no DatedCall that already worked with it.  

Yes, this changes a lot of cose, but then again, our aim is not have any changes in the repo anymore.