### PR TITLE
Update of the XMLSpy project

### DIFF
--- a/NeTEx.spp
+++ b/NeTEx.spp
@@ -642,7 +642,9 @@
 		</Folder>
 		<Folder FolderName="gml">
 			<File FilePath="xsd\gml\basicTypes.xsd" HomeFolder="Yes"/>
+			<File FilePath="xsd\gml\geometryAggregates-extract-v3_2_1.xsd" HomeFolder="Yes"/>
 			<File FilePath="xsd\gml\geometryBasic0d1d-extract-v3_2_1.xsd" HomeFolder="Yes"/>
+			<File FilePath="xsd\gml\geometryPrimitives-extract-v3_2_1.xsd" HomeFolder="Yes"/>
 			<File FilePath="xsd\gml\gml_extract_all_objects_v_3_2_1.xsd" HomeFolder="Yes"/>
 			<File FilePath="xsd\gml\gmlBase-extract-v3_2_1.xsd" HomeFolder="Yes"/>
 			<File FilePath="xsd\gml\gmlBasic2d-extract-v3_2_1-.xsd" HomeFolder="Yes"/>


### PR DESCRIPTION
2 files were missing in the gml extract: they were in NeTEx, and used, but not in the XML Spy project, the result being that seaching for elements like Multisurface was failling in XML Spy search