### PR TITLE
Add additional vehicle entrance dimensions

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -738,6 +738,13 @@
 					<xsd:documentation>Height of ENTRANCE from ground.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="EdgeToTrackCenterDistance" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Distance from the outer edge of the DECK ENTRANCE (including any
+						fixed outer steps) to the vehicle center (center point between axles). Can be used to
+						calculate the horizontal gap in conjunction with the EdgeToTrackCenterDistance from QUAY. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="DeckEntranceClassificationGroup">

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -740,9 +740,7 @@
 			</xsd:element>
 			<xsd:element name="EdgeToTrackCenterDistance" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Distance from the outer edge of the DECK ENTRANCE (including any
-						fixed outer steps) to the vehicle center (center point between axles). Can be used to
-						calculate the horizontal gap in conjunction with the EdgeToTrackCenterDistance from QUAY. +v2.1</xsd:documentation>
+					<xsd:documentation>Distance from the outer edge of the DECK ENTRANCE (including any fixed outer steps) to the vehicle center (center point between axles). Can be used to calculate the horizontal gap in conjunction with the EdgeToTrackCenterDistance from QUAY. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -715,7 +715,7 @@
 	</xsd:group>
 	<xsd:group name="DeckEntrancePositionGroup">
 		<xsd:annotation>
-			<xsd:documentation>Positional ements for a DECK ENTRANCE.</xsd:documentation>
+			<xsd:documentation>Positional elements for a DECK ENTRANCE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="VehicleSide" type="VehicleSideEnumeration" minOccurs="0">
@@ -749,7 +749,7 @@
 	</xsd:group>
 	<xsd:group name="DeckEntranceClassificationGroup">
 		<xsd:annotation>
-			<xsd:documentation>EClassification lements for a DECK ENTRANCE.</xsd:documentation>
+			<xsd:documentation>Classification elements for a DECK ENTRANCE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="DeckEntranceType" type="DeckEntranceTypeEnumeration" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -234,7 +234,16 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="BoardingHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Maximum step height to board.</xsd:documentation>
+					<xsd:documentation>Height of the outer entry point (lowest step), measured from the ground
+						of the road or top of the rail. Together with FloorHeight this describes the lowest and
+						highest point of an entrance.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="FloorHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Height of the inner entry point (floor next to the entrance), measured
+						from the ground of the road or top of the rail. Together with BoardingHeight this
+						describes the lowest and highest point of an entrance. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="EquipmentLength" type="LengthType" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -232,6 +232,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Number of steps to board or alight from VEHICLE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="StepHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Height of an individual step, in metres rounded to the nearest cm.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="BoardingHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Height of the outer entry point (lowest step), measured from the ground

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -266,6 +266,13 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Normal gap between VEHICLE and platform.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="EdgeToTrackCenterDistance" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Distance from the outer entry point (including any
+						fixed outer steps) to the vehicle center (center point between axles). Can be used to
+						calculate the horizontal gap in conjunction with the EdgeToTrackCenterDistance from QUAY. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="AccessVehicleEquipmentDoorGroup">

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -239,16 +239,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="BoardingHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Height of the outer entry point (lowest step), measured from the ground
-						of the road or top of the rail. Together with FloorHeight this describes the lowest and
-						highest point of an entrance.</xsd:documentation>
+					<xsd:documentation>Height of the outer entry point (lowest step), measured from the ground of the road or top of the rail. Together with FloorHeight this describes the lowest and highest point of an entrance.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="FloorHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Height of the inner entry point (floor next to the entrance), measured
-						from the ground of the road or top of the rail. Together with BoardingHeight this
-						describes the lowest and highest point of an entrance. +v2.1</xsd:documentation>
+					<xsd:documentation>Height of the inner entry point (floor next to the entrance), measured from the ground of the road or top of the rail. Together with BoardingHeight this describes the lowest and highest point of an entrance. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="EquipmentLength" type="LengthType" minOccurs="0">
@@ -268,9 +264,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="EdgeToTrackCenterDistance" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Distance from the outer entry point (including any
-						fixed outer steps) to the vehicle center (center point between axles). Can be used to
-						calculate the horizontal gap in conjunction with the EdgeToTrackCenterDistance from QUAY. +v2.1</xsd:documentation>
+					<xsd:documentation>Distance from the outer entry point (including any fixed outer steps) to the vehicle center (center point between axles). Can be used to calculate the horizontal gap in conjunction with the EdgeToTrackCenterDistance from QUAY. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -411,16 +411,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="BoardingHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Height of the outer entry point (lowest step), measured from the ground
-						of the road or top of the rail. Together with FloorHeight this describes the lowest and
-						highest point of an entrance. +v1.1</xsd:documentation>
+					<xsd:documentation>Height of the outer entry point (lowest step), measured from the ground of the road or top of the rail. Together with FloorHeight this describes the lowest and highest point of an entrance. +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="FloorHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Height of the inner entry point (floor next to the entrance), measured
-						from the ground of the road or top of the rail. Together with BoardingHeight this
-						describes the lowest and highest point of an entrance. +v2.1</xsd:documentation>
+					<xsd:documentation>Height of the inner entry point (floor next to the entrance), measured from the ground of the road or top of the rail. Together with BoardingHeight this describes the lowest and highest point of an entrance. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="GapToPlatform" type="LengthType" minOccurs="0">
@@ -430,9 +426,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="EdgeToTrackCenterDistance" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Distance from the outer entry point (including any
-						fixed outer steps) to the vehicle center (center point between axles). Can be used to
-						calculate the horizontal gap in conjunction with the EdgeToTrackCenterDistance from QUAY. +v2.1</xsd:documentation>
+					<xsd:documentation>Distance from the outer entry point (including any fixed outer steps) to the vehicle center (center point between axles). Can be used to calculate the horizontal gap in conjunction with the EdgeToTrackCenterDistance from QUAY. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -428,6 +428,13 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Expected maximal gap between VEHICLE and platform. +v1.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="EdgeToTrackCenterDistance" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Distance from the outer entry point (including any
+						fixed outer steps) to the vehicle center (center point between axles). Can be used to
+						calculate the horizontal gap in conjunction with the EdgeToTrackCenterDistance from QUAY. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== VEHICLE TYPE ==================================================== -->

