### PR TITLE
Rename dummy 3

### DIFF
--- a/scripts/match_dummy.py
+++ b/scripts/match_dummy.py
@@ -1,0 +1,46 @@
+import os
+from lxml import etree
+from collections import defaultdict
+
+XSD_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
+NSMAP = {"xsd": XSD_NAMESPACE}
+
+def find_elements_with_dummy_pair(root_dir):
+    dummy_elements = defaultdict(list)  # map: base_name -> [(filepath, etree_element)]
+    normal_elements = defaultdict(list)
+
+    for dirpath, _, filenames in os.walk(root_dir):
+        for filename in filenames:
+            if not filename.endswith(".xsd"):
+                continue
+            filepath = os.path.join(dirpath, filename)
+            try:
+                tree = etree.parse(filepath)
+            except Exception as e:
+                print(f"Error parsing {filepath}: {e}")
+                continue
+
+            for elem in tree.xpath("//xsd:element", namespaces=NSMAP):
+                name = elem.get("name")
+                if not name:
+                    continue
+                if name.endswith("_Dummy"):
+                    base = name[:-6]
+                    dummy_elements[base].append((filepath, elem))
+                else:
+                    normal_elements[name].append((filepath, elem))
+
+    # Nu zoeken naar matchende paren
+    for base in sorted(dummy_elements):
+        if base in normal_elements:
+            for dummy_file, _ in dummy_elements[base]:
+                for normal_file, normal_elem in normal_elements[base]:
+                    if normal_elem.get("abstract") == "true":
+                        print(f"Pair: {base}_Dummy in {dummy_file}")
+                        print(f"      {base}       in {normal_file}")
+                        print()
+
+if __name__ == "__main__":
+    # Vervang dit pad door jouw projectpad
+    find_elements_with_dummy_pair("./xsd")
+

--- a/scripts/rename.py
+++ b/scripts/rename.py
@@ -1,0 +1,74 @@
+import glob
+from lxml import etree
+
+XSD_NS = "http://www.w3.org/2001/XMLSchema"
+NSMAP = {"xs": XSD_NS}
+
+# Attributen met één enkele type-ref
+SINGLE_REF_ATTRS = {'type', 'base', 'ref', 'substitutionGroup', 'itemType'}
+
+# Attributen met meerdere type-refs (spatiegescheiden)
+MULTI_REF_ATTRS = {'memberTypes'}
+
+def collect_renames(xsd_files):
+    rename_map = {}
+    for file in xsd_files:
+        tree = etree.parse(file)
+        for tag in ['xs:element', 'xs:complexType', 'xs:simpleType']:
+            for elem in tree.xpath(f'//{tag}', namespaces=NSMAP):
+                name = elem.get("name")
+                if name and name.endswith("_"):
+                    rename_map[name] = name + "Dummy"
+                # if name and name.endswith("_DummyTypeAbstract"):
+                #     rename_map[name] = name.replace('_DummyTypeAbstract', "_Abstract")
+    return rename_map
+
+def apply_renames(xsd_files, rename_map):
+    for file in xsd_files:
+        tree = etree.parse(file)
+        root = tree.getroot()
+        changed = False
+
+        for elem in root.iter():
+            # Pas name aan
+            if "name" in elem.attrib:
+                old = elem.attrib["name"]
+                if old in rename_map:
+                    elem.attrib["name"] = rename_map[old]
+                    changed = True
+
+            # Pas enkelvoudige verwijzingen aan
+            for attr in SINGLE_REF_ATTRS:
+                if attr in elem.attrib:
+                    value = elem.attrib[attr]
+                    if ":" not in value and value in rename_map:
+                        elem.attrib[attr] = rename_map[value]
+                        changed = True
+
+            # Pas meervoudige verwijzingen aan (zoals bij xs:union)
+            for attr in MULTI_REF_ATTRS:
+                if attr in elem.attrib:
+                    values = elem.attrib[attr].split()
+                    new_values = [
+                        rename_map.get(v, v) if ':' not in v else v
+                        for v in values
+                    ]
+                    if new_values != values:
+                        elem.attrib[attr] = ' '.join(new_values)
+                        changed = True
+
+        if changed:
+            print(f"Updated {file}")
+            tree.write(file, encoding="utf-8", xml_declaration=True, pretty_print=True)
+
+def main():
+    xsd_files = glob.glob("xsd/**/*.xsd", recursive=True)
+    rename_map = collect_renames(xsd_files)
+    if not rename_map:
+        print("Geen hernoemingen nodig.")
+        return
+    print("Te hernoemen:", rename_map)
+    apply_renames(xsd_files, rename_map)
+
+if __name__ == "__main__":
+    main()

--- a/xsd/NX.xsd
+++ b/xsd/NX.xsd
@@ -131,8 +131,8 @@
 						<xsd:element name="organisations" minOccurs="0">
 							<xsd:complexType>
 								<xsd:sequence>
-									<xsd:element ref="Organisation_" minOccurs="0" maxOccurs="unbounded"/>
-									<xsd:element ref="OrganisationRef_"/>
+									<xsd:element ref="Organisation_Dummy" minOccurs="0" maxOccurs="unbounded"/>
+									<xsd:element ref="OrganisationRef_Dummy"/>
 								</xsd:sequence>
 							</xsd:complexType>
 						</xsd:element>
@@ -147,7 +147,7 @@
 						<xsd:element name="assignments" minOccurs="0">
 							<xsd:complexType>
 								<xsd:sequence>
-									<xsd:element ref="Assignment_"/>
+									<xsd:element ref="Assignment_Dummy"/>
 									<xsd:element ref="AssignmentRef"/>
 								</xsd:sequence>
 							</xsd:complexType>
@@ -155,7 +155,7 @@
 						<xsd:element name="priceableObjects" minOccurs="0">
 							<xsd:complexType>
 								<xsd:sequence>
-									<xsd:element ref="PriceableObject_" maxOccurs="unbounded"/>
+									<xsd:element ref="PriceableObject_Dummy" maxOccurs="unbounded"/>
 									<xsd:element ref="PriceableObjectRef"/>
 								</xsd:sequence>
 							</xsd:complexType>
@@ -280,7 +280,7 @@
 												<xsd:element name="quality" minOccurs="0">
 													<xsd:complexType>
 														<xsd:sequence>
-															<xsd:element ref="QualityStructureFactor_" minOccurs="0" maxOccurs="unbounded"/>
+															<xsd:element ref="QualityStructureFactor_Dummy" minOccurs="0" maxOccurs="unbounded"/>
 														</xsd:sequence>
 													</xsd:complexType>
 												</xsd:element>
@@ -307,7 +307,7 @@
 									<xsd:element name="usageParameters" minOccurs="0">
 										<xsd:complexType>
 											<xsd:sequence>
-												<xsd:element ref="UsageParameter_" minOccurs="0" maxOccurs="unbounded"/>
+												<xsd:element ref="UsageParameter_Dummy" minOccurs="0" maxOccurs="unbounded"/>
 												<xsd:element ref="UsageParameterPrice" minOccurs="0" maxOccurs="unbounded"/>
 												<xsd:element ref="TypeOfUsageParameter" minOccurs="0" maxOccurs="unbounded"/>
 												<xsd:element ref="TypeOfConcession" minOccurs="0"/>
@@ -325,7 +325,7 @@
 									<xsd:element name="fareProducts" minOccurs="0">
 										<xsd:complexType>
 											<xsd:sequence>
-												<xsd:element ref="FareProduct_" maxOccurs="unbounded"/>
+												<xsd:element ref="FareProduct_Dummy" maxOccurs="unbounded"/>
 												<xsd:element ref="ChargingMoment" minOccurs="0" maxOccurs="unbounded"/>
 												<xsd:element ref="TypeOfFareProduct" minOccurs="0" maxOccurs="unbounded"/>
 												<xsd:element ref="AccessRightInProduct" minOccurs="0" maxOccurs="unbounded"/>
@@ -381,22 +381,22 @@
 										<xsd:complexType>
 											<xsd:sequence>
 												<xsd:element ref="PriceUnit" minOccurs="0" maxOccurs="unbounded"/>
-												<xsd:element ref="FarePrice_" minOccurs="0" maxOccurs="unbounded"/>
+												<xsd:element ref="FarePrice_Dummy" minOccurs="0" maxOccurs="unbounded"/>
 											</xsd:sequence>
 										</xsd:complexType>
 									</xsd:element>
 									<xsd:element name="priceGroups" minOccurs="0">
 										<xsd:complexType>
 											<xsd:sequence>
-												<xsd:element ref="PriceGroup_"/>
-												<xsd:element ref="Cell_"/>
+												<xsd:element ref="PriceGroup_Dummy"/>
+												<xsd:element ref="Cell_Dummy"/>
 											</xsd:sequence>
 										</xsd:complexType>
 									</xsd:element>
 									<xsd:element name="priceableObjects" minOccurs="0">
 										<xsd:complexType>
 											<xsd:sequence>
-												<xsd:element ref="PriceableObject_"/>
+												<xsd:element ref="PriceableObject_Dummy"/>
 											</xsd:sequence>
 										</xsd:complexType>
 									</xsd:element>
@@ -469,7 +469,7 @@
 			<xsd:element name="routes" minOccurs="0">
 				<xsd:complexType>
 					<xsd:sequence>
-						<xsd:element ref="Route_" minOccurs="0" maxOccurs="unbounded"/>
+						<xsd:element ref="Route_Dummy" minOccurs="0" maxOccurs="unbounded"/>
 						<xsd:element ref="RouteLink" minOccurs="0" maxOccurs="unbounded"/>
 						<xsd:element ref="RoutePoint" minOccurs="0" maxOccurs="unbounded"/>
 					</xsd:sequence>
@@ -486,7 +486,7 @@
 				<xsd:complexType>
 					<xsd:sequence>
 						<xsd:element ref="GroupOfLines" maxOccurs="unbounded"/>
-						<xsd:element ref="Line_" maxOccurs="unbounded"/>
+						<xsd:element ref="Line_Dummy" maxOccurs="unbounded"/>
 						<xsd:element ref="Direction" maxOccurs="unbounded"/>
 					</xsd:sequence>
 				</xsd:complexType>
@@ -538,7 +538,7 @@
 						<xsd:annotation>
 							<xsd:documentation>JOURNEY PATTERN.</xsd:documentation>
 						</xsd:annotation>
-						<xsd:element ref="JourneyPattern_" maxOccurs="unbounded"/>
+						<xsd:element ref="JourneyPattern_Dummy" maxOccurs="unbounded"/>
 						<xsd:element ref="TimingLinkInJourneyPattern" maxOccurs="unbounded"/>
 						<xsd:element ref="StopPointInJourneyPattern" maxOccurs="unbounded"/>
 					</xsd:sequence>
@@ -560,7 +560,7 @@
 						<xsd:element name="journeys" minOccurs="0">
 							<xsd:complexType>
 								<xsd:choice maxOccurs="unbounded">
-									<xsd:element ref="Journey_"/>
+									<xsd:element ref="Journey_Dummy"/>
 									<xsd:element ref="JourneyPart" maxOccurs="unbounded"/>
 									<xsd:element ref="JourneyPartCouple"/>
 									<xsd:element ref="GroupOfServices" maxOccurs="1"/>
@@ -573,7 +573,7 @@
 								<xsd:choice maxOccurs="unbounded">
 									<xsd:element ref="InterchangeRule"/>
 									<xsd:element ref="JourneyMeeting" maxOccurs="unbounded"/>
-									<xsd:element ref="Interchange_"/>
+									<xsd:element ref="Interchange_Dummy"/>
 								</xsd:choice>
 							</xsd:complexType>
 						</xsd:element>

--- a/xsd/ifopt.xsd
+++ b/xsd/ifopt.xsd
@@ -11,7 +11,7 @@
 			<xsd:element name="organisations" minOccurs="0">
 				<xsd:complexType>
 					<xsd:sequence minOccurs="0" maxOccurs="1">
-						<xsd:element ref="Organisation_" maxOccurs="unbounded"/>
+						<xsd:element ref="Organisation_Dummy" maxOccurs="unbounded"/>
 					</xsd:sequence>
 				</xsd:complexType>
 			</xsd:element>

--- a/xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd
@@ -58,12 +58,12 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NetEX: GENERAL ASSIGNMENT types for NeTEx Network Exchange.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<xsd:element name="Assignment_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="Assignment_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Abstract Assignment. An Assignment assigns a property to an other element. It has a name and an order.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="Assignment_VersionStructure_" abstract="true">
+	<xsd:complexType name="Assignment_VersionStructure_Dummy" abstract="true">
 		<xsd:annotation>
 			<xsd:documentation>Type for ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -97,7 +97,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="Assignment" abstract="true" substitutionGroup="Assignment_">
+	<xsd:element name="Assignment" abstract="true" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of properties to be applied to an another element. It has a name and an order.</xsd:documentation>
 		</xsd:annotation>
@@ -125,7 +125,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Type for ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:restriction base="Assignment_VersionStructure_">
+			<xsd:restriction base="Assignment_VersionStructure_Dummy">
 				<xsd:sequence>
 					<xsd:sequence>
 						<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>

--- a/xsd/netex_framework/netex_genericFramework/netex_grouping_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_grouping_support.xsd
@@ -58,7 +58,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfEntitiesRef_" type="VersionOfObjectRefStructure" abstract="true" substitutionGroup="VersionOfObjectRef">
+	<xsd:element name="GroupOfEntitiesRef_Dummy" type="VersionOfObjectRefStructure" abstract="true" substitutionGroup="VersionOfObjectRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF ENTITies.</xsd:documentation>
 		</xsd:annotation>
@@ -84,7 +84,7 @@ Rail transport, Roads and Road transport
 			</xsd:simpleContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="GroupOfEntitiesRefStructure_" abstract="true">
+	<xsd:complexType name="GroupOfEntitiesRefStructure_Dummy" abstract="true">
 		<xsd:annotation>
 			<xsd:documentation>Extending Type for a reference to a GROUP OF ENTITies.</xsd:documentation>
 		</xsd:annotation>
@@ -103,7 +103,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Extending Type for a reference to a GROUP OF ENTITies.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
-			<xsd:restriction base="GroupOfEntitiesRefStructure_">
+			<xsd:restriction base="GroupOfEntitiesRefStructure_Dummy">
 				<xsd:attribute name="ref" type="GroupOfEntitiesIdType" use="required">
 					<xsd:annotation>
 						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>
@@ -159,7 +159,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GeneralGroupOfEntitiesRef" type="GeneralGroupOfEntitiesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GeneralGroupOfEntitiesRef" type="GeneralGroupOfEntitiesRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GENERAL GROUP OF ENTITies.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_layer_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_layer_support.xsd
@@ -74,7 +74,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="LayerRef" type="LayerRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="LayerRef" type="LayerRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a LAYER.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_loggable_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_loggable_support.xsd
@@ -57,7 +57,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="LogRef" type="LogRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="LogRef" type="LogRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a LOG.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_organisation_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_organisation_version.xsd
@@ -80,7 +80,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="Organisation_" maxOccurs="unbounded"/>
+					<xsd:element ref="Organisation_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -98,12 +98,12 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="Organisation_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="Organisation_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy supertype for ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Organisation" abstract="true" substitutionGroup="Organisation_">
+	<xsd:element name="Organisation" abstract="true" substitutionGroup="Organisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An legally incorporated body associated with any aspect of the transport system.</xsd:documentation>
 		</xsd:annotation>
@@ -335,17 +335,17 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="OrganisationPartRef"/>
-					<xsd:element ref="OrganisationPart_"/>
+					<xsd:element ref="OrganisationPart_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="OrganisationPart_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="OrganisationPart_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy supertype for ORGANISATION PART.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="OrganisationPart" substitutionGroup="OrganisationPart_">
+	<xsd:element name="OrganisationPart" substitutionGroup="OrganisationPart_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A named subdivision of an ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
@@ -420,7 +420,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Coordinates of ORGANISATION PART.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 			<xsd:element ref="TypeOfOrganisationPartRef" minOccurs="0"/>
 			<xsd:element name="administrativeZones" type="administrativeZones_RelStructure" minOccurs="0">
 				<xsd:annotation>
@@ -444,7 +444,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Department" substitutionGroup="OrganisationPart_">
+	<xsd:element name="Department" substitutionGroup="OrganisationPart_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Department of an ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
@@ -509,7 +509,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="OrganisationalUnit" substitutionGroup="OrganisationPart_">
+	<xsd:element name="OrganisationalUnit" substitutionGroup="OrganisationPart_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>OrganisationalUnit of an ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
@@ -618,7 +618,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Description of the nature pf the Relationship.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 			<xsd:element name="OrganisationRoleType" type="OrganisationRoleEnumeration" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Role of the related Organbisation</xsd:documentation>
@@ -636,17 +636,17 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="AdministrativeZoneRef"/>
-					<xsd:element ref="AdministrativeZone_"/>
+					<xsd:element ref="AdministrativeZone_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="AdministrativeZone_" type="Zone_VersionStructure" abstract="true" substitutionGroup="Zone">
+	<xsd:element name="AdministrativeZone_Dummy" type="Zone_VersionStructure" abstract="true" substitutionGroup="Zone">
 		<xsd:annotation>
 			<xsd:documentation>Dummy supertype for ADMINISTRATIVE ZONE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="AdministrativeZone" substitutionGroup="AdministrativeZone_">
+	<xsd:element name="AdministrativeZone" substitutionGroup="AdministrativeZone_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A ZONE relating to the management responsibilities of an ORGANISATION. For example to allocate bus stop identifiers for a region.</xsd:documentation>
 		</xsd:annotation>
@@ -700,7 +700,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Public Code assosociated with ADMINISTRATIVE ZONE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 			<xsd:element name="responsibilities" type="responsibilitySets_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>RESPONSIBILITY SETs allocated to ADMINISTRATIVE ZONE.</xsd:documentation>
@@ -1006,7 +1006,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="DerivedViewStructure">
 				<xsd:sequence>
-					<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+					<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 					<xsd:group ref="OrganisationNameGroup"/>
 					<xsd:element name="ContactDetails" type="ContactStructure" minOccurs="0">
 						<xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_path_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_path_support.xsd
@@ -129,7 +129,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PlaceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GenericPathJunctionRef" type="GenericPathJunctionRefStructure" substitutionGroup="PlaceRef_">
+	<xsd:element name="GenericPathJunctionRef" type="GenericPathJunctionRefStructure" substitutionGroup="PlaceRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PATH JUNCTION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_place_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_place_support.xsd
@@ -78,12 +78,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ZoneIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PlaceRef_" type="VersionOfObjectRefStructure" abstract="true" substitutionGroup="VersionOfObjectRef">
+	<xsd:element name="PlaceRef_Dummy" type="VersionOfObjectRefStructure" abstract="true" substitutionGroup="VersionOfObjectRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PLACE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="PlaceRef" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="PlaceRef" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PLACE.</xsd:documentation>
 		</xsd:annotation>
@@ -114,7 +114,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="oneToManyRelationshipStructure">
 				<xsd:sequence>
-					<xsd:element ref="PlaceRef_" maxOccurs="unbounded"/>
+					<xsd:element ref="PlaceRef_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/xsd/netex_framework/netex_genericFramework/netex_pointAndLink_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_pointAndLink_support.xsd
@@ -183,7 +183,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Reference to a POINT ON LINK.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="PointOnLinkRefStructure_">
+	<xsd:complexType name="PointOnLinkRefStructure_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Type for a reference to a POINT ON LINK.</xsd:documentation>
 		</xsd:annotation>
