### PR TITLE
Remove wrong `PlaceName` property from `HeadingSign`

### DIFF
--- a/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentSigns_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentSigns_version.xsd
@@ -270,11 +270,6 @@ Rail transport, Roads and Road transport
 							<xsd:group ref="SignEquipmentGroup"/>
 						</xsd:sequence>
 						<xsd:sequence>
-							<xsd:element name="PlaceName" type="MultilingualString">
-								<xsd:annotation>
-									<xsd:documentation>Name of Stop.</xsd:documentation>
-								</xsd:annotation>
-							</xsd:element>
 							<xsd:group ref="HeadingSignGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
@@ -294,11 +289,6 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="SignEquipment_VersionStructure">
 				<xsd:sequence>
-					<xsd:element name="PlaceName" type="MultilingualString">
-						<xsd:annotation>
-							<xsd:documentation>Name of Stop.</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
 					<xsd:group ref="HeadingSignGroup"/>
 				</xsd:sequence>
 			</xsd:extension>


### PR DESCRIPTION
While working at #944 I noticed that in order to add any `HeadingSign` specific property (like `LineName` or `TransportSubmode`) I had to define a `PlaceName` first. This is probably a copy paste error from `PlaceSign`. At least to me it doesn't make sense why there should be a mandatory `PlaceName` property that must exist in order to define any properties from the `HeadingSignGroup`.

It is probably to late but since this would be a braking change perhaps it could be included in 2.0. Otherwise I could also deprecate the property and set it to ` minOccurs="0"`. Let me know what you think @Aurige @skinkie 