### PR TITLE
Wrong assignment of ActualVehicleEquipmentGroup

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -133,6 +133,33 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="AccessibilityAssessment" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
+	<xsd:group name="_DeprecatedActualVehicleEquipmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Helper group to retain backwards compatibility with deprecation notice. Will be removed in 3.0.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+				<xsd:element name="Units" type="xsd:integer" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED: Use Units from ACTUAL VEHICLE EQUIPMENT. Will be removed in 3.0.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element ref="VehicleTypeRef" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED: Use VehicleTypeRef from ACTUAL VEHICLE EQUIPMENT. Will be removed in 3.0.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element ref="EquipmentRef" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED: This should NOT be used. Will be removed in 3.0.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element ref="AccessibilityAssessment" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED: Use AccessibilityAssessment from ACTUAL VEHICLE EQUIPMENT or on the actual element like DECK ENTRANCE. Will be removed in 3.0.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
 	<!-- ======================================================================= -->
 	<xsd:element name="AccessVehicleEquipment" substitutionGroup="PassengerEquipment">
 		<xsd:annotation>
@@ -159,6 +186,7 @@ Rail transport, Roads and Road transport
 							</xsd:element>
 						</xsd:sequence>
 						<xsd:sequence>
+							<xsd:group ref="_DeprecatedActualVehicleEquipmentGroup"/>
 							<xsd:group ref="AccessVehicleEquipmentGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
@@ -326,6 +354,7 @@ Rail transport, Roads and Road transport
 							</xsd:element>
 						</xsd:sequence>
 						<xsd:sequence>
+							<xsd:group ref="_DeprecatedActualVehicleEquipmentGroup"/>
 							<xsd:group ref="WheelchairVehicleEquipmentGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -172,7 +172,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Type for an ACCESS VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="ActualVehicleEquipment_VersionStructure">
+			<xsd:extension base="PassengerEquipment_VersionStructure">
 				<xsd:sequence>
 					<xsd:group ref="AccessVehicleEquipmentGroup"/>
 				</xsd:sequence>
@@ -339,7 +339,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Type for a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="ActualVehicleEquipment_VersionStructure">
+			<xsd:extension base="PassengerEquipment_VersionStructure">
 				<xsd:sequence>
 					<xsd:group ref="WheelchairVehicleEquipmentGroup"/>
 				</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -159,9 +159,6 @@ Rail transport, Roads and Road transport
 							</xsd:element>
 						</xsd:sequence>
 						<xsd:sequence>
-							<xsd:group ref="ActualVehicleEquipmentGroup"/>
-						</xsd:sequence>
-						<xsd:sequence>
 							<xsd:group ref="AccessVehicleEquipmentGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
@@ -327,9 +324,6 @@ Rail transport, Roads and Road transport
 									<xsd:documentation>Whether the EQUIPMENT is fixed at a place or min a vehicle.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="ActualVehicleEquipmentGroup"/>
 						</xsd:sequence>
 						<xsd:sequence>
 							<xsd:group ref="WheelchairVehicleEquipmentGroup"/>


### PR DESCRIPTION
I noticed that `EquipmentRef` can be assigned to `WheelchairVehicleEquipment` and `AccessVehicleEquipment`. This seemed wrong to me. My guess is that the `ActualVehicleEquipmentGroup` shouldn't be part of them.

Currently things like this can be done:
```xml
<ActualVehicleEquipment>
   <Units>3</Units>
   <AccessVehicleEquipmentRef ref="a"/>
</ActualVehicleEquipment>

<AccessVehicleEquipment version="any" id="a">
   <Units>3</Units><!-- feels wrong -->
   <BedEquipmentRef ref="x"/><!-- feels wrong -->
   <!-- equipment properties here -->
</AccessVehicleEquipment>
```
I think only this should be possible
```xml
<ActualVehicleEquipment>
   <Units>3</Units>
   <AccessVehicleEquipmentRef ref="a"/>
</ActualVehicleEquipment>

<AccessVehicleEquipment version="any" id="a">
   <!-- equipment properties here -->
</AccessVehicleEquipment>
```

The [commit](https://github.com/NeTEx-CEN/NeTEx/commit/c07c8850e009b308f23e6a3fdecd903d97d6479b) states that these changes are originally from @nick-knowles 