@@ -202,7 +202,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Type for a reference to a POINT ON LINK.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
-			<xsd:restriction base="PointOnLinkRefStructure_">
+			<xsd:restriction base="PointOnLinkRefStructure_Dummy">
 				<xsd:attribute name="ref" type="PointOnLinkIdType" use="required">
 					<xsd:annotation>
 						<xsd:documentation>Identifier of a LINK.</xsd:documentation>
@@ -304,7 +304,7 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- ==Group of Points============================================================ -->
-	<xsd:element name="GroupOfPointsRef_" type="GroupOfEntitiesRefStructure" abstract="true" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfPointsRef_Dummy" type="GroupOfEntitiesRefStructure" abstract="true" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 		</xsd:annotation>
 	</xsd:element>
@@ -314,7 +314,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfPointsRef" abstract="true" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfPointsRef" abstract="true" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF POINTs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_pointAndLink_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_pointAndLink_version.xsd
@@ -176,7 +176,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="oneToManyRelationshipStructure">
 				<xsd:sequence>
-					<xsd:element ref="GroupOfPointsRef_" maxOccurs="unbounded"/>
+					<xsd:element ref="GroupOfPointsRef_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/xsd/netex_framework/netex_genericFramework/netex_section_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_section_support.xsd
@@ -59,7 +59,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="LinkSequenceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="SectionRef" type="SectionRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="SectionRef" type="SectionRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a SECTION.</xsd:documentation>
 		</xsd:annotation>
@@ -78,7 +78,7 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<xsd:element name="ParentSectionRef" type="SectionRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="ParentSectionRef" type="SectionRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a parent SECTION. May be omitted if given by context..</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_genericFramework/netex_section_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_section_version.xsd
@@ -81,12 +81,12 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<!-- ======================================================================= -->
 	<!-- ==COMMON SECTION=========================================================== -->
-	<xsd:element name="Section_" type="LinkSequence_VersionStructure" abstract="true">
+	<xsd:element name="Section_Dummy" type="LinkSequence_VersionStructure" abstract="true">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Supertype for SECTION +v1.1.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Section" abstract="true" substitutionGroup="Section_">
+	<xsd:element name="Section" abstract="true" substitutionGroup="Section_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A shared sequence of LINKS or POINTs. +v1.1.</xsd:documentation>
 		</xsd:annotation>
@@ -131,7 +131,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="GeneralSection" substitutionGroup="Section_">
+	<xsd:element name="GeneralSection" substitutionGroup="Section_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A resuable sequence of LINKS or POINTs. +v1.1.</xsd:documentation>
 		</xsd:annotation>
@@ -219,17 +219,17 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="PointOnSection_" maxOccurs="unbounded"/>
+					<xsd:element ref="PointOnSection_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PointOnSection_" type="PointInLinkSequence_VersionedChildStructure" abstract="true" substitutionGroup="PointInLinkSequence">
+	<xsd:element name="PointOnSection_Dummy" type="PointInLinkSequence_VersionedChildStructure" abstract="true" substitutionGroup="PointInLinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>DUmmy Supertype for Point On SECTION. +v1.1.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="PointOnSection" substitutionGroup="PointOnSection_">
+	<xsd:element name="PointOnSection" substitutionGroup="PointOnSection_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>POINT on a SECTION. +v1.1.</xsd:documentation>
 		</xsd:annotation>
@@ -449,7 +449,7 @@ Rail transport, Roads and Road transport
 						<xsd:documentation>Reference to a LINK SEQUENCE.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
-				<xsd:element ref="Section_"/>
+				<xsd:element ref="Section_Dummy"/>
 			</xsd:choice>
 		</xsd:sequence>
 	</xsd:group>

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_support.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_support.xsd
@@ -60,7 +60,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfPointsIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="ZoneRef" type="ZoneRefStructure" substitutionGroup="GroupOfPointsRef_">
+	<xsd:element name="ZoneRef" type="ZoneRefStructure" substitutionGroup="GroupOfPointsRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a ZONE.</xsd:documentation>
 		</xsd:annotation>
@@ -83,7 +83,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==== TARIFF ZONE ======================================================== -->
-	<xsd:element name="TariffZoneRef_" type="ZoneRefStructure" abstract="true" substitutionGroup="ZoneRef">
+	<xsd:element name="TariffZoneRef_Dummy" type="ZoneRefStructure" abstract="true" substitutionGroup="ZoneRef">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type Reference to a TARIFF ZONE.</xsd:documentation>
 		</xsd:annotation>
@@ -94,7 +94,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ZoneIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TariffZoneRef" substitutionGroup="TariffZoneRef_">
+	<xsd:element name="TariffZoneRef" substitutionGroup="TariffZoneRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TARIFF ZONE.</xsd:documentation>
 		</xsd:annotation>
@@ -119,7 +119,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="oneToManyRelationshipStructure">
 				<xsd:sequence>
-					<xsd:element ref="TariffZoneRef_" maxOccurs="unbounded"/>
+					<xsd:element ref="TariffZoneRef_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_zone_version.xsd
@@ -87,7 +87,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="TariffZone_" maxOccurs="unbounded"/>
+					<xsd:element ref="TariffZone_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -183,12 +183,12 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TariffZone_" type="Zone_VersionStructure" abstract="true" substitutionGroup="Zone">
+	<xsd:element name="TariffZone_Dummy" type="Zone_VersionStructure" abstract="true" substitutionGroup="Zone">
 		<xsd:annotation>
 			<xsd:documentation>Dummy TARIFF ZONE to workaround xML spy Substitution Group limitations</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="TariffZone" substitutionGroup="TariffZone_">
+	<xsd:element name="TariffZone" substitutionGroup="TariffZone_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A ZONE used to define a zonal fare structure in a zone-counting or zone-matrix system.</xsd:documentation>
 		</xsd:annotation>
@@ -309,7 +309,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="GroupOfTariffZonesRef" type="GroupOfTariffZonesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfTariffZonesRef" type="GroupOfTariffZonesRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF TARIFF ZONEs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_responsibility_support.xsd
@@ -202,7 +202,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="oneToManyRelationshipStructure">
 				<xsd:sequence>
-					<xsd:element ref="OrganisationRef_" maxOccurs="unbounded"/>
+					<xsd:element ref="OrganisationRef_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -213,12 +213,12 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="OrganisationRef_" type="OrganisationRefStructure" abstract="true" substitutionGroup="VersionOfObjectRef">
+	<xsd:element name="OrganisationRef_Dummy" type="OrganisationRefStructure" abstract="true" substitutionGroup="VersionOfObjectRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="OrganisationRef" type="OrganisationRefStructure" substitutionGroup="OrganisationRef_">
+	<xsd:element name="OrganisationRef" type="OrganisationRefStructure" substitutionGroup="OrganisationRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>DEPRECATED reference to any ORGANISATION meeting the substitutiongroup. -v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -256,7 +256,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:choice>
 			<xsd:element ref="AllOrganisationsRef"/>
-			<xsd:element ref="OrganisationRef_"/>
+			<xsd:element ref="OrganisationRef_Dummy"/>
 		</xsd:choice>
 	</xsd:group>
 	<!-- ======================================================================= -->

--- a/xsd/netex_framework/netex_responsibility/netex_validityCondition_version.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_validityCondition_version.xsd
@@ -68,19 +68,19 @@ Rail transport, Roads and Road transport
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="ValidityConditionRef"/>
 					<xsd:element ref="ValidBetween"/>
-					<xsd:element ref="ValidityCondition_"/>
+					<xsd:element ref="ValidityCondition_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ValidityCondition_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="ValidityCondition_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Condition used in order to characterise a given VERSION of a VERSION FRAME. A VALIDITY CONDITION consists of a parameter (e.g. date, triggering event, etc) and its type of application (e.g. for, from, until, etc.).</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<!-- ======================================================================= -->
-	<xsd:element name="ValidityCondition" substitutionGroup="ValidityCondition_">
+	<xsd:element name="ValidityCondition" substitutionGroup="ValidityCondition_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Condition used in order to characterise a given VERSION of a VERSION FRAME. A VALIDITY CONDITION consists of a parameter (e.g. date, triggering event, etc) and its type of application (e.g. for, from, until, etc.).</xsd:documentation>
 		</xsd:annotation>
@@ -173,7 +173,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ValidityTrigger" substitutionGroup="ValidityCondition_">
+	<xsd:element name="ValidityTrigger" substitutionGroup="ValidityCondition_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>External event defining a VALIDITY CONDITION. E.g. exceptional flow of a river, bad weather, Road closure for works.</xsd:documentation>
 		</xsd:annotation>
@@ -261,7 +261,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ValidityRuleParameter" substitutionGroup="ValidityCondition_">
+	<xsd:element name="ValidityRuleParameter" substitutionGroup="ValidityCondition_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A user defined VALIDITY CONDITION used by a rule for selecting versions. E.g. river level &gt; 1,5 m and bad weather.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_address_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_address_support.xsd
@@ -65,7 +65,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PlaceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="AddressRef" type="AddressRefStructure" substitutionGroup="PlaceRef_">
+	<xsd:element name="AddressRef" type="AddressRefStructure" substitutionGroup="PlaceRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an ADDRESS.</xsd:documentation>
 		</xsd:annotation>
@@ -91,7 +91,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PlaceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="AddressablePlaceRef" type="AddressablePlaceRefStructure" substitutionGroup="PlaceRef_">
+	<xsd:element name="AddressablePlaceRef" type="AddressablePlaceRefStructure" substitutionGroup="PlaceRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an ADDRESSED PLACE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_availabilityCondition_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_availabilityCondition_version.xsd
@@ -86,7 +86,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="AvailabilityCondition" substitutionGroup="ValidityCondition_">
+	<xsd:element name="AvailabilityCondition" substitutionGroup="ValidityCondition_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>VALIDITY CONDITION stated in terms of DAY TYPES and PROPERTIES OF DAYs.</xsd:documentation>
 		</xsd:annotation>
@@ -185,7 +185,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===A simple availability condition==================================================================== -->
-	<xsd:element name="ValidDuring" substitutionGroup="ValidityCondition_">
+	<xsd:element name="ValidDuring" substitutionGroup="ValidityCondition_Dummy">
 		<xsd:annotation>
 			<xsd:documentation> OPTIMISATION: Sversion of an AVAILABILITY CONDITION Comprises a simple period and DAY TYPE.</xsd:documentation>
 		</xsd:annotation>
@@ -285,7 +285,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===ALIAS As (DEPRECATED)======================================================== -->
-	<xsd:element name="SimpleAvailabilityCondition" substitutionGroup="ValidityCondition_">
+	<xsd:element name="SimpleAvailabilityCondition" substitutionGroup="ValidityCondition_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Simple version of an AVAILABILITY CONDITION used in order to characterise a given VERSION of a VERSION FRAME. Comprises a simple period and DAY TYPE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_dayType_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_dayType_support.xsd
@@ -139,7 +139,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfTimebandsRef" type="GroupOfTimebandsRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfTimebandsRef" type="GroupOfTimebandsRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF TIMEBANDs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_dayType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_dayType_version.xsd
@@ -69,7 +69,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="DayType_" maxOccurs="unbounded"/>
+					<xsd:element ref="DayType_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -107,7 +107,7 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="DayTypeRef"/>
-					<xsd:element ref="DayType_">
+					<xsd:element ref="DayType_Dummy">
 						<xsd:annotation>
 							<xsd:documentation>A type of day characterized by one or more properties which affect public transport operation. For example: weekday in school holidays.</xsd:documentation>
 						</xsd:annotation>
@@ -116,12 +116,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DayType_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="DayType_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Supertype for DAY TYPE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="DayType" substitutionGroup="DayType_">
+	<xsd:element name="DayType" substitutionGroup="DayType_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A type of day characterized by one or more properties which affect public transport operation. For example: weekday in school holidays.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -311,12 +311,12 @@
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="DeckSpaceRef"/>
-					<xsd:element ref="DeckSpace_"/>
+					<xsd:element ref="DeckSpace_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DeckSpace_" type="DeckComponent_VersionStructure" abstract="true" substitutionGroup="DeckComponent">
+	<xsd:element name="DeckSpace_Dummy" type="DeckComponent_VersionStructure" abstract="true" substitutionGroup="DeckComponent">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type to work around SG limitations</xsd:documentation>
 		</xsd:annotation>
@@ -454,7 +454,7 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PassengerSpace" substitutionGroup="DeckSpace_">
+	<xsd:element name="PassengerSpace" substitutionGroup="DeckSpace_Dummy">
 		<xsd:annotation>
 			<xsd:documentation> A specialisation of DECK SPACE defining an area within a VEHICLE (i.e. bus, boat, coach, car) or TRAIN ELEMENT for use by passengers. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -561,7 +561,7 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="OtherDeckSpace" substitutionGroup="DeckSpace_">
+	<xsd:element name="OtherDeckSpace" substitutionGroup="DeckSpace_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A specialisation of DECK SPACE defining an area within a VEHICLE (i.e. bus, boat, coach, car) or TRAIN ELEMENT for restricted use, such as a crew area. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -624,7 +624,7 @@
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ====== DECK ENTRANCE =================================== -->
-	<xsd:element name="DeckEntrance_" type="DeckComponent_VersionStructure" abstract="true" substitutionGroup="DeckComponent">
+	<xsd:element name="DeckEntrance_Dummy" type="DeckComponent_VersionStructure" abstract="true" substitutionGroup="DeckComponent">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type to work around SG limitations</xsd:documentation>
 		</xsd:annotation>
@@ -637,7 +637,7 @@
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="DeckEntranceRef"/>
-					<xsd:element ref="DeckEntrance_"/>
+					<xsd:element ref="DeckEntrance_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -769,7 +769,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== PASSENGER  ENTRANCE =================================== -->
-	<xsd:element name="PassengerEntrance" substitutionGroup="DeckEntrance_">
+	<xsd:element name="PassengerEntrance" substitutionGroup="DeckEntrance_Dummy">
 		<xsd:annotation>
 			<xsd:documentation> A normal entrance for passengers to or within a DECK. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -832,7 +832,7 @@
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ====== DECK VEHICLE  ENTRANCE =================================== -->
-	<xsd:element name="DeckVehicleEntrance" substitutionGroup="DeckEntrance_">
+	<xsd:element name="DeckVehicleEntrance" substitutionGroup="DeckEntrance_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A normal entrance for passengers to or within a DECK. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -906,7 +906,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== OTHER DECK ENTRANCE =================================== -->
-	<xsd:element name="OtherDeckEntrance" substitutionGroup="DeckEntrance_">
+	<xsd:element name="OtherDeckEntrance" substitutionGroup="DeckEntrance_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An entrance to or within a DECK for use for other purposes than normal passenger access. E.g. crew, emergency exit, etc. +v2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipment_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipment_support.xsd
@@ -139,7 +139,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PlaceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="EquipmentPositionRef" type="EquipmentPositionRefStructure" substitutionGroup="PlaceRef_">
+	<xsd:element name="EquipmentPositionRef" type="EquipmentPositionRefStructure" substitutionGroup="PlaceRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an EQUIPMENT POSITION.</xsd:documentation>
 		</xsd:annotation>
@@ -165,7 +165,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PlaceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="EquipmentPlaceRef" type="EquipmentPlaceRefStructure" substitutionGroup="PlaceRef_">
+	<xsd:element name="EquipmentPlaceRef" type="EquipmentPlaceRefStructure" substitutionGroup="PlaceRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an EQUIPMENT PLACE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_version.xsd
@@ -61,17 +61,17 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="ModeOfOperation_" maxOccurs="unbounded"/>
+					<xsd:element ref="ModeOfOperation_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ModeOfOperation_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="ModeOfOperation_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type to work around SG limitations.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ModeOfOperation" abstract="true" substitutionGroup="ModeOfOperation_">
+	<xsd:element name="ModeOfOperation" abstract="true" substitutionGroup="ModeOfOperation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The use of any kind of vehicle to perform a trip using any mode of operation, this can be a CONVENTIONAL, ALTERNATIVE or a PERSONAL MODE OF OPERATION. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -128,12 +128,12 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ===== CONVENTIONAL MODEs ================================================= -->
-	<xsd:element name="ConventionalModeOfOperation_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="ModeOfOperation_">
+	<xsd:element name="ConventionalModeOfOperation_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="ModeOfOperation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type to work around SG limitations.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ConventionalModeOfOperation" abstract="true" substitutionGroup="ModeOfOperation_">
+	<xsd:element name="ConventionalModeOfOperation" abstract="true" substitutionGroup="ModeOfOperation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Legacy mode of operation which is provided as a scheduled and/or flexible publicly advertised transport offer. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -172,7 +172,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ScheduledOperation" substitutionGroup="ConventionalModeOfOperation_">
+	<xsd:element name="ScheduledOperation" substitutionGroup="ConventionalModeOfOperation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The operation of a transportation using any kind of vehicle with a predefined time table. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -226,7 +226,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="FlexibleOperation" substitutionGroup="ConventionalModeOfOperation_">
+	<xsd:element name="FlexibleOperation" substitutionGroup="ConventionalModeOfOperation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Passenger transport operation linked to a fixed network/schedule but offering flexibility, in order for instance, to optimise the service or to satisfy passenger demand. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -260,12 +260,12 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ====== ALTERNATIVE MODEs =================================================== -->
-	<xsd:element name="AlternativeModeOfOperation_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="ModeOfOperation_">
+	<xsd:element name="AlternativeModeOfOperation_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="ModeOfOperation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type to work around SG limitations.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="AlternativeModeOfOperation" substitutionGroup="ModeOfOperation_">
+	<xsd:element name="AlternativeModeOfOperation" substitutionGroup="ModeOfOperation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Any publicly advertised mode of operation different from the CONVENTIONAL MODE OF OPERATION, for example: VEHICLE SHARING, VEHICLE RENTAL, VEHICLE POOLING. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -304,7 +304,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="VehicleRental" substitutionGroup="AlternativeModeOfOperation_">
+	<xsd:element name="VehicleRental" substitutionGroup="AlternativeModeOfOperation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An ALTERNATIVE MODE OF OPERATION of a vehicle, part of a FLEET (in general privately owned), available for use for a certain period of time and fee, with the constraint to bring it back at specified agencies. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -358,7 +358,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="VehicleSharing" substitutionGroup="AlternativeModeOfOperation_">
+	<xsd:element name="VehicleSharing" substitutionGroup="AlternativeModeOfOperation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Short term VEHICLE RENTAL where the vehicle can be taken from and parked at different places in the urban area, possibly without the constraint to bring back the vehicle to a specific location. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -418,7 +418,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="VehiclePooling" substitutionGroup="AlternativeModeOfOperation_">
+	<xsd:element name="VehiclePooling" substitutionGroup="AlternativeModeOfOperation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An ALTERNATIVE MODE OF OPERATION of a privately-owned vehicle consisting in sharing the vehicle for a trip between the driver who is at the same time performing a trip and at least another traveller. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -478,7 +478,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ====== PERSONAL MODEs  ============================================ -->
-	<xsd:element name="PersonalModeOfOperation" substitutionGroup="ModeOfOperation_">
+	<xsd:element name="PersonalModeOfOperation" substitutionGroup="ModeOfOperation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A non-advertised mode of operation of vehicles by persons using their own vehicle. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_nm_fleet_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_nm_fleet_support.xsd
@@ -75,7 +75,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="FleetRef" type="FleetRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="FleetRef" type="FleetRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a FLEET. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_noticeAssignment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_noticeAssignment_version.xsd
@@ -67,7 +67,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="NoticeAssignment_" maxOccurs="unbounded"/>
+					<xsd:element ref="NoticeAssignment_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -97,18 +97,18 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
-					<xsd:element ref="NoticeAssignment_" maxOccurs="1"/>
+					<xsd:element ref="NoticeAssignment_Dummy" maxOccurs="1"/>
 					<xsd:element ref="NoticeAssignmentView"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="NoticeAssignment_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="Assignment_">