--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -411,7 +411,16 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="BoardingHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Maximum step height to board. +v1.1</xsd:documentation>
+					<xsd:documentation>Height of the outer entry point (lowest step), measured from the ground
+						of the road or top of the rail. Together with FloorHeight this describes the lowest and
+						highest point of an entrance. +v1.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="FloorHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Height of the inner entry point (floor next to the entrance), measured
+						from the ground of the road or top of the rail. Together with BoardingHeight this
+						describes the lowest and highest point of an entrance. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="GapToPlatform" type="LengthType" minOccurs="0">

--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAccess_version.xsd
@@ -32,7 +32,7 @@
 					CD Add new attribute to StairEquipment; WithoutRiser.
 						  NJSK Review:  move order  to be with other  step properties
 					CD  Add new attribute to EscalatorEquipment;  EscalatorWithLanding
-					CD  Add new attributes to TravellatorEquipment; Length, Slope and IntegratesAnEscalatorPart  
+					CD  Add new attributes to TravellatorEquipment; Length, Slope and IntegratesAnEscalatorPart
 							 NJSK Review:  correct  name of IntegratesAnEscalatorPart
 					CD Add new attributs  to EscalatorEquipment: MagneticInductionLoop, GroundMarkAlignedWithButton, TactileGroundFloorButton ExternalFloorSelection
 								 NJSK Review:  correct  name of GroundMarkAlignedWithButton
@@ -40,7 +40,7 @@
 								 NJSK Review: change order to group with like properties
 					CD Add new attributes  to EntranceEquipment: AudioOrVideoIntercom, Airlock, DoorstepMark AudioPassthroughIndicator, OpeningNecessaryForce
 								 NJSK Review: change order to group with like properties
-								  NJSK Review: NB AudioOrVideoIntercom overlap with EntranceAttention								  
+								  NJSK Review: NB AudioOrVideoIntercom overlap with EntranceAttention
 					CD Add new attributes  to QueuingEquipment:  DisabledPriority QueuingSeatedPossible.
  				</Date>
 				<Date><Modified>2019-05-27</Modified>Fix add missing DropKerbOutside value to Entrance Eqeuipment
@@ -48,7 +48,7 @@
 					Move WIthoutRaiser to be specifc to Staircase.
 				</Date>
 				<Date><Modified>2019-05-27</Modified>Doc tidy up
-					Rename Accoustic(six)  to AUdio 
+					Rename Accoustic(six)  to AUdio
 					Correct comments
 				</Date>
 				<Date><Modified>2021-07-14</Modified>Fix catch up - Make Access Equipment Abstarct
@@ -376,12 +376,12 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="StepHeight" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Depth of an individual step, in metres rounded to the nearest cm.</xsd:documentation>
+					<xsd:documentation>Height of an individual step, in metres rounded to the nearest cm.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="StepLength" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>The length of the step, in metres rounded to the nearest cm.</xsd:documentation>
+					<xsd:documentation>Length of an individual step, in metres rounded to the nearest cm.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="StepColourContrast" type="xsd:boolean" minOccurs="0">


### PR DESCRIPTION
Resolves #900

This slightly deviates from the original proposal in the following ways:
- Add `StepHeight` to `AccessVehicleEquipment` (required by  [German handbook of accessible travel chains](https://www.delfi.de/media/delfi_handbuch_barrierefreie_reiseketten_2._auflage_2024.pdf) - see code 3111)
- Add `EdgeToTrackCenterDistance` to `VehicleType` and `AccessVehicleEquipment` to allow modelling/calculating the horizontal gap withot the necessity of having a DeckPlan.