+	<xsd:element name="NoticeAssignment_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy abstract NOTICE ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="NoticeAssignment" substitutionGroup="NoticeAssignment_">
+	<xsd:element name="NoticeAssignment" substitutionGroup="NoticeAssignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a NOTICE showing an exception in a JOURNEY PATTERN, a COMMON SECTION, or a VEHICLE JOURNEY, possibly specifying at which POINT IN JOURNEY PATTERN the validity of the NOTICE starts and ends respectively.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_otherOrganisation_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_otherOrganisation_support.xsd
@@ -58,7 +58,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="OrganisationIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="OtherOrganisationRef" type="OtherOrganisationRefStructure" substitutionGroup="OrganisationRef_">
+	<xsd:element name="OtherOrganisationRef" type="OtherOrganisationRefStructure" substitutionGroup="OrganisationRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an OTHER ORGANISATION.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_otherOrganisation_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_otherOrganisation_version.xsd
@@ -55,7 +55,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NetEX:OTHER ORGANISATION types for NeTEx Network Exchange.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<xsd:element name="OtherOrganisation" substitutionGroup="Organisation_">
+	<xsd:element name="OtherOrganisation" substitutionGroup="Organisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Generic ORGANISATION being neither an AUTHORITY, neither a public transport OPERATOR (TRAVEL AGENT, MANAGEMENT AGENT, etc.).</xsd:documentation>
 		</xsd:annotation>
@@ -90,7 +90,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TravelAgent" substitutionGroup="Organisation_">
+	<xsd:element name="TravelAgent" substitutionGroup="Organisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A travel agent who can retail travel products.</xsd:documentation>
 		</xsd:annotation>
@@ -133,7 +133,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ManagementAgent" substitutionGroup="Organisation_">
+	<xsd:element name="ManagementAgent" substitutionGroup="Organisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>ORGANISATION that manages data or a SITE or FACILITY.</xsd:documentation>
 		</xsd:annotation>
@@ -176,7 +176,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="GeneralOrganisation" substitutionGroup="Organisation_">
+	<xsd:element name="GeneralOrganisation" substitutionGroup="Organisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Any type of GENERAL ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
@@ -215,7 +215,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="ServicedOrganisation" substitutionGroup="Organisation_">
+	<xsd:element name="ServicedOrganisation" substitutionGroup="Organisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>ORGANISATION for which Service is provided, e.g. school college.</xsd:documentation>
 		</xsd:annotation>
@@ -274,7 +274,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="OrganisationDayType" substitutionGroup="DayType_">
+	<xsd:element name="OrganisationDayType" substitutionGroup="DayType_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>DAY TYPE defined as being available on days when ORGANISATION is open and requires service.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_securityList_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_securityList_version.xsd
@@ -169,7 +169,7 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfSecurityListRef" minOccurs="0"/>
-			<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 			<xsd:element name="securityListings" type="securityListings_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Items in SECURITY LIST.</xsd:documentation>
@@ -185,17 +185,17 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="SecurityListing_" maxOccurs="unbounded"/>
+					<xsd:element ref="SecurityListing_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SecurityListing_" type="VersionedChildStructure" abstract="true" substitutionGroup="VersionedChild">
+	<xsd:element name="SecurityListing_Dummy" type="VersionedChildStructure" abstract="true" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>DUMMY type for SECIRITY LISTING.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="SecurityListing" abstract="true" substitutionGroup="SecurityListing_">
+	<xsd:element name="SecurityListing" abstract="true" substitutionGroup="SecurityListing_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The presence of an identified Entity on a SECURITY LIST.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_sensorEquipment_version.xsd
@@ -60,7 +60,7 @@
 		<xsd:documentation>SENSOR EQUIPMENT types for NeTEx.</xsd:documentation>
 	</xsd:annotation>
 	<!-- === SENSOR EQUIPMENT ============================================ -->
-	<xsd:element name="SensorEquipment_" abstract="true" substitutionGroup="InstalledEquipment">
+	<xsd:element name="SensorEquipment_Dummy" abstract="true" substitutionGroup="InstalledEquipment">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type for +V2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_version.xsd
@@ -385,12 +385,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="OperatingPeriod_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="OperatingPeriod_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Operating Period</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="OperatingPeriod" substitutionGroup="OperatingPeriod_">
+	<xsd:element name="OperatingPeriod" substitutionGroup="OperatingPeriod_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A continuous interval of time between two OPERATING DAYs which will be used to define validities.</xsd:documentation>
 		</xsd:annotation>
@@ -482,7 +482,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="UicOperatingPeriod" substitutionGroup="OperatingPeriod_">
+	<xsd:element name="UicOperatingPeriod" substitutionGroup="OperatingPeriod_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An OPERATING PERIOD coded in UIC style as a bit string between two dates.</xsd:documentation>
 		</xsd:annotation>
@@ -555,7 +555,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DayTypeAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="DayTypeAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Associates a DAY TYPE with an OPERATING DAY within a specific Calendar. A specification of a particular DAY TYPE which will be valid during a TIME BAND on an OPERATING DAY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_spotEquipment_version.xsd
@@ -56,7 +56,7 @@
 		<xsd:documentation>SPOT EQUIPMENT types for NeTEx.</xsd:documentation>
 	</xsd:annotation>
 	<!-- === SPOT EQUIPMENT ============================================ -->
-	<xsd:element name="SpotEquipment_" abstract="true" substitutionGroup="InstalledEquipment">
+	<xsd:element name="SpotEquipment_Dummy" abstract="true" substitutionGroup="InstalledEquipment">
 		<xsd:annotation>
 			<xsd:documentation>An abstract EQUIPMENT in a LOCATABLE SPOT providing a onboard seat, bed or other amenity. +V2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_topographicPlace_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_topographicPlace_support.xsd
@@ -152,7 +152,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PlaceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="TopographicPlaceRef" type="TopographicPlaceRefStructure" substitutionGroup="PlaceRef_">
+	<xsd:element name="TopographicPlaceRef" type="TopographicPlaceRefStructure" substitutionGroup="PlaceRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation> Reference to a TOPOGRAPHIC PLACE.</xsd:documentation>
 		</xsd:annotation>
@@ -195,7 +195,7 @@ Rail transport, Roads and Road transport
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
 	<!-- ==  GROUP OF PLACEs ============================================== -->
-	<xsd:element name="GroupOfPlacesRef" type="GroupOfPlacesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfPlacesRef" type="GroupOfPlacesRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF PLACEs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_support.xsd
@@ -92,7 +92,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TransportOrganisationRef" type="TransportOrganisationRefStructure" abstract="true" substitutionGroup="OrganisationRef_">
+	<xsd:element name="TransportOrganisationRef" type="TransportOrganisationRefStructure" abstract="true" substitutionGroup="OrganisationRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a TRANSPORT ORGANISATION.</xsd:documentation>
 		</xsd:annotation>
@@ -250,7 +250,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfOperatorsRef" type="GroupOfOperatorsRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfOperatorsRef" type="GroupOfOperatorsRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF OPERATORs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_version.xsd
@@ -163,13 +163,13 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TransportOrganisation_" type="Organisation_VersionStructure" abstract="true" substitutionGroup="Organisation_">
+	<xsd:element name="TransportOrganisation_Dummy" type="Organisation_VersionStructure" abstract="true" substitutionGroup="Organisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A company providing public transport services.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<!-- ==== PUBLIC TRANSPORT ORGANISATION ================================================== -->
-	<xsd:element name="TransportOrganisation" abstract="true" substitutionGroup="TransportOrganisation_">
+	<xsd:element name="TransportOrganisation" abstract="true" substitutionGroup="TransportOrganisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A company providing transport services.</xsd:documentation>
 		</xsd:annotation>
@@ -286,7 +286,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== OPERATOR ========================================================= -->
-	<xsd:element name="Operator" substitutionGroup="TransportOrganisation_">
+	<xsd:element name="Operator" substitutionGroup="TransportOrganisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A company providing public transport services.</xsd:documentation>
 		</xsd:annotation>
@@ -331,7 +331,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ===== AUTHORITY ========================================================== -->
-	<xsd:element name="Authority" substitutionGroup="TransportOrganisation_">
+	<xsd:element name="Authority" substitutionGroup="TransportOrganisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The ORGANISATION under which the responsibility of organising the transport service in a certain area is placed.</xsd:documentation>
 		</xsd:annotation>
@@ -519,7 +519,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== OPERATOR DEPARTMENT t========================================================= -->
-	<xsd:element name="OperatingDepartment" substitutionGroup="OrganisationPart_">
+	<xsd:element name="OperatingDepartment" substitutionGroup="OrganisationPart_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A specific DEPARTMENT which administers certain LINEs.</xsd:documentation>
 		</xsd:annotation>
@@ -614,7 +614,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ControlCentre" substitutionGroup="OrganisationPart_">
+	<xsd:element name="ControlCentre" substitutionGroup="OrganisationPart_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An ORGANISATION PART for an operational team who are responsible for issuing commands to control the services.</xsd:documentation>
 		</xsd:annotation>
@@ -675,7 +675,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===== TRANSPORT ADMINISTRATIVE ZONE ================================================ -->
-	<xsd:element name="TransportAdministrativeZone" substitutionGroup="AdministrativeZone_">
+	<xsd:element name="TransportAdministrativeZone" substitutionGroup="AdministrativeZone_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A ZONE relating to the management responsibilities of an ORGANISATION. For example to allocate bus stop identifiers for a region.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_checkConstraint_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_checkConstraint_version.xsd
@@ -143,7 +143,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CheckConstraint" substitutionGroup="Assignment_">
+	<xsd:element name="CheckConstraint" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Characteristics of a SITE COMPONENT representing a process, such as check-in, security
 screening, ticket control or immigration, that may potentially incur a time penalty that should be allowed for when journey planning. Used to mark PATH LINKs to determine transit routes through interchanges.</xsd:documentation>
@@ -277,7 +277,7 @@ screening, ticket control or immigration, that may potentially incur a time pena
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CheckConstraintDelay" substitutionGroup="Assignment_">
+	<xsd:element name="CheckConstraintDelay" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Time penalty associated with a CHECK CONSTRAINT.</xsd:documentation>
 		</xsd:annotation>
@@ -367,7 +367,7 @@ screening, ticket control or immigration, that may potentially incur a time pena
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CheckConstraintThroughput" substitutionGroup="Assignment_">
+	<xsd:element name="CheckConstraintThroughput" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Throughput of a CHECK CONSTRAINT. the number of passengers who can pass through it.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_flexibleStopPlace_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_flexibleStopPlace_support.xsd
@@ -63,7 +63,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PlaceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="FlexibleStopPlaceRef" type="FlexibleStopPlaceRefStructure" substitutionGroup="PlaceRef_">
+	<xsd:element name="FlexibleStopPlaceRef" type="FlexibleStopPlaceRefStructure" substitutionGroup="PlaceRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a FLEXIBLE STOP PLACE.</xsd:documentation>
 		</xsd:annotation>
@@ -101,7 +101,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="PlaceIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="FlexibleQuayRef" type="FlexibleQuayRefStructure" substitutionGroup="PlaceRef_">
+	<xsd:element name="FlexibleQuayRef" type="FlexibleQuayRefStructure" substitutionGroup="PlaceRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a FLEXIBLE QUAY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_parking_version.xsd
@@ -83,7 +83,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="Parking_" maxOccurs="unbounded">
+					<xsd:element ref="Parking_Dummy" maxOccurs="unbounded">
 						<xsd:annotation>
 							<xsd:documentation>A designated path between two PLACEs. May include an Ordered sequence of references to PATH LINKS.</xsd:documentation>
 						</xsd:annotation>
@@ -93,7 +93,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="Parking" substitutionGroup="Parking_">
+	<xsd:element name="Parking" substitutionGroup="Parking_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A named place where Parking may be accessed. May be a building complex (e.g. a station) or an on-street location.</xsd:documentation>
 		</xsd:annotation>
@@ -867,7 +867,7 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="ParkingAreaRef"/>
-					<xsd:element ref="ParkingArea_">
+					<xsd:element ref="ParkingArea_Dummy">
 						<xsd:annotation>
 							<xsd:documentation>An area within a Site. May be connected to Quays by PATH LINKs.</xsd:documentation>
 						</xsd:annotation>
@@ -876,7 +876,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ParkingArea" substitutionGroup="ParkingArea_">
+	<xsd:element name="ParkingArea" substitutionGroup="ParkingArea_Dummy">
 		<xsd:annotation>
 			<xsd:documentation> Area within a PARKING.</xsd:documentation>
 		</xsd:annotation>
@@ -975,7 +975,7 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="ParkingBayRef"/>
-					<xsd:element ref="ParkingBay_">
+					<xsd:element ref="ParkingBay_Dummy">
 						<xsd:annotation>
 							<xsd:documentation>An area within a Site. May be connected to Quays by PATH LINKs.</xsd:documentation>
 						</xsd:annotation>
@@ -984,7 +984,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ParkingBay" substitutionGroup="ParkingBay_">
+	<xsd:element name="ParkingBay" substitutionGroup="ParkingBay_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An individual place to park a VEHICLE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_pointOfInterest_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_pointOfInterest_support.xsd
@@ -135,7 +135,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PointOfInterestHierarchyRef" type="PointOfInterestHierarchyRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="PointOfInterestHierarchyRef" type="PointOfInterestHierarchyRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Classification of a POINT OF INTEREST CLASSIFICATION HIERARCHY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_support.xsd
@@ -65,7 +65,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: SITE identifier types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ==  GROUP OF SITEs ============================================== -->
-	<xsd:element name="GroupOfSitesRef" type="GroupOfSitesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfSitesRef" type="GroupOfSitesRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF SITEs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_site_version.xsd
@@ -210,7 +210,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element ref="Locale" minOccurs="0"/>
 			<xsd:choice minOccurs="0">
-				<xsd:element ref="OrganisationRef_"/>
+				<xsd:element ref="OrganisationRef_Dummy"/>
 				<xsd:element name="OperatingOrganisationView" type="Organisation_DerivedViewStructure">
 					<xsd:annotation>
 						<xsd:documentation>Reference to OPERATOR of SITE - derived details can be included.</xsd:documentation>
@@ -944,27 +944,27 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ===DUMMY TYPES======================================================= -->
-	<xsd:element name="ParkingBay_" type="SiteComponent_VersionStructure" abstract="true" substitutionGroup="SiteComponent">
+	<xsd:element name="ParkingBay_Dummy" type="SiteComponent_VersionStructure" abstract="true" substitutionGroup="SiteComponent">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Type to get round SG limitations</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ParkingArea_" type="SiteComponent_VersionStructure" abstract="true" substitutionGroup="SiteComponent">
+	<xsd:element name="ParkingArea_Dummy" type="SiteComponent_VersionStructure" abstract="true" substitutionGroup="SiteComponent">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Type to get round SG limitations</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="StopPlace_" type="Site_VersionStructure" abstract="true" substitutionGroup="Site">
+	<xsd:element name="StopPlace_Dummy" type="Site_VersionStructure" abstract="true" substitutionGroup="Site">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Type to get round SG limitations. Can be a STOP PLACE, VEHICLE MEETING POINT, TAXI RANK.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Quay_" type="Site_VersionStructure" abstract="true" substitutionGroup="Site">
+	<xsd:element name="Quay_Dummy" type="Site_VersionStructure" abstract="true" substitutionGroup="Site">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Type to get round SG limitations</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Parking_" type="Site_VersionStructure" abstract="true" substitutionGroup="Site">
+	<xsd:element name="Parking_Dummy" type="Site_VersionStructure" abstract="true" substitutionGroup="Site">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Type to get round SG limitations</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_support.xsd
@@ -109,7 +109,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="SiteComponentIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfStopPlacesRef" type="GroupOfStopPlacesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfStopPlacesRef" type="GroupOfStopPlacesRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF STOP PLACEs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_stopPlace_version.xsd
@@ -149,7 +149,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="StopPlace" substitutionGroup="StopPlace_">
+	<xsd:element name="StopPlace" substitutionGroup="StopPlace_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Version of a named place where public transport may be accessed. May be a building complex (e.g. a station) or an on-street location. Can be a STOP PLACE, VEHICLE MEETING POINT, TAXI RANK. Note: If a master id exists for a StopPlace (must be stable and globally unique), then it is best used in the id. Optimally it would be built according IFOPT. It can also be put into one of the privateCodes in addition. If it is stored in KeyValue, then it should be documented well, so that importing systems know, which id is the relevant one.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_rechargingPointAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_rechargingPointAssignment_version.xsd
@@ -91,7 +91,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RechargingPointAssignment" type="RechargingPointAssignment_VersionStructure" substitutionGroup="Assignment_">
+	<xsd:element name="RechargingPointAssignment" type="RechargingPointAssignment_VersionStructure" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a TIMING POINT to a SITE COMPONENT such as a PARKING BAY that has VEHICLE CHARGING EQUIPMENT. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -138,7 +138,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RechargingStation" substitutionGroup="Parking_">
+	<xsd:element name="RechargingStation" substitutionGroup="Parking_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A PARKING with bays specifically equipped for recharging VEHICLEs. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -222,7 +222,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RechargingBay" substitutionGroup="ParkingBay_">
+	<xsd:element name="RechargingBay" substitutionGroup="ParkingBay_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A PARKING BAY specifically equipped for recharging VEHICLEs. +v2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_ifopt/netex_taxiPlace_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_taxiPlace_version.xsd
@@ -76,7 +76,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TaxiRank" substitutionGroup="StopPlace_">
+	<xsd:element name="TaxiRank" substitutionGroup="StopPlace_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A place comprising one or more locations where taxis may stop to pick up or set down passengers. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -263,7 +263,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== TAXI PARKING AREA  ============================================================ -->
-	<xsd:element name="TaxiParkingArea" substitutionGroup="ParkingArea_">
+	<xsd:element name="TaxiParkingArea" substitutionGroup="ParkingArea_Dummy">
 		<xsd:annotation>
 			<xsd:documentation> A specific area where any taxi is able to safely park for a long period. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_activation_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_activation_version.xsd
@@ -127,7 +127,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="ActivationPoint_" maxOccurs="unbounded"/>
+					<xsd:element ref="ActivationPoint_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -199,12 +199,12 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ================================================================ -->
-	<xsd:element name="ActivationPoint_" type="Point_VersionStructure" abstract="true" substitutionGroup="Point">
+	<xsd:element name="ActivationPoint_Dummy" type="Point_VersionStructure" abstract="true" substitutionGroup="Point">
 		<xsd:annotation>
 			<xsd:documentation>A POINT where a control process is activated when a vehicle passes it. EQUIPMENT may be needed for the activation.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ActivationPoint" substitutionGroup="ActivationPoint_">
+	<xsd:element name="ActivationPoint" substitutionGroup="ActivationPoint_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A POINT where a control process is activated when a vehicle passes it. EQUIPMENT may be needed for the activation.</xsd:documentation>
 		</xsd:annotation>
@@ -266,7 +266,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ================================================================== -->
-	<xsd:element name="BeaconPoint" substitutionGroup="ActivationPoint_">
+	<xsd:element name="BeaconPoint" substitutionGroup="ActivationPoint_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A POINT where a beacon or similar device to support the automatic detection of vehicles passing by is located.</xsd:documentation>
 		</xsd:annotation>
@@ -416,7 +416,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ActivationAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="ActivationAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An assignment of an ACTIVATION POINT/LINK to an ACTIVATED EQUIPMENT related on its turn to a TRAFFIC CONTROL POINT. The considered ACTIVATION POINT/LINK will be used to influence the control process for that TRAFFIC CONTROL POINT (e.g. to fix priorities as regards the processing of competing requests from different ACTIVATION POINTs/LINKs).</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_flexibleNetwork_version.xsd
@@ -44,7 +44,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="FlexibleLine" substitutionGroup="Line_">
+	<xsd:element name="FlexibleLine" substitutionGroup="Line_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A group of FLEXIBLE ROUTEs of which is generally known to the public by a similar name or number and which have common booking arrangements. DEPRECATED: please use LINE instead. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -101,7 +101,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==FlexibleRoute============================================================ -->
-	<xsd:element name="FlexibleRoute" substitutionGroup="Route_">
+	<xsd:element name="FlexibleRoute" substitutionGroup="Route_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Specialisation of ROUTE for flexible service. May include both point and zonal areas and ordered and unordered sections.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_lineNetwork_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_lineNetwork_version.xsd
@@ -168,7 +168,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="LineSection" substitutionGroup="Section_">
+	<xsd:element name="LineSection" substitutionGroup="Section_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A section of a LINE NETWORK comprising an edge between two nodes. Not directional.</xsd:documentation>
 		</xsd:annotation>
@@ -260,7 +260,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PointOnLineSection" substitutionGroup="PointOnSection_">
+	<xsd:element name="PointOnLineSection" substitutionGroup="PointOnSection_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Inclusion of a POINT on a LINE SECTION. +v1.1</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_line_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_support.xsd
@@ -36,7 +36,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEx LINE identifier Type Definitions.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ==  GROUP OF LINEs ============================================== -->
-	<xsd:element name="GroupOfLinesRef" type="GroupOfLinesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfLinesRef" type="GroupOfLinesRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF LINEs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
@@ -274,17 +274,17 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="Line_" maxOccurs="unbounded"/>
+					<xsd:element ref="Line_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Line_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="Line_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Supertype for LINE &amp; FLEXIBLE LINe.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Line" substitutionGroup="Line_" id="Line">
+	<xsd:element name="Line" substitutionGroup="Line_Dummy" id="Line">
 		<xsd:annotation>
 			<xsd:documentation>A group of ROUTEs which is generally known to the public by a similar name or number.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_version.xsd
@@ -236,7 +236,7 @@ Rail transport, Roads and ROAD transport
 	</xsd:complexType>
 	<!-- ======================================================================= -->
 	<!-- ====Links========================================================== -->
-	<xsd:element name="InfrastructureLink_" type="Link_VersionStructure" abstract="true" substitutionGroup="Link">
+	<xsd:element name="InfrastructureLink_Dummy" type="Link_VersionStructure" abstract="true" substitutionGroup="Link">
 		<xsd:annotation>
 			<xsd:documentation>A Dummy Supertype for Infrastructure Link Types.</xsd:documentation>
 		</xsd:annotation>
@@ -272,7 +272,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====Railway ============================================================ -->
-	<xsd:element name="RailwayElement" substitutionGroup="InfrastructureLink_">
+	<xsd:element name="RailwayElement" substitutionGroup="InfrastructureLink_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A type of INFRASTRUCTURE LINK used to describe a RAILWAY network.</xsd:documentation>
 		</xsd:annotation>
@@ -330,7 +330,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- === Road============================================================== -->
-	<xsd:element name="RoadElement" substitutionGroup="InfrastructureLink_">
+	<xsd:element name="RoadElement" substitutionGroup="InfrastructureLink_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A type of INFRASTRUCTURE LINK used to describe a ROAD network.</xsd:documentation>
 		</xsd:annotation>
@@ -388,7 +388,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====Wire=============================================================== -->
-	<xsd:element name="WireElement" substitutionGroup="InfrastructureLink_">
+	<xsd:element name="WireElement" substitutionGroup="InfrastructureLink_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A type of INFRASTRUCTURE LINK used to describe a WIRE network.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_networkRestriction_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_networkRestriction_version.xsd
@@ -96,7 +96,7 @@ Rail transport, Roads and ROAD transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ===NETWORK RESTRICTIONs================================================= -->
-	<xsd:element name="NetworkRestriction" type="NetworkRestriction_VersionStructure" abstract="true" substitutionGroup="Assignment_">
+	<xsd:element name="NetworkRestriction" type="NetworkRestriction_VersionStructure" abstract="true" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A constraint on use of a network of INFRASTRUCTURE POINTs and INFRASTUCTURE LINKs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_route_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_route_version.xsd
@@ -114,7 +114,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="Route_" maxOccurs="unbounded"/>
+					<xsd:element ref="Route_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -214,12 +214,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Route_" type="LinkSequence_VersionStructure" abstract="true" substitutionGroup="LinkSequence">
+	<xsd:element name="Route_Dummy" type="LinkSequence_VersionStructure" abstract="true" substitutionGroup="LinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>Dummy supertype for Route.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Route" substitutionGroup="Route_">
+	<xsd:element name="Route" substitutionGroup="Route_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An ordered list of located POINTs defining one single path through the Road (or rail) network. A ROUTE may pass through the same POINT more than once.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_timingPattern_support.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_timingPattern_support.xsd
@@ -189,7 +189,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfLinksIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfTimingLinksRef" type="GroupOfTimingLinksRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfTimingLinksRef" type="GroupOfTimingLinksRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF TIMING LINKs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_networkDescription/netex_vehicleAndCrewPoint_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_vehicleAndCrewPoint_version.xsd
@@ -118,7 +118,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="ReliefPoint_" maxOccurs="unbounded"/>
+					<xsd:element ref="ReliefPoint_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -176,12 +176,12 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ================================================================== -->
-	<xsd:element name="ReliefPoint_" type="TimingPoint_VersionStructure" abstract="true" substitutionGroup="TimingPoint_">
+	<xsd:element name="ReliefPoint_Dummy" type="TimingPoint_VersionStructure" abstract="true" substitutionGroup="TimingPoint_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A TIMING POINT where a relief is possible, i.e. a driver may take on or hand over a vehicle. The vehicle may sometimes be left unattended.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ReliefPoint" substitutionGroup="ReliefPoint_">
+	<xsd:element name="ReliefPoint" substitutionGroup="ReliefPoint_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A TIMING POINT where a relief is possible, i.e. a driver may take on or hand over a vehicle. The vehicle may sometimes be left unattended.</xsd:documentation>
 		</xsd:annotation>
@@ -235,12 +235,12 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="ParkingPoint_" type="ReliefPoint_VersionStructure" abstract="true" substitutionGroup="ReliefPoint_">
+	<xsd:element name="ParkingPoint_Dummy" type="ReliefPoint_VersionStructure" abstract="true" substitutionGroup="ReliefPoint_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A TIMING POINT where vehicles may stay unattended for a long time. A vehicle's return to park at a PARKING POINT marks the end of a BLOCK.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ParkingPoint" substitutionGroup="ReliefPoint_">
+	<xsd:element name="ParkingPoint" substitutionGroup="ReliefPoint_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A TIMING POINT where vehicles may stay unattended for a long time. A vehicle's return to park at a PARKING POINT marks the end of a BLOCK.</xsd:documentation>
 		</xsd:annotation>
@@ -303,7 +303,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GaragePoint" substitutionGroup="ParkingPoint_">
+	<xsd:element name="GaragePoint" substitutionGroup="ParkingPoint_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A subtype of PARKING POINT located in a GARAGE.</xsd:documentation>
 		</xsd:annotation>
@@ -415,7 +415,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Contact details for GARAGE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 			<xsd:element name="operators" type="transportOrganisationRefs_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>OPERATORs assoicated with GARAGE.</xsd:documentation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_commonSection_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_commonSection_version.xsd
@@ -86,7 +86,7 @@ Rail transport, Roads and Road transport
 	<!-- ========= ============================================================== -->
 	<!-- ==COMMON SECTION=========================================================== -->
 	<!-- ======================================================================= -->
-	<xsd:element name="CommonSection" substitutionGroup="Section_">
+	<xsd:element name="CommonSection" substitutionGroup="Section_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A shared set of LINKS or POINTs. A part of a public transport network where the ROUTEs of several JOURNEY PATTERNs are going in parallel and where the synchronisation of SERVICE JOURNEYs may be planned and controlled with respect to commonly used LINKs and STOP POINTs. COMMON SECTIONs are defined arbitrarily and need not cover the total lengths of topologically bundled sections.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_fareZone_support.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_fareZone_support.xsd
@@ -198,7 +198,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="TariffZoneIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="FareZoneRef" type="FareZoneRefStructure" substitutionGroup="TariffZoneRef_">
+	<xsd:element name="FareZoneRef" type="FareZoneRefStructure" substitutionGroup="TariffZoneRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a FARE ZONE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_fareZone_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_fareZone_version.xsd
@@ -418,7 +418,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareSection" substitutionGroup="Section_">
+	<xsd:element name="FareSection" substitutionGroup="Section_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A subdivision of a JOURNEY PATTERN consisting of consecutive POINTs IN JOURNEY PATTERN, used to define an element of the fare structure.</xsd:documentation>
 		</xsd:annotation>
@@ -484,7 +484,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="FareZone" substitutionGroup="TariffZone_">
+	<xsd:element name="FareZone" substitutionGroup="TariffZone_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A specialization of TARIFF ZONE to include FARE SECTIONs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_journeyPattern_version.xsd
@@ -85,18 +85,18 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="JourneyPattern_" maxOccurs="unbounded"/>
+					<xsd:element ref="JourneyPattern_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ===Journey Pattern===================================================== -->
-	<xsd:element name="JourneyPattern_" type="LinkSequence_VersionStructure" abstract="true" substitutionGroup="LinkSequence">
+	<xsd:element name="JourneyPattern_Dummy" type="LinkSequence_VersionStructure" abstract="true" substitutionGroup="LinkSequence">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Supertype for JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="JourneyPattern" substitutionGroup="JourneyPattern_">
+	<xsd:element name="JourneyPattern" substitutionGroup="JourneyPattern_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An ordered list of SCHEDULED STOP POINTs and TIMING POINTs on a single ROUTE, describing the pattern of working for public transport vehicles. A JOURNEY PATTERN may pass through the same POINT more than once. The first point of a JOURNEY PATTERN is the origin. The last point is the destination.</xsd:documentation>
 		</xsd:annotation>
@@ -234,7 +234,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="DeadRunJourneyPattern" substitutionGroup="JourneyPattern_">
+	<xsd:element name="DeadRunJourneyPattern" substitutionGroup="JourneyPattern_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A JOURNEY PATTERN to be used for DEAD RUNs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_passengerInformationEquipment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_passengerInformationEquipment_version.xsd
@@ -280,7 +280,7 @@ LOGICAL DISPLAY corresponds to a SIRI STOP MONITORING point.</xsd:documentation>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DisplayAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="DisplayAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of one STOP POINT and one JOURNEY PATTERN to a PASSENGER INFORMATION EQUIPMENT, specifying that information on this STOP POINT and this JOURNEY PATTERN will be provided (e.g. displayed, printed).</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_routingConstraint_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_routingConstraint_version.xsd
@@ -184,7 +184,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================== =============================================== -->
-	<xsd:element name="ServiceExclusion" substitutionGroup="Assignment_">
+	<xsd:element name="ServiceExclusion" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A constraint on the use of a service. The service, on this specific JOURNEY PATTERN (usually a FTS JOURNEY PATTERN) cannot operate when another (regular) service operates. This may occur only on subpart of the JOURNEY PATTERN, or only on one or some specific SCHEDULED STOP POINTs within the pattern.</xsd:documentation>
 		</xsd:annotation>
@@ -257,7 +257,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TransferRestriction" substitutionGroup="Assignment_">
+	<xsd:element name="TransferRestriction" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A CONSTRAINT that can be applied on a CONNECTION or INTERCHANGE between two SCHEDULED STOP POINT, preventing or forbidding the passenger to use it.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd
@@ -689,7 +689,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="ServiceJourneyPattern" substitutionGroup="JourneyPattern_">
+	<xsd:element name="ServiceJourneyPattern" substitutionGroup="JourneyPattern_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The JOURNEY PATTERN for a (passenger carrying) SERVICE JOURNEY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_stopAssignment_version.xsd
@@ -268,7 +268,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======PASSENGER BOARDING POSITION ASSIGNMENT============================================ -->
-	<xsd:element name="PassengerBoardingPositionAssignment_" type="PassengerBoardingPositionAssignment_VersionStructure" abstract="true" substitutionGroup="StopAssignment">
+	<xsd:element name="PassengerBoardingPositionAssignment_Dummy" type="PassengerBoardingPositionAssignment_VersionStructure" abstract="true" substitutionGroup="StopAssignment">
 		<xsd:annotation>
 			<xsd:documentation>Assignment of a SCHEDULED STOP POINT to a STOP PLACE and QUAY, etc.</xsd:documentation>
 		</xsd:annotation>
@@ -282,7 +282,7 @@ Rail transport, Roads and Road transport
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="PassengerBoardingPositionAssignmentRef"/>
 					<xsd:element ref="PassengerBoardingPositionAssignment"/>
-					<xsd:element ref="PassengerBoardingPositionAssignment_"/>
+					<xsd:element ref="PassengerBoardingPositionAssignment_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_timeDemandType_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_timeDemandType_version.xsd
@@ -222,7 +222,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="TimeDemandTypeAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="TimeDemandTypeAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a TIME DEMAND TYPE to a TIME BAND depending on the DAY TYPE and GROUP OF TIMING LINKS.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_timingPattern_version.xsd
@@ -144,7 +144,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="TimingPoint_" maxOccurs="unbounded">
+					<xsd:element ref="TimingPoint_Dummy" maxOccurs="unbounded">
 						<xsd:annotation>
 							<xsd:documentation>TIMING POINT.</xsd:documentation>
 						</xsd:annotation>
@@ -153,12 +153,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TimingPoint_" type="Point_VersionStructure" abstract="true" substitutionGroup="Point">
+	<xsd:element name="TimingPoint_Dummy" type="Point_VersionStructure" abstract="true" substitutionGroup="Point">
 		<xsd:annotation>
 			<xsd:documentation>A POINT against which the timing information necessary to build schedules may be recorded.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="TimingPoint" substitutionGroup="TimingPoint_">
+	<xsd:element name="TimingPoint" substitutionGroup="TimingPoint_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A POINT against which the timing information necessary to build schedules may be recorded.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -118,7 +118,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="DatedVehicleJourney" substitutionGroup="Journey_">
+	<xsd:element name="DatedVehicleJourney" substitutionGroup="Journey_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A particular journey of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff.</xsd:documentation>
 		</xsd:annotation>
@@ -246,7 +246,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====DATED SERVICE JOURNEY====================================-->
-	<xsd:element name="DatedServiceJourney" substitutionGroup="ServiceJourney_">
+	<xsd:element name="DatedServiceJourney" substitutionGroup="ServiceJourney_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A particular SERVICE JOURNEY of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff. 
 
@@ -297,7 +297,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="NormalDatedVehicleJourney" substitutionGroup="Journey_">
+	<xsd:element name="NormalDatedVehicleJourney" substitutionGroup="Journey_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A DATED VEHICLE JOURNEY identical to a long-term planned VEHICLE JOURNEY, possibly updated according to short-term modifications of the PRODUCTION PLAN decided by the control staff.</xsd:documentation>
 		</xsd:annotation>
@@ -344,7 +344,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="DatedSpecialService" substitutionGroup="Journey_">
+	<xsd:element name="DatedSpecialService" substitutionGroup="Journey_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A particular journey of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_deckEntranceAssignment_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_deckEntranceAssignment_version.xsd
@@ -77,7 +77,7 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DeckEntranceAssignment" substitutionGroup="PassengerBoardingPositionAssignment_">
+	<xsd:element name="DeckEntranceAssignment" substitutionGroup="PassengerBoardingPositionAssignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The association of a DECK ENTRANCE of a VEHICLE's DECK PLAN with a TRAIN and TRAIN COMPONENT and a specific STOP PLACE, QUAY and possibly BOARDING POSITION. NOTE: may indicate which side of VEHICLE door is. +v2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_deckPlanAssignment_version.xsd
@@ -81,7 +81,7 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DeckPlanAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="DeckPlanAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a DECK PLAN to all or part of a specific VEHICLE JOURNEY and /or VEHICLE TYPE and/or TRAIN ELEMENT. +v2.0</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
@@ -347,7 +347,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="DefaultInterchange" substitutionGroup="Interchange_">
+	<xsd:element name="DefaultInterchange" substitutionGroup="Interchange_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A quality parameter fixing the acceptable duration (standard and maximum) for an INTERCHANGE to be planned between two SCHEDULED STOP POINTs. This parameter will be used to control whether any two SERVICE JOURNEYs serving those points may be in connection.</xsd:documentation>
 		</xsd:annotation>
@@ -408,7 +408,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="Interchange_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="Interchange_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy supertype for INTERCHANGe.</xsd:documentation>
 		</xsd:annotation>
@@ -589,7 +589,7 @@ Default is false.</xsd:documentation>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ServiceJourneyInterchange" substitutionGroup="Interchange_">
+	<xsd:element name="ServiceJourneyInterchange" substitutionGroup="Interchange_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The scheduled possibility for transfer of passengers between two SERVICE JOURNEYs at the same or different STOP POINTs.</xsd:documentation>
 		</xsd:annotation>
@@ -663,7 +663,7 @@ Default is false.</xsd:documentation>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="ServiceJourneyPatternInterchange" substitutionGroup="Interchange_">
+	<xsd:element name="ServiceJourneyPatternInterchange" substitutionGroup="Interchange_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A recognised/organised possibility for passengers to change public transport vehicles using two STOP POINTs (which may be identical) on two particular SERVICE JOURNEY PATTERNs, including the maximum wait duration allowed and the standard to be aimed at. These may supersede the times given for the DEFAULT INTERCHANGE. Schedulers may use this entity for synchronisation of journeys.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_journeyAccounting_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_journeyAccounting_version.xsd
@@ -101,7 +101,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="JourneyAccounting" substitutionGroup="Assignment_">
+	<xsd:element name="JourneyAccounting" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Parameters characterizing VEHICLE JOURNEYs or SPECIAL SERVICEs used for accounting purposes in particular in contracts between ORGANISATIONs.</xsd:documentation>
 		</xsd:annotation>
@@ -151,7 +151,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Object for which this accounts.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="OrganisationRef_" minOccurs="0">
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>ORGANISATION contracting service.</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_journey_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_journey_version.xsd
@@ -72,12 +72,12 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>JOURNEY types for NeTEx.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<xsd:element name="Journey_" type="LinkSequence_VersionStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="Journey_Dummy" type="LinkSequence_VersionStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy supertype for Journey.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="Journey" abstract="true" substitutionGroup="Journey_">
+	<xsd:element name="Journey" abstract="true" substitutionGroup="Journey_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Common properties of a JOURNEY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd
@@ -147,7 +147,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfServicesRef" type="GroupOfServicesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfServicesRef" type="GroupOfServicesRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF SERVICEs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_version.xsd
@@ -86,12 +86,12 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<!-- ======================================================================= -->
 	<!-- ===SERVICE JOURNEY===================================================== -->
-	<xsd:element name="ServiceJourney_" type="Journey_VersionStructure" abstract="true" substitutionGroup="VehicleJourney_">
+	<xsd:element name="ServiceJourney_Dummy" type="Journey_VersionStructure" abstract="true" substitutionGroup="VehicleJourney_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy SERVICE JOURNEY Supertype.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ServiceJourney" substitutionGroup="VehicleJourney_">
+	<xsd:element name="ServiceJourney" substitutionGroup="VehicleJourney_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A passenger carrying VEHICLE JOURNEY for one specified DAY TYPE. The pattern of working is in principle defined by a SERVICE JOURNEY PATTERN.
 
@@ -294,7 +294,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 		</xsd:sequence>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="TemplateServiceJourney" substitutionGroup="ServiceJourney_">
+	<xsd:element name="TemplateServiceJourney" substitutionGroup="ServiceJourney_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A VEHICLE JOURNEY with a set of frequencies that may be used to represent a set of similar journeys differing only by their time of departure.</xsd:documentation>
 		</xsd:annotation>
@@ -348,7 +348,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SpecialService" substitutionGroup="Journey_">
+	<xsd:element name="SpecialService" substitutionGroup="Journey_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A passenger carrying VEHICLE JOURNEY for one specified DAY TYPE. The pattern of working is in principle defined by a SERVICE JOURNEY PATTERN.</xsd:documentation>
 		</xsd:annotation>
@@ -668,7 +668,7 @@ The VIEW includes derived ancillary data from referenced entities.</xsd:document
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="DeadRun" substitutionGroup="VehicleJourney_">
+	<xsd:element name="DeadRun" substitutionGroup="VehicleJourney_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A non-service VEHICLE JOURNEY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourneyFrequency_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourneyFrequency_support.xsd
@@ -110,7 +110,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="JourneyFrequencyGroupRef" type="JourneyFrequencyGroupRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="JourneyFrequencyGroupRef" type="JourneyFrequencyGroupRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a JOURNEY FREQUENCY GROUP.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_vehicleJourney_version.xsd
@@ -107,12 +107,12 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- === VEHICLE JOURNEY =================================================== -->
-	<xsd:element name="VehicleJourney_" type="Journey_VersionStructure" abstract="true" substitutionGroup="Journey_">
+	<xsd:element name="VehicleJourney_Dummy" type="Journey_VersionStructure" abstract="true" substitutionGroup="Journey_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy VEHICLE JOURNEY supertype.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="VehicleJourney" substitutionGroup="VehicleJourney_" id="VehicleJourney">
+	<xsd:element name="VehicleJourney" substitutionGroup="VehicleJourney_Dummy" id="VehicleJourney">
 		<xsd:annotation>
 			<xsd:documentation>The planned movement of a public transport vehicle on a DAY TYPE from the start point to the end point of a JOURNEY PATTERN on a specified ROUTE.</xsd:documentation>
 		</xsd:annotation>
@@ -305,7 +305,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- =====TEMPLATE VEHICLE JOURNEY=========================================== -->
-	<xsd:element name="TemplateVehicleJourney" substitutionGroup="VehicleJourney_" id="TemplateTemplateVehicleJourney">
+	<xsd:element name="TemplateVehicleJourney" substitutionGroup="VehicleJourney_Dummy" id="TemplateTemplateVehicleJourney">
 		<xsd:annotation>
 			<xsd:documentation>A repeating VEHICLE JOURNEY for which a frequency has been specified, either as a HEADWAY JOURNEY GROUP (e.g. every 20 minutes) or a RHYTHMICAL JOURNEY GROUP (e.g. at 15, 27 and 40 minutes past the hour). It may thus represent multiple journeys.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -178,7 +178,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="frameContainmentStructure">
 				<xsd:choice>
-					<xsd:element ref="AccessRightParameterAssignment_" maxOccurs="unbounded"/>
+					<xsd:element ref="AccessRightParameterAssignment_Dummy" maxOccurs="unbounded"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -205,7 +205,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="AccessRightParameterAssignment_" maxOccurs="unbounded">
+					<xsd:element ref="AccessRightParameterAssignment_Dummy" maxOccurs="unbounded">
 						<xsd:annotation>
 							<xsd:documentation>A sequence or set of CONTROLLABLE ELEMENTs to which rules for limitation of access rights and calculation of prices (fare structure) are applied.</xsd:documentation>
 						</xsd:annotation>
@@ -214,12 +214,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="AccessRightParameterAssignment_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="Assignment_">
+	<xsd:element name="AccessRightParameterAssignment_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a fare parameter (referring to geography, time, quality or usage) to an element of a fare system (access right, validated access, control mean, etc.).</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="AccessRightParameterAssignment" type="AccessRightParameterAssignment_VersionStructure" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="AccessRightParameterAssignment" type="AccessRightParameterAssignment_VersionStructure" substitutionGroup="AccessRightParameterAssignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a fare parameter (referring to geography, time, quality or usage) to an element of a fare system (access right, validated access, control mean, etc.).</xsd:documentation>
 		</xsd:annotation>
@@ -768,12 +768,12 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="AccessRightParameterAssignment_" maxOccurs="unbounded"/>
+					<xsd:element ref="AccessRightParameterAssignment_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ValidityParameterAssignment" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="ValidityParameterAssignment" substitutionGroup="AccessRightParameterAssignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An ACCESS RIGHT PARAMETER ASSIGNMENT relating a fare collection parameter to a theoretical FARE PRODUCT (or one of its components) or a SALES OFFER PACKAGE.</xsd:documentation>
 		</xsd:annotation>
@@ -868,7 +868,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GenericParameterAssignment" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="GenericParameterAssignment" substitutionGroup="AccessRightParameterAssignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A VALIDITY PARAMETER ASSIGNMENT specifying practical parameters during a TRAVEL GenericATION, within a given fare structure (e.g. the origin or destination zone in a zone-counting system).</xsd:documentation>
 		</xsd:annotation>
@@ -943,7 +943,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="GenericParameterAssignmentInContext" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="GenericParameterAssignmentInContext" substitutionGroup="AccessRightParameterAssignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Optimisation: Can be used without id constraintA VALIDITY PARAMETER ASSIGNMENT specifying practical parameters during a TRAVEL GenericATION, within a given fare structure (e.g. the origin or destination zone in a zone-counting system).</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
@@ -374,7 +374,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ===ROUNDING================================================= -->
-	<xsd:element name="FareDayType" substitutionGroup="DayType_" id="FareDayType">
+	<xsd:element name="FareDayType" substitutionGroup="DayType_Dummy" id="FareDayType">
 		<xsd:annotation>
 			<xsd:documentation>A type of day used in the fare collection domain, characterized by one or more properties which affect the definition of access rights and prices in the fare system.</xsd:documentation>
 		</xsd:annotation>
@@ -491,17 +491,17 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="frameContainmentStructure">
 				<xsd:sequence>
-					<xsd:element ref="PricingRule_" maxOccurs="unbounded"/>
+					<xsd:element ref="PricingRule_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PricingRule_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="PricingRule_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dumm abstact type of Pricing rule.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="PricingRule" substitutionGroup="PricingRule_">
+	<xsd:element name="PricingRule" substitutionGroup="PricingRule_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Parameters describing how a fare is to be computed.</xsd:documentation>
 		</xsd:annotation>
@@ -581,7 +581,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- =====DISCOUNTING RULE======================================= -->
-	<xsd:element name="DiscountingRule" substitutionGroup="PricingRule_">
+	<xsd:element name="DiscountingRule" substitutionGroup="PricingRule_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A price for which a discount can be offered.</xsd:documentation>
 		</xsd:annotation>
@@ -646,7 +646,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- =====DISCOUNTING RULE======================================= -->
-	<xsd:element name="LimitingRule" substitutionGroup="PricingRule_">
+	<xsd:element name="LimitingRule" substitutionGroup="PricingRule_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A price for which a discount can be offered.</xsd:documentation>
 		</xsd:annotation>
@@ -764,7 +764,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="LimitingRuleInContext" substitutionGroup="PricingRule_">
+	<xsd:element name="LimitingRuleInContext" substitutionGroup="PricingRule_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>OPTIMISED version whcih can be be used only in line assues ID of comtainign context -no id checking. A price for which a discount can be offered.</xsd:documentation>
 		</xsd:annotation>
@@ -903,7 +903,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Name of PRICING SERVICE parameter set.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 			<xsd:element name="Url" type="xsd:anyURI" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>URL at which service is available.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_support.xsd
@@ -79,7 +79,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfDistanceMatrixElementsRef" type="GroupOfDistanceMatrixElementsRefStructureElement" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfDistanceMatrixElementsRef" type="GroupOfDistanceMatrixElementsRefStructureElement" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF DISTANCE MATRIX ELEMENTs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_version.xsd
@@ -224,12 +224,12 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DistanceMatrixElement_" type="PriceableObject_VersionStructure" abstract="true" substitutionGroup="PriceableObject">
+	<xsd:element name="DistanceMatrixElement_Dummy" type="PriceableObject_VersionStructure" abstract="true" substitutionGroup="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy SERVICE JOURNEY supertype.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="DistanceMatrixElement" substitutionGroup="DistanceMatrixElement_">
+	<xsd:element name="DistanceMatrixElement" substitutionGroup="DistanceMatrixElement_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A cell of an origin-destination matrix for TARIFF ZONEs or STOP POINTs, expressing a fare distance for the corresponding trip: value in km, number of fare units etc.</xsd:documentation>
 		</xsd:annotation>
@@ -439,12 +439,12 @@ Rail transport, Roads and Road transport
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="DistanceMatrixElementPriceRef"/>
 					<xsd:element ref="DistanceMatrixElementPrice"/>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DistanceMatrixElementPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="DistanceMatrixElementPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a DISTANCE MATRIX ELEMENT: default total price etc.
 .</xsd:documentation>
@@ -494,7 +494,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- === DYNAMIC DISTANCE MATRIX ELEMENT  ================================================= -->
-	<xsd:element name="DynamicDistanceMatrixElement" substitutionGroup="DistanceMatrixElement_">
+	<xsd:element name="DynamicDistanceMatrixElement" substitutionGroup="DistanceMatrixElement_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A dynamic free-standing distance matrix element. Used when a pre-computed distance matrix element is not feasible.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_farePrice_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_farePrice_support.xsd
@@ -137,7 +137,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PriceGroupRef" type="PriceGroupRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="PriceGroupRef" type="PriceGroupRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a PRICE GROUP.</xsd:documentation>
 		</xsd:annotation>
@@ -157,7 +157,7 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- === DUmmy Cell Ref ====================================================== -->
-	<xsd:element name="CellRef_" type="VersionOfObjectRefStructure" abstract="true" substitutionGroup="VersionOfObjectRef">
+	<xsd:element name="CellRef_Dummy" type="VersionOfObjectRefStructure" abstract="true" substitutionGroup="VersionOfObjectRef">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Reference to a FARE TABLE CELL.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
@@ -91,18 +91,18 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="frameContainmentStructure">
 				<xsd:choice maxOccurs="unbounded">
-					<xsd:element ref="PriceGroup_"/>
+					<xsd:element ref="PriceGroup_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ===FARE PRICE================================================= -->
-	<xsd:element name="PriceableObject_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="PriceableObject_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Abstract price.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="PriceableObject" type="PriceableObject_VersionStructure" abstract="true" substitutionGroup="PriceableObject_" id="PriceableObject">
+	<xsd:element name="PriceableObject" type="PriceableObject_VersionStructure" abstract="true" substitutionGroup="PriceableObject_Dummy" id="PriceableObject">
 		<xsd:annotation>
 			<xsd:documentation>An element that may have a FARE PRICE.</xsd:documentation>
 		</xsd:annotation>
@@ -189,7 +189,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="FareTable_" type="GroupOfEntities_VersionStructure" abstract="true" substitutionGroup="GroupOfEntities">
+	<xsd:element name="FareTable_Dummy" type="GroupOfEntities_VersionStructure" abstract="true" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of prices that may be associated with a DISTANCE MATRIX ELEMENT, FARE STRUCTURE ELEMENT or other PRICEABLE OBJECT.</xsd:documentation>
 		</xsd:annotation>
@@ -202,7 +202,7 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="FareTableRef"/>
-					<xsd:element ref="FareTable_"/>
+					<xsd:element ref="FareTable_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -216,18 +216,18 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="FarePriceRef"/>
-					<xsd:element ref="CellRef_"/>
-					<xsd:element ref="FarePrice_"/>
+					<xsd:element ref="CellRef_Dummy"/>
+					<xsd:element ref="FarePrice_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FarePrice_" type="VersionedChildStructure" abstract="true" substitutionGroup="VersionedChild">
+	<xsd:element name="FarePrice_Dummy" type="VersionedChildStructure" abstract="true" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Abstract PRICE.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="FarePrice" abstract="true" substitutionGroup="FarePrice_" id="FarePrice">
+	<xsd:element name="FarePrice" abstract="true" substitutionGroup="FarePrice_Dummy" id="FarePrice">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features for a Fare element.</xsd:documentation>
 		</xsd:annotation>
@@ -342,7 +342,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="FarePriceRef" minOccurs="0"/>
 			<xsd:choice minOccurs="0">
 				<xsd:element ref="PricingRuleRef"/>
-				<xsd:element ref="PricingRule_"/>
+				<xsd:element ref="PricingRule_Dummy"/>
 			</xsd:choice>
 			<xsd:element name="CanBeCumulative" type="xsd:boolean" default="true" minOccurs="0">
 				<xsd:annotation>
@@ -452,8 +452,8 @@ The RULE STEP RESULT  Adjustment Amount is  the difference beteen the original i
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="FarePriceRef"/>
 					<xsd:element ref="PriceGroupRef"/>
-					<xsd:element ref="FarePrice_"/>
-					<xsd:element ref="PriceGroup_"/>
+					<xsd:element ref="FarePrice_Dummy"/>
+					<xsd:element ref="PriceGroup_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -466,17 +466,17 @@ The RULE STEP RESULT  Adjustment Amount is  the difference beteen the original i
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="PriceGroupRef"/>
-					<xsd:element ref="PriceGroup_"/>
+					<xsd:element ref="PriceGroup_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="PriceGroup_" type="GroupOfEntities_VersionStructure" abstract="true" substitutionGroup="GroupOfEntities">
+	<xsd:element name="PriceGroup_Dummy" type="GroupOfEntities_VersionStructure" abstract="true" substitutionGroup="GroupOfEntities">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of prices, allowing the grouping of numerous possible consumption elements into a limited number of price references, or to apply grouped increase, in value or percentage.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="PriceGroup" substitutionGroup="PriceGroup_">
+	<xsd:element name="PriceGroup" substitutionGroup="PriceGroup_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of prices, allowing the grouping of numerous possible consumption elements into a limited number of price references, or to apply grouped increase, in value or percentage.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
@@ -113,18 +113,18 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="frameContainmentStructure">
 				<xsd:sequence>
-					<xsd:element ref="FareProduct_" maxOccurs="unbounded"/>
+					<xsd:element ref="FareProduct_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====FARE PRODUCT=================================================== -->
-	<xsd:element name="ServiceAccessRight_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="PriceableObject_">
+	<xsd:element name="ServiceAccessRight_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An immaterial marketable element</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="ServiceAccessRight" substitutionGroup="ServiceAccessRight_">
+	<xsd:element name="ServiceAccessRight" substitutionGroup="ServiceAccessRight_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An immaterial marketable element dedicated to accessing some services.</xsd:documentation>
 		</xsd:annotation>
@@ -193,12 +193,12 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====FARE PRODUCT=================================================== -->
-	<xsd:element name="FareProduct_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="ServiceAccessRight_">
+	<xsd:element name="FareProduct_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="ServiceAccessRight_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An immaterial marketable element (access rights, discount rights etc), specific to a CHARGING MOMENT.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="FareProduct" abstract="true" substitutionGroup="FareProduct_">
+	<xsd:element name="FareProduct" abstract="true" substitutionGroup="FareProduct_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An immaterial marketable element (access rights, discount rights etc), specific to a CHARGING MOMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -273,7 +273,7 @@ Rail transport, Roads and Road transport
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
-			<xsd:element ref="OrganisationRef_" minOccurs="0">
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>ORGANISATION in charge of the FARE PRODUCT. +v1.2.2</xsd:documentation>
 				</xsd:annotation>
@@ -379,7 +379,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== SALES DISCOUNT RIGHT.=============================================== -->
-	<xsd:element name="SaleDiscountRight" substitutionGroup="FareProduct_">
+	<xsd:element name="SaleDiscountRight" substitutionGroup="FareProduct_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT allowing a customer to benefit from discounts when purchasing SALES OFFER PACKAGEs.</xsd:documentation>
 		</xsd:annotation>
@@ -450,7 +450,7 @@ Rail transport, Roads and Road transport
 		</xsd:choice>
 	</xsd:group>
 	<!-- ==== ENTITLEMENT PRODUCT.=============================================== -->
-	<xsd:element name="EntitlementProduct" substitutionGroup="ServiceAccessRight_">
+	<xsd:element name="EntitlementProduct" substitutionGroup="ServiceAccessRight_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A precondition to access a service or to purchase a FARE PRODUCT issued by an organisation that may not be a PT operator (e.g. military card).</xsd:documentation>
 		</xsd:annotation>
@@ -505,7 +505,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== THIRD PARTY PRODUCT.=============================================== -->
-	<xsd:element name="ThirdPartyProduct" substitutionGroup="FareProduct_">
+	<xsd:element name="ThirdPartyProduct" substitutionGroup="FareProduct_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT that is marketed together with a Public Transport Fare Product.</xsd:documentation>
 		</xsd:annotation>
@@ -558,7 +558,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== USAGE DISCOUNT RIGHT.=============================================== -->
-	<xsd:element name="UsageDiscountRight" substitutionGroup="FareProduct_">
+	<xsd:element name="UsageDiscountRight" substitutionGroup="FareProduct_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT allowing a customer to benefit from discounts when consuming VALIDABLE ELEMENTs.</xsd:documentation>
 		</xsd:annotation>
@@ -603,7 +603,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== CAPPED DISCOUNT RIGHT.=============================================== -->
-	<xsd:element name="CappedDiscountRight" substitutionGroup="FareProduct_">
+	<xsd:element name="CappedDiscountRight" substitutionGroup="FareProduct_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT allowing a customer to benefit from discounts when consuming VALIDABLE ELEMENTs.</xsd:documentation>
 		</xsd:annotation>
@@ -675,7 +675,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CappingRule" substitutionGroup="PriceableObject_">
+	<xsd:element name="CappingRule" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Rule about capping for a mode.</xsd:documentation>
 		</xsd:annotation>
@@ -799,7 +799,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="AmountOfPriceUnitProduct" substitutionGroup="FareProduct_">
+	<xsd:element name="AmountOfPriceUnitProduct" substitutionGroup="FareProduct_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT consisting in a stored value of PRICE UNITs: an amount of money on an electronic purse, amount of units on a value card etc.</xsd:documentation>
 		</xsd:annotation>
@@ -862,7 +862,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== PREASSIGNED FARE PRODUC=============================================== -->
-	<xsd:element name="PreassignedFareProduct" substitutionGroup="FareProduct_">
+	<xsd:element name="PreassignedFareProduct" substitutionGroup="FareProduct_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT consisting of one or several VALIDABLE ELEMENTs, specific to a CHARGING MOMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -919,7 +919,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== PREASSIGNED FARE PRODUC=============================================== -->
-	<xsd:element name="SupplementProduct" substitutionGroup="FareProduct_">
+	<xsd:element name="SupplementProduct" substitutionGroup="FareProduct_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A FARE PRODUCT consisting of one or several VALIDABLE ELEMENTs, specific to a CHARGING MOMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -1078,13 +1078,13 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="FareProductPriceRef"/>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 					<xsd:element ref="FareProductPrice"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareProductPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="FareProductPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a FARE PRODUCT default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>
@@ -1140,13 +1140,13 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="CappingRulePriceRef"/>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 					<xsd:element ref="CappingRulePrice"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CappingRulePrice" substitutionGroup="FarePrice_">
+	<xsd:element name="CappingRulePrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a CAPPING RULE default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_fareSeries_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareSeries_support.xsd
@@ -88,7 +88,7 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="SeriesConstraintRefStructure_">
+	<xsd:complexType name="SeriesConstraintRefStructure_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Extending type for Reference to a SERIES CONSTRAINT.</xsd:documentation>
 		</xsd:annotation>
@@ -107,7 +107,7 @@
 			<xsd:documentation>Type for Reference to a SERIES CONSTRAINT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
-			<xsd:restriction base="SeriesConstraintRefStructure_">
+			<xsd:restriction base="SeriesConstraintRefStructure_Dummy">
 				<xsd:attribute name="ref" type="SeriesConstraintIdType" use="required">
 					<xsd:annotation>
 						<xsd:documentation>Identifier of a SERIES CONSTRAINT.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_fareSeries_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareSeries_version.xsd
@@ -105,7 +105,7 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SeriesConstraint" substitutionGroup="PriceableObject_">
+	<xsd:element name="SeriesConstraint" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A particular tariff, described by a combination of parameters.</xsd:documentation>
 		</xsd:annotation>
@@ -286,12 +286,12 @@
 							<xsd:documentation>A set of all possible price features of a SERIES CONSTRAINT: default total price, discount in value or percentage etc.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SeriesConstraintPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="SeriesConstraintPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a SERIES CONSTRAINT: default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>
@@ -399,7 +399,7 @@
 			<xsd:documentation>Elements for a ZONE IN SERIES.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element ref="TariffZoneRef_"/>
+			<xsd:element ref="TariffZoneRef_Dummy"/>
 			<xsd:element name="InterchangeAllowed" type="xsd:boolean" default="true" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Whether interchange is allowed in a zone.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_fareStructureElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareStructureElement_version.xsd
@@ -242,7 +242,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Calculation Elements for TARIFF.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:choice>
-			<xsd:element ref="OrganisationRef_"/>
+			<xsd:element ref="OrganisationRef_Dummy"/>
 			<xsd:element ref="GroupOfOperatorsRef"/>
 		</xsd:choice>
 	</xsd:group>
@@ -611,12 +611,12 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>A set of all possible price features of a FARE STRUCTURE ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareStructureElementPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="FareStructureElementPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a FARE STRUCTURE ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_fareTable_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareTable_support.xsd
@@ -78,7 +78,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="FareTableRef" type="FareTableRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="FareTableRef" type="FareTableRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a FARE TABLE.</xsd:documentation>
 		</xsd:annotation>
@@ -168,7 +168,7 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<xsd:element name="CellRef" type="CellRefStructure" substitutionGroup="CellRef_">
+	<xsd:element name="CellRef" type="CellRefStructure" substitutionGroup="CellRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a CELL.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
@@ -142,14 +142,14 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="frameContainmentStructure">
 				<xsd:sequence>
-					<xsd:element ref="FareTable_" maxOccurs="unbounded"/>
+					<xsd:element ref="FareTable_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- == CELL ================================ -->
 	<!-- ===CELL================================================= -->
-	<xsd:element name="Cell_" type="VersionedChildStructure" abstract="true" substitutionGroup="VersionedChild">
+	<xsd:element name="Cell_Dummy" type="VersionedChildStructure" abstract="true" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Abstract CELL.</xsd:documentation>
 		</xsd:annotation>
@@ -167,7 +167,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<!-- ======================================================================= -->
 	<!-- ==  FARE TABLE============================= -->
-	<xsd:element name="FareTable" substitutionGroup="FareTable_">
+	<xsd:element name="FareTable" substitutionGroup="FareTable_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of prices that may be associated with a DISTANCE MATRIX ELEMENT, FARE STRUCTURE ELEMENT or other PRICEABLE OBJECT.</xsd:documentation>
 		</xsd:annotation>
@@ -276,7 +276,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Elements that use FARE TABLE that are not PRICEABLE OBJECTs.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="FareTableCommonAssignmentsGroup">
@@ -337,13 +337,13 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareTableInContext" type="FareTable_VersionStructure" substitutionGroup="FareTable_">
+	<xsd:element name="FareTableInContext" type="FareTable_VersionStructure" substitutionGroup="FareTable_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A grouping of prices that may be associated with a DISTANCE MATRIX ELEMENT, FARE STRUCTURE ELEMENT or other PRICEABLE OBJECT. OPTIMIZATION - Alias for FARE TABLE That does not require an ID to be present.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<!-- ===== STANDARD FARE TABLE =================================================== -->
-	<xsd:element name="StandardFareTable" substitutionGroup="FareTable_">
+	<xsd:element name="StandardFareTable" substitutionGroup="FareTable_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of price for a combination of price features in a Tariff.</xsd:documentation>
 		</xsd:annotation>
@@ -446,7 +446,7 @@ Rail transport, Roads and Road transport
 							</xsd:complexContent>
 						</xsd:complexType>
 					</xsd:element>
-					<xsd:element ref="FarePrice_"/>
+					<xsd:element ref="FarePrice_Dummy"/>
 					<xsd:element ref="FarePriceRef"/>
 					<xsd:element ref="CellRef"/>
 				</xsd:choice>
@@ -492,7 +492,7 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="CellHeadingsGroup"/>
 		</xsd:sequence>
 	</xsd:group>
-	<xsd:element name="Cell" substitutionGroup="Cell_">
+	<xsd:element name="Cell" substitutionGroup="Cell_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An individual combination of features in a FARE TABLE, used to associate a FARE PRICE.</xsd:documentation>
 		</xsd:annotation>
@@ -558,7 +558,7 @@ Rail transport, Roads and Road transport
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element ref="FarePriceRef"/>
-				<xsd:element ref="FarePrice_"/>
+				<xsd:element ref="FarePrice_Dummy"/>
 				<xsd:element ref="PriceGroupRef"/>
 			</xsd:choice>
 			<xsd:group ref="CellReferencesGroup">

--- a/xsd/netex_part_3/part3_fares/netex_geographicStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_geographicStructureFactor_version.xsd
@@ -189,7 +189,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GeographicalInterval" substitutionGroup="PriceableObject_">
+	<xsd:element name="GeographicalInterval" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A factor influencing access rights definition or calculation of prices.</xsd:documentation>
 		</xsd:annotation>
@@ -363,12 +363,12 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>A set of all possible price features of a GEOGRAPHICAL UNIT : default total price, discount in value or percentage etc.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GeographicalUnitPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="GeographicalUnitPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a GEOGRAPHICAL UNIT: default total price etc.</xsd:documentation>
 		</xsd:annotation>
@@ -434,12 +434,12 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>A set of all possible price features of a GEOGRAPHICAL INTERVAL : default total price, discount in value or percentage etc.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="GeographicalIntervalPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="GeographicalIntervalPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a GEOGRAPHICAL INTERVAL: default total price etc.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_qualityStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_qualityStructureFactor_version.xsd
@@ -91,17 +91,17 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="QualityStructureFactorRef"/>
-					<xsd:element ref="QualityStructureFactor_"/>
+					<xsd:element ref="QualityStructureFactor_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="QualityStructureFactor_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="PriceableObject_">
+	<xsd:element name="QualityStructureFactor_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="QualityStructureFactor" substitutionGroup="QualityStructureFactor_">
+	<xsd:element name="QualityStructureFactor" substitutionGroup="QualityStructureFactor_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The value of a QUALITY INTERVAL or a DISTANCE MATRIX ELEMENT expressed by a QUALITY UNIT.</xsd:documentation>
 		</xsd:annotation>
@@ -183,12 +183,12 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>A set of all possible price features of a QUALITY STRUCTURE FACTOR : default total price, discount in value or percentage etc.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="QualityStructureFactorPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="QualityStructureFactorPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a QUALITY STRUCTURE FACTOR: default total price etc.</xsd:documentation>
 		</xsd:annotation>
@@ -248,7 +248,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareDemandFactor" substitutionGroup="QualityStructureFactor_">
+	<xsd:element name="FareDemandFactor" substitutionGroup="QualityStructureFactor_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The value of a QUALITY INTERVAL or a DISTANCE MATRIX ELEMENT expressed by a QUALITY UNIT.</xsd:documentation>
 		</xsd:annotation>
@@ -339,7 +339,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareQuotaFactor" substitutionGroup="QualityStructureFactor_">
+	<xsd:element name="FareQuotaFactor" substitutionGroup="QualityStructureFactor_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A named set of parameters defining the number of quota fares available. of a given denomination.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_salesDistribution_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesDistribution_support.xsd
@@ -208,7 +208,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfDistributionChannelsRef" type="GroupOfDistributionChannelsRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfDistributionChannelsRef" type="GroupOfDistributionChannelsRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF DISTRIBUTION CHANNELs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_salesDistribution_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesDistribution_version.xsd
@@ -197,7 +197,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Contact details for distribution channel</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 			<xsd:element name="PaymentMethods" type="PaymentMethodListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Payment methods allowed.</xsd:documentation>
@@ -307,7 +307,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FulfilmentMethod" substitutionGroup="PriceableObject_">
+	<xsd:element name="FulfilmentMethod" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The means by which the ticket is delivered to the Customer. e.g. online, collection, etc.</xsd:documentation>
 		</xsd:annotation>
@@ -391,12 +391,12 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>A set of all possible price features of a FARE STRUCTURE ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FulfilmentMethodPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="FulfilmentMethodPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a FULFILMENT METHOD: default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackageEntitlement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackageEntitlement_version.xsd
@@ -61,7 +61,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: SALES OFFER ENTITLEMENT USAGE PARAMETER types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====SALES OFFER PACKAGE ENTITLEMENT GIVEN================================================= -->
-	<xsd:element name="SalesOfferPackageEntitlementGiven" substitutionGroup="UsageParameter_">
+	<xsd:element name="SalesOfferPackageEntitlementGiven" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A right to a SALES OFFER PACKAGE given by a SALES OFFER PACKAGE .</xsd:documentation>
 		</xsd:annotation>
@@ -117,7 +117,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====SALES OFFER PACKAGE ENTITLEMENT REQUIRED================================================= -->
-	<xsd:element name="SalesOfferPackageEntitlementRequired" substitutionGroup="UsageParameter_">
+	<xsd:element name="SalesOfferPackageEntitlementRequired" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A rerirement to a SALES OFFER PACKAGE in order to purchase or use PRODUCT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_support.xsd
@@ -197,7 +197,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfSalesOfferPackagesRef" type="GroupOfSalesOfferPackagesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfSalesOfferPackagesRef" type="GroupOfSalesOfferPackagesRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF SALES OFFER PACKAGEs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
@@ -168,7 +168,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====SALES OFFER PACKAGE=================================================== -->
-	<xsd:element name="SalesOfferPackage" substitutionGroup="PriceableObject_">
+	<xsd:element name="SalesOfferPackage" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A package to be sold as a whole, consisting of one or several FARE PRODUCTs materialised thanks to one or several TRAVEL DOCUMENTs. The FARE PRODUCTs may be either directly attached to the TRAVEL DOCUMENTs, or may be reloadable on the TRAVEL DOCUMENTs.</xsd:documentation>
 		</xsd:annotation>
@@ -367,12 +367,12 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>A set of all possible price features of a SALES OFFER PACKAGE ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SalesOfferPackagePrice" substitutionGroup="FarePrice_">
+	<xsd:element name="SalesOfferPackagePrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a SALES OFFER PACKAGE ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>
@@ -433,7 +433,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SalesOfferPackageSubstitution" substitutionGroup="Assignment_">
+	<xsd:element name="SalesOfferPackageSubstitution" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A particular tariff, described by a combination of parameters.</xsd:documentation>
 		</xsd:annotation>
@@ -551,7 +551,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====SALES NOTICE ASSIGNMENT ================================================= -->
-	<xsd:element name="SalesNoticeAssignment" substitutionGroup="NoticeAssignment_">
+	<xsd:element name="SalesNoticeAssignment" substitutionGroup="NoticeAssignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a NOTICE to a SALES OFFER PACKAGE or a GROUP OF SALES OFFER PACKAGEs.</xsd:documentation>
 		</xsd:annotation>
@@ -618,7 +618,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="DistributionAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="DistributionAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An assignment of the COUNTRY and/or DISTRIBUTION CHANNEL through which a product may or may not be distributed.</xsd:documentation>
 		</xsd:annotation>
@@ -649,7 +649,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Type for DISTRIBUTION ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="Assignment_VersionStructure_">
+			<xsd:extension base="Assignment_VersionStructure_Dummy">
 				<xsd:sequence>
 					<xsd:group ref="DistributionAssignmentGroup"/>
 				</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_timeStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_timeStructureFactor_version.xsd
@@ -192,7 +192,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TimeInterval" substitutionGroup="PriceableObject_">
+	<xsd:element name="TimeInterval" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A factor influencing access rights definition or calculation of prices.</xsd:documentation>
 		</xsd:annotation>
@@ -349,7 +349,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- == TIME UNIT PRICE.================================ -->
-	<xsd:element name="TimeUnitPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="TimeUnitPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a TIME UNIT: default total price etc.</xsd:documentation>
 		</xsd:annotation>
@@ -388,7 +388,7 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>A set of all possible price features of a TIME UNIT : default total price, discount in value or percentage etc.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -414,7 +414,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- == TIME INTERVAL PRICE.================================ -->
-	<xsd:element name="TimeIntervalPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="TimeIntervalPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a TIME INTERVAL: default total price etc.</xsd:documentation>
 		</xsd:annotation>
@@ -453,7 +453,7 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>A set of all possible price features of a TIME INTERVAL : default total price, discount in value or percentage etc.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
@@ -75,7 +75,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: After Sales USAGE PARAMETER types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====RESELLING=================================================== -->
-	<xsd:element name="Reselling" substitutionGroup="UsageParameter_">
+	<xsd:element name="Reselling" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Common resale conditions (i.e. for exchange or refund) attaching to the product</xsd:documentation>
 		</xsd:annotation>
@@ -251,7 +251,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====EXCHANGING=================================================== -->
-	<xsd:element name="Exchanging" substitutionGroup="UsageParameter_">
+	<xsd:element name="Exchanging" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer.</xsd:documentation>
 		</xsd:annotation>
@@ -323,7 +323,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== REFUNDING================================================= -->
-	<xsd:element name="Refunding" substitutionGroup="UsageParameter_">
+	<xsd:element name="Refunding" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Whether and how the product may be refunded.</xsd:documentation>
 		</xsd:annotation>
@@ -396,7 +396,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ==== REPLACING ================================================== -->
-	<xsd:element name="Replacing" substitutionGroup="UsageParameter_">
+	<xsd:element name="Replacing" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Whether the product can be replaced if lost or stolen.</xsd:documentation>
 		</xsd:annotation>
@@ -448,7 +448,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<!-- ======================================================================= -->
 	<!-- ====TRANSFERABILITY=================================================== -->
-	<xsd:element name="Transferability" substitutionGroup="UsageParameter_">
+	<xsd:element name="Transferability" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterBooking_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterBooking_version.xsd
@@ -75,7 +75,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Booking USAGE PARAMETER types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====  PURCHASE  WINDOW================================================ -->
-	<xsd:element name="PurchaseWindow" substitutionGroup="UsageParameter_">
+	<xsd:element name="PurchaseWindow" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer.</xsd:documentation>
 		</xsd:annotation>
@@ -164,7 +164,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====BOOKING POLICY=================================================== -->
-	<xsd:element name="BookingPolicy" abstract="true" substitutionGroup="UsageParameter_">
+	<xsd:element name="BookingPolicy" abstract="true" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -218,7 +218,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====RESERVING=================================================== -->
-	<xsd:element name="Reserving" substitutionGroup="UsageParameter_">
+	<xsd:element name="Reserving" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer.</xsd:documentation>
 		</xsd:annotation>
@@ -345,7 +345,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====RESERVING=================================================== -->
-	<xsd:element name="Cancelling" substitutionGroup="UsageParameter_">
+	<xsd:element name="Cancelling" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to use the public transport service instead of the original customer.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_version.xsd
@@ -67,7 +67,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Charging USAGE PARAMETER types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ==== CHARGING POLICY USER PARAMETER ================================================ -->
-	<xsd:element name="ChargingPolicy" substitutionGroup="UsageParameter_">
+	<xsd:element name="ChargingPolicy" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Policy regarding different aspects of charging such as credit limits.</xsd:documentation>
 		</xsd:annotation>
@@ -141,7 +141,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== PENALTY POLICY USER PARAMETER ================================================ -->
-	<xsd:element name="PenaltyPolicy" substitutionGroup="UsageParameter_">
+	<xsd:element name="PenaltyPolicy" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Policy regarding different aspects of penalty charges, for example repeated entry at the same station, no ticket etc.</xsd:documentation>
 		</xsd:annotation>
@@ -210,7 +210,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== SUBSCRIBING USER PARAMETER ================================================ -->
-	<xsd:element name="Subscribing" substitutionGroup="UsageParameter_">
+	<xsd:element name="Subscribing" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Parameters relating to paying by Subscribing for a product. +v1.1</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
@@ -73,7 +73,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Eligibility USAGE PARAMETER types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====USER PROFILE================================================= -->
-	<xsd:element name="UserProfile" substitutionGroup="UsageParameter_">
+	<xsd:element name="UserProfile" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The social profile of a passenger, based on age group, education, profession, social status, sex etc., often used for allowing discounts: 18-40 years old, graduates, drivers, unemployed, women etc.</xsd:documentation>
 		</xsd:annotation>
@@ -205,7 +205,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====COMMERCIAL PROFILE=================================================== -->
-	<xsd:element name="CommercialProfile" substitutionGroup="UsageParameter_">
+	<xsd:element name="CommercialProfile" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A category of users depending on their commercial relations with the operator (frequency of use, amount of purchase etc.), often used for allowing discounts.</xsd:documentation>
 		</xsd:annotation>
@@ -266,7 +266,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====GROUP TICKET=================================================== -->
-	<xsd:element name="GroupTicket" substitutionGroup="UsageParameter_">
+	<xsd:element name="GroupTicket" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics of persons entitled to travel including the holder of the access right.</xsd:documentation>
 		</xsd:annotation>
@@ -418,7 +418,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CompanionProfile" substitutionGroup="UsageParameter_">
+	<xsd:element name="CompanionProfile" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics (weight, volume) of luggage that a holder of an access right is entitled to carry.</xsd:documentation>
 		</xsd:annotation>
@@ -690,7 +690,7 @@ Rail transport, Roads and Road transport
 	<!-- ======================================================================= -->
 	<!-- ======================================================================= -->
 	<!-- ==== ELIGIBILITY CHANGE POLICY QUALIFICATION. ================================================== -->
-	<xsd:element name="EligibilityChangePolicy" substitutionGroup="UsageParameter_">
+	<xsd:element name="EligibilityChangePolicy" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The policy to apply if ta user's eligibility as a USER PROFILE changes.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEntitlement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEntitlement_version.xsd
@@ -64,7 +64,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Entitlement USAGE PARAMETER types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====ENTITLEMENT GIVEN================================================= -->
-	<xsd:element name="EntitlementGiven" substitutionGroup="UsageParameter_">
+	<xsd:element name="EntitlementGiven" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A right to a SERVICE ACCESS RIGHT is given by a FARE PRODUCT.</xsd:documentation>
 		</xsd:annotation>
@@ -120,7 +120,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====ENTITLEMENT REQUIRED================================================= -->
-	<xsd:element name="EntitlementRequired" substitutionGroup="UsageParameter_">
+	<xsd:element name="EntitlementRequired" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A rerirement to a SERVICE ACCESS RIGHT in order to purchase or use PRODUCT.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterLuggage_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterLuggage_version.xsd
@@ -61,7 +61,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Luggage USAGE PARAMETER types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ====LUGGAGE ALLOWANCE=================================================== -->
-	<xsd:element name="LuggageAllowance" substitutionGroup="UsageParameter_">
+	<xsd:element name="LuggageAllowance" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The number and characteristics (weight, volume) of luggage that a holder of an access right is entitled to carry.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_version.xsd
@@ -78,7 +78,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: Travel USAGE PARAMETER types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ==== ROUND TRIP ================================================ -->
-	<xsd:element name="RoundTrip" substitutionGroup="UsageParameter_">
+	<xsd:element name="RoundTrip" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Properties relating to single or return trip use of a fare.</xsd:documentation>
 		</xsd:annotation>
@@ -147,7 +147,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== ROUTING ================================================ -->
-	<xsd:element name="Routing" substitutionGroup="UsageParameter_">
+	<xsd:element name="Routing" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Limitations on routing of a fare.</xsd:documentation>
 		</xsd:annotation>
@@ -216,7 +216,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== STEP LIMIT ================================================ -->
-	<xsd:element name="StepLimit" substitutionGroup="UsageParameter_">
+	<xsd:element name="StepLimit" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Geographical parameter limiting the access rights by counts of stops, sections or zones.</xsd:documentation>
 		</xsd:annotation>
@@ -290,7 +290,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== FREQUENCY OF USE ================================================= -->
-	<xsd:element name="FrequencyOfUse" substitutionGroup="UsageParameter_">
+	<xsd:element name="FrequencyOfUse" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The limits of usage frequency for a FARE PRODUCT (or one of its components) or a SALES OFFER PACKAGE during a specific VALIDITY PERIOD. There may be different tariffs depending on how often the right is consumed during the period.</xsd:documentation>
 		</xsd:annotation>
@@ -365,7 +365,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====USAGE VALIDITY PERIOD.================================================ -->
-	<xsd:element name="UsageValidityPeriod" substitutionGroup="UsageParameter_">
+	<xsd:element name="UsageValidityPeriod" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A time limitation for validity of a FARE PRODUCT or a SALES OFFER PACKAGE. It may be composed of a standard duration (e.g. 3 days, 1 month) and/or fixed start/end dates and times.</xsd:documentation>
 		</xsd:annotation>
@@ -535,7 +535,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:complexType>
 	<!-- ====SUSPENDING.================================================ -->
-	<xsd:element name="Suspending" substitutionGroup="UsageParameter_">
+	<xsd:element name="Suspending" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Conditions governing suspension of a FARE PRODUCT, e.g. period pass or subscription.</xsd:documentation>
 		</xsd:annotation>
@@ -614,7 +614,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== INTERCHANGING ================================================ -->
-	<xsd:element name="Interchanging" substitutionGroup="UsageParameter_">
+	<xsd:element name="Interchanging" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Limitations on making changes within a trip.</xsd:documentation>
 		</xsd:annotation>
@@ -703,7 +703,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== MINIMUM STAY ================================================ -->
-	<xsd:element name="MinimumStay" substitutionGroup="UsageParameter_">
+	<xsd:element name="MinimumStay" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Details of any minimum stay at the destination required to use the product.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameter_version.xsd
@@ -71,7 +71,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="frameContainmentStructure">
 				<xsd:sequence>
-					<xsd:element ref="UsageParameter_" maxOccurs="unbounded"/>
+					<xsd:element ref="UsageParameter_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -84,18 +84,18 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="oneToManyRelationshipStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="UsageParameterRef"/>
-					<xsd:element ref="UsageParameter_"/>
+					<xsd:element ref="UsageParameter_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ====USAGE PARAMETER=================================================== -->
-	<xsd:element name="UsageParameter_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="PriceableObject_">
+	<xsd:element name="UsageParameter_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Supertype: A parameter used to specify the use of a fare system.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="UsageParameter" abstract="true" substitutionGroup="UsageParameter_">
+	<xsd:element name="UsageParameter" abstract="true" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A parameter used to specify the use of a fare system.</xsd:documentation>
 		</xsd:annotation>
@@ -162,7 +162,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="UsageParameterPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="UsageParameterPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a FARE USAGE PARAMETER: default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_validableElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_validableElement_version.xsd
@@ -103,7 +103,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ValidableElement" substitutionGroup="PriceableObject_">
+	<xsd:element name="ValidableElement" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A sequence or set of FARE STRUCTURE ELEMENTs, grouped together to be validated in one go.</xsd:documentation>
 		</xsd:annotation>
@@ -213,12 +213,12 @@ Rail transport, Roads and Road transport
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="ValidableElementPriceRef"/>
 					<xsd:element ref="ValidableElementPrice"/>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ValidableElementPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="ValidableElementPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a VALIDABLE ELEMENT ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>
@@ -291,7 +291,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ControllableElement" substitutionGroup="PriceableObject_">
+	<xsd:element name="ControllableElement" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The smallest controllable element of public transport consumption, all along which any VALIDITY PARAMETER ASSIGNMENT remains valid.</xsd:documentation>
 		</xsd:annotation>
@@ -430,13 +430,13 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="ControllableElementPriceRef"/>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 					<xsd:element ref="ControllableElementPrice"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ControllableElementPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="ControllableElementPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a CONTROLLABLE ELEMENT ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_parkingTariff/netex_parkingTariff_version.xsd
+++ b/xsd/netex_part_3/part3_parkingTariff/netex_parkingTariff_version.xsd
@@ -304,7 +304,7 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="ParkingPriceRef"/>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 					<xsd:element name="ParkingPrice" type="ParkingPrice_VersionedChildStructure">
 						<xsd:annotation>
 							<xsd:documentation>A set of all possible price features of a PARKING TARIFF ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
@@ -314,7 +314,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ParkingPrice" substitutionGroup="FarePrice_">
+	<xsd:element name="ParkingPrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a PARKING TARIFF ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerEligibility_version.xsd
@@ -40,17 +40,17 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="CustomerEligibility_" maxOccurs="unbounded"/>
+					<xsd:element ref="CustomerEligibility_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerEligibility_" type="VersionedChildStructure" abstract="true" substitutionGroup="VersionedChild">
+	<xsd:element name="CustomerEligibility_Dummy" type="VersionedChildStructure" abstract="true" substitutionGroup="VersionedChild">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Type for Customer Eligibility.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="CustomerEligibility" abstract="true" substitutionGroup="CustomerEligibility_">
+	<xsd:element name="CustomerEligibility" abstract="true" substitutionGroup="CustomerEligibility_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Whether a specific TRANSPORT CUSTOMER is eligible for a FARE PRODUCT with a specific validity Parameter. This may be subject to a particular VALIDITY CONDITION.</xsd:documentation>
 		</xsd:annotation>
@@ -103,7 +103,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== USER PROFILE ELIGIBILITY ======================================== -->
-	<xsd:element name="UserProfileEligibility" substitutionGroup="CustomerEligibility_">
+	<xsd:element name="UserProfileEligibility" substitutionGroup="CustomerEligibility_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Whether a specific TRANSPORT CUSTOMER is eligible for a FARE PRODUCT with a specific USER PROFILE as a validity parameter.</xsd:documentation>
 		</xsd:annotation>
@@ -154,7 +154,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== COMMERCIAL PROFILE ELIGIBILITY ======================================== -->
-	<xsd:element name="CommercialProfileEligibility" substitutionGroup="CustomerEligibility_">
+	<xsd:element name="CommercialProfileEligibility" substitutionGroup="CustomerEligibility_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Whether a specific TRANSPORT CUSTOMER is eligible for a FARE PRODUCT with a specific COMMERCIAL PROFILE as a validity parameter.</xsd:documentation>
 		</xsd:annotation>
@@ -205,7 +205,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== RESIDENTIAL QUALIFICATION ELIGIBILITY ======================================== -->
-	<xsd:element name="ResidentialQualificationEligibility" substitutionGroup="CustomerEligibility_">
+	<xsd:element name="ResidentialQualificationEligibility" substitutionGroup="CustomerEligibility_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Whether a specific TRANSPORT CUSTOMER is eligible for a FARE PRODUCT with a specific RESIDENTIAL QUALIFICATION as a validity parameter.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
@@ -350,7 +350,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfCustomerPurchasePackagesRef" type="GroupOfCustomerPurchasePackagesRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfCustomerPurchasePackagesRef" type="GroupOfCustomerPurchasePackagesRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF CUSTOMER PURCHASE PACKAGEs.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -162,17 +162,17 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="TravelSpecificationRef"/>
-					<xsd:element ref="TravelSpecification_"/>
+					<xsd:element ref="TravelSpecification_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="TravelSpecification_" abstract="true" type="DataManagedObjectStructure" substitutionGroup="FareContractEntry_">
+	<xsd:element name="TravelSpecification_Dummy" abstract="true" type="DataManagedObjectStructure" substitutionGroup="FareContractEntry_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type for FARE CONTRACT ENTRY.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="TravelSpecification" substitutionGroup="TravelSpecification_">
+	<xsd:element name="TravelSpecification" substitutionGroup="TravelSpecification_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The recording of a specification by a customer of parameters giving details of an intended consumption (e.g. origin and destination of a travel).</xsd:documentation>
 		</xsd:annotation>
@@ -259,13 +259,13 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:choice minOccurs="0">
 				<xsd:element ref="FarePriceRef"/>
-				<xsd:element ref="CellRef_"/>
+				<xsd:element ref="CellRef_Dummy"/>
 			</xsd:choice>
 			<xsd:group ref="PaymentAmountGroup"/>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====  REQUESTED TRAVEL SPECIFICATION  ================================================ -->
-	<xsd:element name="RequestedTravelSpecification" substitutionGroup="TravelSpecification_">
+	<xsd:element name="RequestedTravelSpecification" substitutionGroup="TravelSpecification_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The recording of a specification by a customer of parameters giving details of an intended consumption (e.g. origin and destination of a travel).</xsd:documentation>
 		</xsd:annotation>
@@ -329,7 +329,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="OfferedTravelSpecification" substitutionGroup="TravelSpecification_">
+	<xsd:element name="OfferedTravelSpecification" substitutionGroup="TravelSpecification_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of parameters giving details of the intended  consumption of access rights associated with an offer or a purchase. (e.g. origin and destination of a travel, class of travel, etc.).
 .</xsd:documentation>
@@ -393,7 +393,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SpecificParameterAssignment" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="SpecificParameterAssignment" substitutionGroup="AccessRightParameterAssignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A VALIDITY PARAMETER ASSIGNMENT specifying practical parameters during a TRAVEL SPECIFICATION, within a given fare structure (e.g. the origin or destination zone in a zone-counting system).</xsd:documentation>
 		</xsd:annotation>
@@ -494,7 +494,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerPurchasePackage" substitutionGroup="PriceableObject_">
+	<xsd:element name="CustomerPurchasePackage" substitutionGroup="PriceableObject_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A purchase of a SALES OFFER PACKAGE by a CUSTOMER, giving access rights to one or several FARE PRODUCTs materialised as one or several TRAVEL DOCUMENTs.</xsd:documentation>
 		</xsd:annotation>
@@ -844,12 +844,12 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>A set of all possible price features of a CUSTOMER PURCHASE PACKAGE ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="CellRef_"/>
+					<xsd:element ref="CellRef_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerPurchasePackagePrice" substitutionGroup="FarePrice_">
+	<xsd:element name="CustomerPurchasePackagePrice" substitutionGroup="FarePrice_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of all possible price features of a CUSTOMER PURCHASE PACKAGE ELEMENT: default total price, discount in value or percentage etc.</xsd:documentation>
 		</xsd:annotation>
@@ -913,7 +913,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="CustomerPurchaseParameterAssignment" substitutionGroup="AccessRightParameterAssignment_">
+	<xsd:element name="CustomerPurchaseParameterAssignment" substitutionGroup="AccessRightParameterAssignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A VALIDITY PARAMETER ASSIGNMENT specifying practical parameters for use in a CUSTOMER PURCHASE PACKAGE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_mediumApplication_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_mediumApplication_version.xsd
@@ -90,7 +90,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>MEDIUM APPLICATION data types</xsd:documentation>
 	</xsd:annotation>
-	<xsd:element name="MediumAccessDevice_" abstract="true">
+	<xsd:element name="MediumAccessDevice_Dummy" abstract="true">
 		<xsd:annotation>
 			<xsd:documentation>A component (mobile phone, smart card, etc) with the necessary facilities (hardware and software) to host a MEDIUM APPLICATION INSTANCE and communicate with a control device. +v1.2.2.</xsd:documentation>
 		</xsd:annotation>
@@ -365,7 +365,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====  MEDIUM ACCESS DEVICE SECURITY LISTING ======================================== -->
-	<xsd:element name="MediumAccessDeviceSecurityListing" substitutionGroup="SecurityListing_">
+	<xsd:element name="MediumAccessDeviceSecurityListing" substitutionGroup="SecurityListing_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a MEDIUM ACCESS DEVICE on a SECURITY LIST. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_retailConsortium_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_retailConsortium_support.xsd
@@ -78,7 +78,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="OrganisationIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="RetailConsortiumRef" type="RetailConsortiumRefStructure" substitutionGroup="OrganisationRef_">
+	<xsd:element name="RetailConsortiumRef" type="RetailConsortiumRefStructure" substitutionGroup="OrganisationRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a RETAIL CONSORTIUM.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_retailConsortium_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_retailConsortium_version.xsd
@@ -129,7 +129,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="RetailConsortium" substitutionGroup="Organisation_">
+	<xsd:element name="RetailConsortium" substitutionGroup="Organisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A group of ORGANISATIONs formally incorporated as a retailer of fare products.</xsd:documentation>
 		</xsd:annotation>
@@ -269,7 +269,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Status of Retail device.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 			<xsd:element ref="TypeOfRetailDeviceRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
@@ -319,7 +319,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexType>
 	</xsd:element>
 	<!-- ====CUSTOMER SECURITY LISTING ======================================== -->
-	<xsd:element name="RetailDeviceSecurityListing" substitutionGroup="SecurityListing_">
+	<xsd:element name="RetailDeviceSecurityListing" substitutionGroup="SecurityListing_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a RETAIL DEVICE on a sSECURITY LIST.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
@@ -424,17 +424,17 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="FareContractEntryRef"/>
-					<xsd:element ref="FareContractEntry_"/>
+					<xsd:element ref="FareContractEntry_Dummy"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="FareContractEntry_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="FareContractEntry_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type for FARE CONTRACT ENTRY.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="FareContractEntry" abstract="true" substitutionGroup="FareContractEntry_">
+	<xsd:element name="FareContractEntry" abstract="true" substitutionGroup="FareContractEntry_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A log entry describing an event referring to the life of a FARE CONTRACT: initial contracting, sales, validation entries, etc. A subset of a FARE CONTRACT ENTRY is often materialised on a TRAVEL DOCUMENT.</xsd:documentation>
 		</xsd:annotation>
@@ -809,7 +809,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==== CUSTOMER ACCOUNT SECURITY LISTING ======================================== -->
-	<xsd:element name="CustomerAccountSecurityListing" substitutionGroup="SecurityListing_">
+	<xsd:element name="CustomerAccountSecurityListing" substitutionGroup="SecurityListing_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a CUSTOMER ACCOUNT on a SECURITY LIST.</xsd:documentation>
 		</xsd:annotation>
@@ -864,7 +864,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== CUSTOMER SECURITY LISTING ======================================== -->
-	<xsd:element name="CustomerSecurityListing" substitutionGroup="SecurityListing_">
+	<xsd:element name="CustomerSecurityListing" substitutionGroup="SecurityListing_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a CUSTOMER on a SECURITY LIST.</xsd:documentation>
 		</xsd:annotation>
@@ -919,7 +919,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== FARE CONTRACT SECURITY LISTING ======================================== -->
-	<xsd:element name="FareContractSecurityListing" substitutionGroup="SecurityListing_">
+	<xsd:element name="FareContractSecurityListing" substitutionGroup="SecurityListing_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a FARE CONTRACT on a SECURITY LIST.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_salesTransaction_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_salesTransaction_version.xsd
@@ -128,7 +128,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SalesTransaction" substitutionGroup="FareContractEntry_">
+	<xsd:element name="SalesTransaction" substitutionGroup="FareContractEntry_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A SALE OF a FIXED PACKAGE or a SALE OF a RELOADABLE PACKAGE.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_travelDocument_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_travelDocument_version.xsd
@@ -169,7 +169,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====FARE CONTRACT SECURITY LISTING ======================================== -->
-	<xsd:element name="TravelDocumentSecurityListing" substitutionGroup="SecurityListing_">
+	<xsd:element name="TravelDocumentSecurityListing" substitutionGroup="SecurityListing_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A listing of a TRAVEL DOCUMENT on a SECURITY LIST.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_fm/netex_nm_accessCredentialsAssignment_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_accessCredentialsAssignment_version.xsd
@@ -139,7 +139,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleAccessCredentialsAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleAccessCredentialsAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a MEDIUM ACCESS DEVICE to a specific VEHICLE, to allow the user (TRANSPORT CUSTOMER) to access the vehicle (tyically for VEHICLE SHARING or VEHICLE RENTAL). This allocation may have validity limitations. +V1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_fm/netex_nm_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_usageParameterEligibility_version.xsd
@@ -59,7 +59,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: New Modes Eligibility USAGE PARAMETER types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ==== VEHICLE POOLER PROFILE================================================= -->
-	<xsd:element name="VehiclePoolerProfile" substitutionGroup="UsageParameter_">
+	<xsd:element name="VehiclePoolerProfile" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A set of USER PARAMETERS characterising access rights to VEHICLE POOLING SERVICE. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_fm/netex_nm_usageParameterRental_version.xsd
+++ b/xsd/netex_part_5/part5_fm/netex_nm_usageParameterRental_version.xsd
@@ -59,7 +59,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEX: RENTAL USAGE PARAMETER types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ==== RENTAL PENALTY POLICY USER PARAMETER ================================================ -->
-	<xsd:element name="RentalPenaltyPolicy" substitutionGroup="UsageParameter_">
+	<xsd:element name="RentalPenaltyPolicy" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Policy regarding different aspects of RENTAL service penalty charges, for example loss of vehicle. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -133,7 +133,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== RENTAL OPTION ================================================ -->
-	<xsd:element name="RentalOption" substitutionGroup="UsageParameter_">
+	<xsd:element name="RentalOption" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Parameters relating to paying by RentalOption for a product. +v1.1</xsd:documentation>
 		</xsd:annotation>
@@ -175,7 +175,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==== RENTAL OPTION ================================================ -->
-	<xsd:element name="AdditionalDriverOption" substitutionGroup="UsageParameter_">
+	<xsd:element name="AdditionalDriverOption" substitutionGroup="UsageParameter_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Parameters relating to paying by AdditionalDriverOption for a product. +v1.1</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_mobilityServiceConstraintZone_support.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_mobilityServiceConstraintZone_support.xsd
@@ -185,7 +185,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="PoolOfVehiclesRef" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="PoolOfVehiclesRef" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an POOL OF VEHICLEs. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPlace_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPlace_version.xsd
@@ -66,12 +66,12 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="VehicleMeetingPlace_" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="VehicleMeetingPlace_Dummy" minOccurs="0" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleMeetingPlace_" type="AddressablePlace_VersionStructure" abstract="true" substitutionGroup="Place">
+	<xsd:element name="VehicleMeetingPlace_Dummy" type="AddressablePlace_VersionStructure" abstract="true" substitutionGroup="Place">
 		<xsd:annotation>
 			<xsd:documentation>DUMMY type to workaround SG limitation.</xsd:documentation>
 		</xsd:annotation>
@@ -138,7 +138,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== VEHICLE MEETING PLACE ======================================================== -->
-	<xsd:element name="VehiclePoolingMeetingPlace" substitutionGroup="VehicleMeetingPlace_">
+	<xsd:element name="VehiclePoolingMeetingPlace" substitutionGroup="VehicleMeetingPlace_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A place where vehicles/passengers meet to change mode of transportation, for boarding, alighting, pick-up, drop-off, etc. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -193,7 +193,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== VEHICLE SHARING PARKING AREA  ============================================================ -->
-	<xsd:element name="VehicleSharingParkingArea" substitutionGroup="ParkingArea_">
+	<xsd:element name="VehicleSharingParkingArea" substitutionGroup="ParkingArea_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A dedicated part of the PARKING AREA for vehicle sharing or rental which is composed of one or more VEHICLE SHARING PARKING BAYs. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -262,7 +262,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== VEHICLE POOLING PARKING AREA  ============================================================ -->
-	<xsd:element name="VehiclePoolingParkingArea" substitutionGroup="ParkingArea_">
+	<xsd:element name="VehiclePoolingParkingArea" substitutionGroup="ParkingArea_Dummy">
 		<xsd:annotation>
 			<xsd:documentation> A dedicated space of a PARKING AREA for either vehicles active in a pooling service or vehicles of a pooling service users where vehicles are left for a longer time. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -331,7 +331,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== VEHICLE SHARING PARKING BAY  ============================================================ -->
-	<xsd:element name="VehicleSharingParkingBay" substitutionGroup="ParkingBay_">
+	<xsd:element name="VehicleSharingParkingBay" substitutionGroup="ParkingBay_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A spot in the PARKING AREA dedicated to vehicle sharing or rental.	+v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -400,7 +400,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ==== VEHICLE POOLING PARKING BAY  ============================================================ -->
-	<xsd:element name="VehiclePoolingParkingBay" substitutionGroup="ParkingBay_">
+	<xsd:element name="VehiclePoolingParkingBay" substitutionGroup="ParkingBay_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A dedicated space of a PARKING AREA for either vehicles active in a pooling service or vehicles of a pooling service users where vehicles are left for a longer time. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPointAssignment_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleMeetingPointAssignment_version.xsd
@@ -88,7 +88,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleMeetingPointAssignment_" abstract="true" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleMeetingPointAssignment_Dummy" abstract="true" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Type to work round SG restrictions.</xsd:documentation>
 		</xsd:annotation>
@@ -115,7 +115,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:element name="VehicleMeetingPointAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleMeetingPointAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a VEHICLE MEETING POINT to a SITE COMPONENT or ADDRESSABLE PLACE (for vehicle pooling or vehicle sharing purposes). +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -170,7 +170,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== DYNAMIC VEHICLE MEETING POINT ASSIGNMENT ========================================== -->
-	<xsd:element name="DynamicVehicleMeetingPointAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="DynamicVehicleMeetingPointAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dynamic allocation of a VEHICLE MEETING ASSIGNMENT. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleParkingAreaInformation_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleParkingAreaInformation_version.xsd
@@ -65,7 +65,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx NM PARKING BAY STATUS data types</xsd:documentation>
 	</xsd:annotation>
-	<xsd:element name="ParkingLogEntry_" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="ParkingLogEntry_Dummy" type="DataManagedObjectStructure" abstract="true" substitutionGroup="DataManagedObject">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type for Parking Log ENTRY.</xsd:documentation>
 		</xsd:annotation>
@@ -79,7 +79,7 @@ Rail transport, Roads and Road transport
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="ParkingBayConditionRef"/>
 					<xsd:element ref="RentalAvailabilityRef"/>
-					<xsd:element ref="ParkingLogEntry_">
+					<xsd:element ref="ParkingLogEntry_Dummy">
 						<xsd:annotation>
 							<xsd:documentation>Dummy type for Parking Log ENTRY. +v1.2.2</xsd:documentation>
 						</xsd:annotation>
@@ -95,7 +95,7 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="ParkingLogEntry_" maxOccurs="unbounded">
+					<xsd:element ref="ParkingLogEntry_Dummy" maxOccurs="unbounded">
 						<xsd:annotation>
 							<xsd:documentation>Dummy type for Parking Log ENTRY. +v1.2.2</xsd:documentation>
 						</xsd:annotation>
@@ -105,7 +105,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==== VEHICLE SHARING PARKING BAY  ============================================================ -->
-	<xsd:element name="MonitoredVehicleSharingParkingBay" substitutionGroup="ParkingBay_">
+	<xsd:element name="MonitoredVehicleSharingParkingBay" substitutionGroup="ParkingBay_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A spot in the PARKING AREA dedicated to MONITORED VEHICLE SHARING or rental. 	+v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -243,7 +243,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====RENTAL AVAILABILITY ============================================================ -->
-	<xsd:element name="RentalAvailability" substitutionGroup="ParkingLogEntry_">
+	<xsd:element name="RentalAvailability" substitutionGroup="ParkingLogEntry_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A summary of the status of the rental at a SITE at a given point on time. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -325,7 +325,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== PARKING BAY STATUS ============================================================ -->
-	<xsd:element name="ParkingBayCondition" substitutionGroup="ParkingLogEntry_">
+	<xsd:element name="ParkingBayCondition" substitutionGroup="ParkingLogEntry_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A record of the status of the PARKING BAY at a given moment in time. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_nd/netex_nm_vehicleServicePlaceAssignment_version.xsd
+++ b/xsd/netex_part_5/part5_nd/netex_nm_vehicleServicePlaceAssignment_version.xsd
@@ -76,7 +76,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="VehicleServicePlaceAssignment_" abstract="true" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleServicePlaceAssignment_Dummy" abstract="true" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy Type to work round SG restrfictions.</xsd:documentation>
 		</xsd:annotation>
@@ -103,7 +103,7 @@ Rail transport, Roads and Road transport
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:element name="VehicleServicePlaceAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleServicePlaceAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a place to a MOBILITY SERVICE. +V1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -154,7 +154,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- ====== TAXI SERVICE PLACE ASSIGNMENT ========================================== -->
-	<xsd:element name="TaxiServicePlaceAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="TaxiServicePlaceAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a TAXI SERVICE to a TAXI PARKING or a TAXI STAND. +V1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -213,7 +213,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== VEHICLE POOLING PLACE ASSIGNMENT ========================================== -->
-	<xsd:element name="VehiclePoolingPlaceAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="VehiclePoolingPlaceAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a VEHICLE POOLING SERVICE to a VEHICLE POOLING PARKING AREA or a VEHICLE POOLING MEETING PLACE. +V1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -274,7 +274,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== VEHICLE POOLING PLACE ASSIGNMENT ========================================== -->
-	<xsd:element name="VehicleSharingPlaceAssignment" substitutionGroup="Assignment_">
+	<xsd:element name="VehicleSharingPlaceAssignment" substitutionGroup="Assignment_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>The allocation of a VEHICLE SHARING AREA to any vehicle sharing or rental service. +V1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd
+++ b/xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd
@@ -80,17 +80,17 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="MobilityService_" maxOccurs="unbounded"/>
+					<xsd:element ref="MobilityService_Dummy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="MobilityService_" type="Equipment_VersionStructure" abstract="true" substitutionGroup="Equipment">
+	<xsd:element name="MobilityService_Dummy" type="Equipment_VersionStructure" abstract="true" substitutionGroup="Equipment">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type to work around SG limitation.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="MobilityService" type="MobilityService_VersionStructure" abstract="true" substitutionGroup="MobilityService_">
+	<xsd:element name="MobilityService" type="MobilityService_VersionStructure" abstract="true" substitutionGroup="MobilityService_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A named service available over a widespread area, for example car pooling, rental, etc. The service may be accessible at designated SITES it for which it can be considered as a n additional form of immaterial EQUIPMENT. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -127,7 +127,7 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="TypeOfMobilityServiceRef" minOccurs="0"/>
-			<xsd:element ref="OrganisationRef_" minOccurs="0"/>
+			<xsd:element ref="OrganisationRef_Dummy" minOccurs="0"/>
 			<xsd:element ref="TopographicPlaceRef" minOccurs="0"/>
 			<xsd:choice>
 				<xsd:element name="serviceBookingArrangements" type="serviceBookingArrangements_RelStructure" minOccurs="0">
@@ -144,12 +144,12 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ===== COMMON VEHICLE SERVICE ============================================= -->
-	<xsd:element name="CommonVehicleService_" type="Equipment_VersionStructure" abstract="true" substitutionGroup="MobilityService_">
+	<xsd:element name="CommonVehicleService_Dummy" type="Equipment_VersionStructure" abstract="true" substitutionGroup="MobilityService_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type to work around SG limitation.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="CommonVehicleService" abstract="true" substitutionGroup="CommonVehicleService_">
+	<xsd:element name="CommonVehicleService" abstract="true" substitutionGroup="CommonVehicleService_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A transport service offer related to VEHICLEs. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -213,12 +213,12 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- =====  VEHICLE POOLING SERVICE ============================================= -->
-	<xsd:element name="VehiclePoolingService_" type="MobilityService_VersionStructure" abstract="true" substitutionGroup="CommonVehicleService_">
+	<xsd:element name="VehiclePoolingService_Dummy" type="MobilityService_VersionStructure" abstract="true" substitutionGroup="CommonVehicleService_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Dummy type to work around SG limitation.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="VehiclePoolingService" abstract="true" substitutionGroup="VehiclePoolingService_">
+	<xsd:element name="VehiclePoolingService" abstract="true" substitutionGroup="VehiclePoolingService_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A transport service that connects users (driver and passenger(s)) for carrying out trips. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -276,7 +276,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- =====  TAXI SERVICE ============================================= -->
-	<xsd:element name="TaxiService" substitutionGroup="VehiclePoolingService_">
+	<xsd:element name="TaxiService" substitutionGroup="VehiclePoolingService_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A type of VEHICLE POOLING SERVICE where the service may be regulated according to a particular taxi policy.
 .  +v1.2.2</xsd:documentation>
@@ -339,7 +339,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- =====  GENERAL POOLING SERVICE ============================================= -->
-	<xsd:element name="CarPoolingService" substitutionGroup="VehiclePoolingService_">
+	<xsd:element name="CarPoolingService" substitutionGroup="VehiclePoolingService_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A transport service that connects users (driver and passenger(s)) for carrying out trips. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -401,7 +401,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- =====  ChauffeuredVehicle SERVICE ============================================= -->
-	<xsd:element name="ChauffeuredVehicleService" substitutionGroup="VehiclePoolingService_">
+	<xsd:element name="ChauffeuredVehicleService" substitutionGroup="VehiclePoolingService_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A type of VEHICLE POOLING SERVICE which can only be used by prior arrangement and where the driver has a commercial agreement with the user. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -463,7 +463,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence/>
 	</xsd:group>
 	<!-- =====  VEHICLE SHARING SERVICE ============================================= -->
-	<xsd:element name="VehicleSharingService" substitutionGroup="CommonVehicleService_">
+	<xsd:element name="VehicleSharingService" substitutionGroup="CommonVehicleService_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A transport service offer related to VEHICLE SHARING. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -541,7 +541,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- =====  VEHICLE RENTAL SERVICE ============================================= -->
-	<xsd:element name="VehicleRentalService" substitutionGroup="CommonVehicleService_">
+	<xsd:element name="VehicleRentalService" substitutionGroup="CommonVehicleService_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>A transport service offer related to VEHICLE RENTAL. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_rc/netex_nm_onlineService_support.xsd
+++ b/xsd/netex_part_5/part5_rc/netex_nm_onlineService_support.xsd
@@ -74,7 +74,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="OrganisationIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="OnlineServiceOperatorRef" type="OnlineServiceOperatorRefStructure" substitutionGroup="OrganisationRef_">
+	<xsd:element name="OnlineServiceOperatorRef" type="OnlineServiceOperatorRefStructure" substitutionGroup="OrganisationRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to an ONLINE SERVICE OPERATOR. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_rc/netex_nm_onlineService_version.xsd
+++ b/xsd/netex_part_5/part5_rc/netex_nm_onlineService_version.xsd
@@ -56,7 +56,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>ONLINE SERVICE types for NeTEx New Modes</xsd:documentation>
 	</xsd:annotation>
 	<!-- ==== ONLINE SERVICE OPERATOR ========================================================= -->
-	<xsd:element name="OnlineServiceOperator" substitutionGroup="TransportOrganisation_">
+	<xsd:element name="OnlineServiceOperator" substitutionGroup="TransportOrganisation_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>An organisation that provides online access to an ONLINE SERVICE without operating transportation services of travellers. +v1.2.2</xsd:documentation>
 		</xsd:annotation>
@@ -160,7 +160,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="OnlineService" substitutionGroup="MobilityService_">
+	<xsd:element name="OnlineService" substitutionGroup="MobilityService_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Any remotely accessible service providing access to any mode of transportation and/or information related to transportation services. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_sj/netex_nm_singleJourneyService_support.xsd
+++ b/xsd/netex_part_5/part5_sj/netex_nm_singleJourneyService_support.xsd
@@ -103,7 +103,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="GroupOfEntitiesIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="GroupOfSingleJourneysRef" type="GroupOfSingleJourneysRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+	<xsd:element name="GroupOfSingleJourneysRef" type="GroupOfSingleJourneysRefStructure" substitutionGroup="GroupOfEntitiesRef_Dummy">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a GROUP OF SINGLE JOURNEYs. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_5/part5_sj/netex_nm_singleJourneyService_version.xsd
+++ b/xsd/netex_part_5/part5_sj/netex_nm_singleJourneyService_version.xsd
@@ -81,7 +81,7 @@ Rail transport, Roads and Road transport
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="SingleJourney" substitutionGroup="Journey_" id="SingleJourney">
+	<xsd:element name="SingleJourney" substitutionGroup="Journey_Dummy" id="SingleJourney">
 		<xsd:annotation>
 			<xsd:documentation>The planned movement of a public transport vehicle on a DAY TYPE from the start point to the end point of a JOURNEY PATTERN on a specified ROUTE. +v1.2.2</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_service/netex_filter_frame.xsd
+++ b/xsd/netex_service/netex_filter_frame.xsd
@@ -131,7 +131,7 @@ Roads and road transport
 				</xsd:annotation>
 				<xsd:complexType>
 					<xsd:sequence>
-						<xsd:element ref="PlaceRef_" minOccurs="0" maxOccurs="unbounded"/>
+						<xsd:element ref="PlaceRef_Dummy" minOccurs="0" maxOccurs="unbounded"/>
 					</xsd:sequence>
 				</xsd:complexType>
 			</xsd:element>

--- a/xsd/netex_service/netex_filter_object.xsd
+++ b/xsd/netex_service/netex_filter_object.xsd
@@ -125,7 +125,7 @@ Roads and road transport
 				</xsd:annotation>
 				<xsd:complexType>
 					<xsd:choice maxOccurs="unbounded">
-						<xsd:element ref="ValidityCondition_"/>
+						<xsd:element ref="ValidityCondition_Dummy"/>
 					</xsd:choice>
 				</xsd:complexType>
 			</xsd:element>


### PR DESCRIPTION
This pull request is in essence "trivial" because it only replaces _ with _Dummy.

But I think it does show that there are still things that look and feel wrong. For example, NeTEx defines the abstract "Organisation" it, is abstract so it cannot be used. The abstract object is not used to derive objects from. I wonder why we won't rename Organisation_Dummy to Organisation. In the overview below *all* elements that are in fact abstract, but still have a matching Dummy.

@Aurige @nick-knowles please review, and let me know if the Dummy element can be just renamed to the "Transmodel-abstract".
```
Pair: Assignment_Dummy in ./xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd
      Assignment       in ./xsd/netex_framework/netex_genericFramework/netex_assignment_version.xsd

Pair: CommonVehicleService_Dummy in ./xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd
      CommonVehicleService       in ./xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd

Pair: ConventionalModeOfOperation_Dummy in ./xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_version.xsd
      ConventionalModeOfOperation       in ./xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_version.xsd

Pair: CustomerEligibility_Dummy in ./xsd/netex_part_3/part3_salesTransactions/netex_customerEligibility_version.xsd
      CustomerEligibility       in ./xsd/netex_part_3/part3_salesTransactions/netex_customerEligibility_version.xsd

Pair: DeckEntrance_Dummy in ./xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
      DeckEntrance       in ./xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd

Pair: DeckSpace_Dummy in ./xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
      DeckSpace       in ./xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd

Pair: FareContractEntry_Dummy in ./xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd
      FareContractEntry       in ./xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd

Pair: FarePrice_Dummy in ./xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
      FarePrice       in ./xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd

Pair: FareProduct_Dummy in ./xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
      FareProduct       in ./xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd

Pair: GroupOfEntitiesRef_Dummy in ./xsd/netex_framework/netex_genericFramework/netex_grouping_support.xsd
      GroupOfEntitiesRef       in ./xsd/netex_framework/netex_genericFramework/netex_grouping_support.xsd

Pair: GroupOfPointsRef_Dummy in ./xsd/netex_framework/netex_genericFramework/netex_pointAndLink_support.xsd
      GroupOfPointsRef       in ./xsd/netex_framework/netex_genericFramework/netex_pointAndLink_support.xsd

Pair: InfrastructureLink_Dummy in ./xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_version.xsd
      InfrastructureLink       in ./xsd/netex_part_1/part1_networkDescription/netex_networkInfrastructure_version.xsd

Pair: Interchange_Dummy in ./xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
      Interchange       in ./xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd

Pair: Journey_Dummy in ./xsd/netex_part_2/part2_journeyTimes/netex_journey_version.xsd
      Journey       in ./xsd/netex_part_2/part2_journeyTimes/netex_journey_version.xsd

Pair: MobilityService_Dummy in ./xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd
      MobilityService       in ./xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd

Pair: ModeOfOperation_Dummy in ./xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_version.xsd
      ModeOfOperation       in ./xsd/netex_framework/netex_reusableComponents/netex_modeOfOperation_version.xsd

Pair: Organisation_Dummy in ./xsd/netex_framework/netex_genericFramework/netex_organisation_version.xsd
      Organisation       in ./xsd/netex_framework/netex_genericFramework/netex_organisation_version.xsd

Pair: PriceableObject_Dummy in ./xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
      PriceableObject       in ./xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd

Pair: Section_Dummy in ./xsd/netex_framework/netex_genericFramework/netex_section_version.xsd
      Section       in ./xsd/netex_framework/netex_genericFramework/netex_section_version.xsd

Pair: SecurityListing_Dummy in ./xsd/netex_framework/netex_reusableComponents/netex_securityList_version.xsd
      SecurityListing       in ./xsd/netex_framework/netex_reusableComponents/netex_securityList_version.xsd

Pair: TransportOrganisation_Dummy in ./xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_version.xsd
      TransportOrganisation       in ./xsd/netex_framework/netex_reusableComponents/netex_transportOrganisation_version.xsd

Pair: UsageParameter_Dummy in ./xsd/netex_part_3/part3_fares/netex_usageParameter_version.xsd
      UsageParameter       in ./xsd/netex_part_3/part3_fares/netex_usageParameter_version.xsd

Pair: VehiclePoolingService_Dummy in ./xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd
      VehiclePoolingService       in ./xsd/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd
```