### PR TITLE
Add vehicle access equipments

### DIFF
--- a/examples/functions/vehicle/Netex_vehicleEquipments_01.xml
+++ b/examples/functions/vehicle/Netex_vehicleEquipments_01.xml
@@ -22,7 +22,7 @@
 						</AccessVehicleEquipment>
 						<!-- Boarding with the folding step -->
 						<RetractableStepVehicleEquipment version="any" id="RetractableStepVehicleEquipment:1">
-							<EquipmentLength>0.2</EquipmentLength>
+							<ExternalLength>0.2</ExternalLength>
 							<BoardingHeight>0.35</BoardingHeight>
 							<NumberOfTreads>1</NumberOfTreads>
 							<!-- Includes all steps required to board -->
@@ -39,7 +39,7 @@
 						<!-- Boarding with the folding steps -->
 						<RetractableStepVehicleEquipment version="any" id="RetractableStepVehicleEquipment:2">
 							<!-- Only the last step reaches out of the train, this is the only step contributing to the equipment length -->
-							<EquipmentLength>0.2</EquipmentLength>
+							<ExternalLength>0.2</ExternalLength>
 							<!-- Boarding height of the lowest folding step -->
 							<BoardingHeight>0.25</BoardingHeight>
 							<NumberOfTreads>3</NumberOfTreads>
@@ -51,7 +51,7 @@
 							https://www.youtube.com/watch?v=5D-TWksvc3Y
 						-->
 						<RetractableStepVehicleEquipment version="any" id="RetractableStepVehicleEquipment:3">
-							<EquipmentLength>0.2</EquipmentLength>
+							<ExternalLength>0.2</ExternalLength>
 							<!-- If the gap is smaller than the full length of the sliding step, it can still be used as it automatically stops extending on impact. -->
 							<IsAdjustableLength>true</IsAdjustableLength>
 							<BearingCapacity>250</BearingCapacity>
@@ -70,8 +70,8 @@
 							<AssistanceRequired>false</AssistanceRequired>
 							<InOperationDuration>PT8S</InOperationDuration>
 							<OutOperationDuration>PT8S</OutOperationDuration>
-							<EquipmentLength>0.678</EquipmentLength>
-							<EquipmentWidth>0.917</EquipmentWidth>
+							<ExternalLength>0.678</ExternalLength>
+							<ExternalWidth>0.917</ExternalWidth>
 							<BearingCapacity>350</BearingCapacity>
 							<Length>0.678</Length>
 						</RampVehicleEquipment>
@@ -79,8 +79,8 @@
 							<Fixed>true</Fixed>
 							<IsAutomatic>false</IsAutomatic>
 							<AssistanceRequired>true</AssistanceRequired>
-							<EquipmentLength>0.819</EquipmentLength>
-							<EquipmentWidth>1.004</EquipmentWidth>
+							<ExternalLength>0.819</ExternalLength>
+							<ExternalWidth>1.004</ExternalWidth>
 							<BearingCapacity>350</BearingCapacity>
 							<Length>0.819</Length>
 						</RampVehicleEquipment>
@@ -92,8 +92,8 @@
 							<Fixed>false</Fixed>
 							<IsAutomatic>false</IsAutomatic>
 							<AssistanceRequired>true</AssistanceRequired>
-							<EquipmentLength>2</EquipmentLength>
-							<EquipmentWidth>1</EquipmentWidth>
+							<ExternalLength>2</ExternalLength>
+							<ExternalWidth>1</ExternalWidth>
 							<BearingCapacity>350</BearingCapacity>
 							<Length>2</Length>
 						</RampVehicleEquipment>
@@ -107,8 +107,8 @@
 							<InOperationDuration>PT20S</InOperationDuration>
 							<OutOperationDuration>PT20S</OutOperationDuration>
 							<!-- This differs widely from the useable/inner width as the arms of the lift have to be taken into account as well -->
-							<EquipmentLength>3</EquipmentLength>
-							<EquipmentWidth>1.2</EquipmentWidth>
+							<ExternalLength>3</ExternalLength>
+							<ExternalWidth>1.2</ExternalWidth>
 							<BearingCapacity>500</BearingCapacity>
 							<InnerLength>1.5</InnerLength>
 							<InnerWidth>1</InnerWidth>
@@ -124,8 +124,8 @@
 							<AssistanceRequired>false</AssistanceRequired>
 							<InOperationDuration>PT25S</InOperationDuration>
 							<OutOperationDuration>PT25S</OutOperationDuration>
-							<EquipmentLength>0.4</EquipmentLength>
-							<EquipmentWidth>1</EquipmentWidth>
+							<ExternalLength>0.4</ExternalLength>
+							<ExternalWidth>1</ExternalWidth>
 							<BearingCapacity>350</BearingCapacity>
 							<InnerLength>1.2</InnerLength>
 							<InnerWidth>1</InnerWidth>

--- a/examples/functions/vehicle/Netex_vehicleEquipments_01.xml
+++ b/examples/functions/vehicle/Netex_vehicleEquipments_01.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" xsi:schemaLocation="http://www.netex.org.uk/netex ../../../xsd/NeTEx_publication.xsd">
+	<PublicationTimestamp>2010-12-17T09:30:47.0Z</PublicationTimestamp>
+	<ParticipantRef>SYS001</ParticipantRef>
+	<Description>Example of vehicle boarding equipments</Description>
+	<dataObjects>
+		<CompositeFrame version="any" id="CompositeFrame:1">
+			<frames>
+				<!--
+					If multiple boarding equipments are assigned to a vehicle, only one or the other is used in practice.
+				-->
+				<ResourceFrame version="any"  id="ResourceFrame:1">
+					<equipments>
+						<!--
+							ICE with 1 built-in step and 1 foldable step
+							https://www.youtube.com/watch?v=AhU9sVWRblk
+						-->
+						<!-- Boarding without the folding step -->
+						<AccessVehicleEquipment version="any" id="AccessVehicleEquipment:1">
+							<NumberOfSteps>1</NumberOfSteps>
+							<BoardingHeight>0.5</BoardingHeight>
+						</AccessVehicleEquipment>
+						<!-- Boarding with the folding step -->
+						<RetractableStepVehicleEquipment version="any" id="RetractableStepVehicleEquipment:1">
+							<EquipmentLength>0.2</EquipmentLength>
+							<BoardingHeight>0.35</BoardingHeight>
+							<NumberOfTreads>1</NumberOfTreads>
+							<!-- Includes all steps required to board -->
+							<NumberOfSteps>2</NumberOfSteps>
+						</RetractableStepVehicleEquipment>
+						<!--
+							Tram with 3 (optional) foldable steps where the lowest step reaches out of the vehicle entrance
+							https://www.youtube.com/watch?v=rtugyMBb904
+						-->
+						<!-- Boarding without the folding steps -->
+						<AccessVehicleEquipment version="any" id="AccessVehicleEquipment:2">
+							<BoardingHeight>0.7</BoardingHeight>
+						</AccessVehicleEquipment>
+						<!-- Boarding with the folding steps -->
+						<RetractableStepVehicleEquipment version="any" id="RetractableStepVehicleEquipment:2">
+							<!-- Only the last step reaches out of the train, this is the only step contributing to the equipment length -->
+							<EquipmentLength>0.2</EquipmentLength>
+							<!-- Boarding height of the lowest folding step -->
+							<BoardingHeight>0.25</BoardingHeight>
+							<NumberOfTreads>3</NumberOfTreads>
+							<NumberOfSteps>3</NumberOfSteps>
+							<StepHeight>0.15</StepHeight>
+						</RetractableStepVehicleEquipment>
+						<!--
+							Stepless train entrance with sliding step
+							https://www.youtube.com/watch?v=5D-TWksvc3Y
+						-->
+						<RetractableStepVehicleEquipment version="any" id="RetractableStepVehicleEquipment:3">
+							<EquipmentLength>0.2</EquipmentLength>
+							<!-- If the gap is smaller than the full length of the sliding step, it can still be used as it automatically stops extending on impact. -->
+							<IsAdjustableLength>true</IsAdjustableLength>
+							<BearingCapacity>250</BearingCapacity>
+							<BoardingHeight>0.7</BoardingHeight>
+							<NumberOfTreads>1</NumberOfTreads>
+							<!-- The sliding step does not introduce any meaningful vertical height difference it just bridges the horizontal gap. -->
+							<NumberOfSteps>0</NumberOfSteps>
+						</RetractableStepVehicleEquipment>
+						<!--
+							Combi-ramp (electrical sliding ramp and manual fold out ramp)
+							https://www.hubner-group.com/news/pressemeldung/doppelrampe-fuer-doppelte-zuverlaessigkeit-bereits-in-madrid-und-oslo-huebner-transportation-entwickelt-hybrides-einstiegssystem-fuer-busse/
+						-->
+						<RampVehicleEquipment version="any" id="RampVehicleEquipment:1">
+							<Fixed>true</Fixed>
+							<IsAutomatic>true</IsAutomatic>
+							<AssistanceRequired>false</AssistanceRequired>
+							<InOperationDuration>PT8S</InOperationDuration>
+							<OutOperationDuration>PT8S</OutOperationDuration>
+							<EquipmentLength>0.678</EquipmentLength>
+							<EquipmentWidth>0.917</EquipmentWidth>
+							<BearingCapacity>350</BearingCapacity>
+						</RampVehicleEquipment>
+						<RampVehicleEquipment version="any" id="RampVehicleEquipment:2">
+							<Fixed>true</Fixed>
+							<IsAutomatic>false</IsAutomatic>
+							<AssistanceRequired>true</AssistanceRequired>
+							<EquipmentLength>0.819</EquipmentLength>
+							<EquipmentWidth>1.004</EquipmentWidth>
+							<BearingCapacity>350</BearingCapacity>
+						</RampVehicleEquipment>
+						<!--
+							Portable ramp
+							https://www.youtube.com/watch?v=FUpuUMP2U_k
+						-->
+						<RampVehicleEquipment version="any" id="RampVehicleEquipment:3">
+							<Fixed>false</Fixed>
+							<IsAutomatic>false</IsAutomatic>
+							<AssistanceRequired>true</AssistanceRequired>
+							<EquipmentLength>2</EquipmentLength>
+							<EquipmentWidth>1</EquipmentWidth>
+							<BearingCapacity>350</BearingCapacity>
+						</RampVehicleEquipment>
+						<!--
+							Automatic double arm lift
+							https://www.youtube.com/watch?v=Kvycxhss2TA
+						-->
+						<HoistVehicleEquipment version="any" id="HoistVehicleEquipment:1">
+							<IsAutomatic>true</IsAutomatic>
+							<AssistanceRequired>true</AssistanceRequired>
+							<InOperationDuration>PT20S</InOperationDuration>
+							<OutOperationDuration>PT20S</OutOperationDuration>
+							<!-- This differs widely from the useable/inner width as the arms of the lift have to be taken into account as well -->
+							<EquipmentLength>3</EquipmentLength>
+							<EquipmentWidth>1.2</EquipmentWidth>
+							<BearingCapacity>500</BearingCapacity>
+							<InnerLength>1.5</InnerLength>
+							<InnerWidth>1</InnerWidth>
+							<!-- More than the actual boarding height as boarding height is measured from the top of the rail  -->
+							<LiftingHeight>1.2</LiftingHeight>
+						</HoistVehicleEquipment>
+						<!--
+							Automatic tram lift
+							https://www.youtube-nocookie.com/embed/6pWkmiuln28?rel=0
+						-->
+						<HoistVehicleEquipment version="any" id="HoistVehicleEquipment:2">
+							<IsAutomatic>true</IsAutomatic>
+							<AssistanceRequired>false</AssistanceRequired>
+							<InOperationDuration>PT25S</InOperationDuration>
+							<OutOperationDuration>PT25S</OutOperationDuration>
+							<EquipmentLength>0.4</EquipmentLength>
+							<EquipmentWidth>1</EquipmentWidth>
+							<BearingCapacity>350</BearingCapacity>
+							<InnerLength>1.2</InnerLength>
+							<InnerWidth>1</InnerWidth>
+							<LiftingHeight>0.3</LiftingHeight>
+						</HoistVehicleEquipment>
+					</equipments>
+				</ResourceFrame>
+			</frames>
+		</CompositeFrame>
+	</dataObjects>
+</PublicationDelivery>

--- a/examples/functions/vehicle/Netex_vehicleEquipments_01.xml
+++ b/examples/functions/vehicle/Netex_vehicleEquipments_01.xml
@@ -73,6 +73,7 @@
 							<EquipmentLength>0.678</EquipmentLength>
 							<EquipmentWidth>0.917</EquipmentWidth>
 							<BearingCapacity>350</BearingCapacity>
+							<Length>0.678</Length>
 						</RampVehicleEquipment>
 						<RampVehicleEquipment version="any" id="RampVehicleEquipment:2">
 							<Fixed>true</Fixed>
@@ -81,6 +82,7 @@
 							<EquipmentLength>0.819</EquipmentLength>
 							<EquipmentWidth>1.004</EquipmentWidth>
 							<BearingCapacity>350</BearingCapacity>
+							<Length>0.819</Length>
 						</RampVehicleEquipment>
 						<!--
 							Portable ramp
@@ -93,6 +95,7 @@
 							<EquipmentLength>2</EquipmentLength>
 							<EquipmentWidth>1</EquipmentWidth>
 							<BearingCapacity>350</BearingCapacity>
+							<Length>2</Length>
 						</RampVehicleEquipment>
 						<!--
 							Automatic double arm lift

--- a/examples/functions/vehicle/Netex_vehicleEquipments_01.xml
+++ b/examples/functions/vehicle/Netex_vehicleEquipments_01.xml
@@ -92,7 +92,7 @@
 							<Fixed>false</Fixed>
 							<IsAutomatic>false</IsAutomatic>
 							<AssistanceRequired>true</AssistanceRequired>
-							<ExternalLength>2</ExternalLength>
+							<!-- ExternalLength is undefined due to the portability of the ramp. Ultimately the entrance determines how much of the ramp will be outside of the vehicle. -->
 							<ExternalWidth>1</ExternalWidth>
 							<BearingCapacity>350</BearingCapacity>
 							<Length>2</Length>

--- a/examples/functions/vehicle/Netex_vehicleEquipments_02.xml
+++ b/examples/functions/vehicle/Netex_vehicleEquipments_02.xml
@@ -20,8 +20,8 @@
 							<Fixed>true</Fixed>
 							<IsAutomatic>false</IsAutomatic>
 							<AssistanceRequired>true</AssistanceRequired>
-							<EquipmentLength>1</EquipmentLength>
-							<EquipmentWidth>1</EquipmentWidth>
+							<ExternalLength>1</ExternalLength>
+							<ExternalWidth>1</ExternalWidth>
 							<BearingCapacity>350</BearingCapacity>
 						</RampVehicleEquipment>
 					</equipments>

--- a/examples/functions/vehicle/Netex_vehicleEquipments_02.xml
+++ b/examples/functions/vehicle/Netex_vehicleEquipments_02.xml
@@ -9,9 +9,12 @@
 				<ResourceFrame version="any"  id="ResourceFrame:1">
 					<equipments>
 						<AccessVehicleEquipment version="any" id="AccessVehicleEquipment:1">
-							<BoardingHeight>0.3</BoardingHeight>
+							<BoardingHeight>0.2</BoardingHeight>
 							<Kneeling>true</Kneeling>
-							<KneelingBoardingHeight>0.2</KneelingBoardingHeight>
+						</AccessVehicleEquipment>
+						<AccessVehicleEquipment version="any" id="AccessVehicleEquipment:2">
+							<BoardingHeight>0.3</BoardingHeight>
+							<Kneeling>false</Kneeling>
 						</AccessVehicleEquipment>
 						<RampVehicleEquipment version="any" id="RampVehicleEquipment:1">
 							<Fixed>true</Fixed>
@@ -41,8 +44,10 @@
 												<PassengerEntrance version="any" id="PassengerEntrance:1">
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment>
-															<Units>1</Units>
 															<AccessVehicleEquipmentRef ref="AccessVehicleEquipment:1"/>
+														</ActualVehicleEquipment>
+														<ActualVehicleEquipment>
+															<AccessVehicleEquipmentRef ref="AccessVehicleEquipment:2"/>
 														</ActualVehicleEquipment>
 													</actualVehicleEquipments>
 												</PassengerEntrance>
@@ -50,11 +55,12 @@
 												<PassengerEntrance version="any" id="PassengerEntrance:2">
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment>
-															<Units>1</Units>
 															<AccessVehicleEquipmentRef ref="AccessVehicleEquipment:1"/>
 														</ActualVehicleEquipment>
 														<ActualVehicleEquipment>
-															<Units>1</Units>
+															<AccessVehicleEquipmentRef ref="AccessVehicleEquipment:2"/>
+														</ActualVehicleEquipment>
+														<ActualVehicleEquipment>
 															<RampVehicleEquipmentRef ref="RampVehicleEquipment:1"/>
 														</ActualVehicleEquipment>
 													</actualVehicleEquipments>

--- a/examples/functions/vehicle/Netex_vehicleEquipments_02.xml
+++ b/examples/functions/vehicle/Netex_vehicleEquipments_02.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" xsi:schemaLocation="http://www.netex.org.uk/netex ../../../xsd/NeTEx_publication.xsd">
+	<PublicationTimestamp>2010-12-17T09:30:47.0Z</PublicationTimestamp>
+	<ParticipantRef>SYS001</ParticipantRef>
+	<Description>Bus example with kneeling and ramp</Description>
+	<dataObjects>
+		<CompositeFrame version="any" id="CompositeFrame:1">
+			<frames>
+				<ResourceFrame version="any"  id="ResourceFrame:1">
+					<equipments>
+						<AccessVehicleEquipment version="any" id="AccessVehicleEquipment:1">
+							<BoardingHeight>0.3</BoardingHeight>
+							<Kneeling>true</Kneeling>
+							<KneelingBoardingHeight>0.2</KneelingBoardingHeight>
+						</AccessVehicleEquipment>
+						<RampVehicleEquipment version="any" id="RampVehicleEquipment:1">
+							<Fixed>true</Fixed>
+							<IsAutomatic>false</IsAutomatic>
+							<AssistanceRequired>true</AssistanceRequired>
+							<EquipmentLength>1</EquipmentLength>
+							<EquipmentWidth>1</EquipmentWidth>
+							<BearingCapacity>350</BearingCapacity>
+						</RampVehicleEquipment>
+					</equipments>
+
+					<vehicleTypes>
+						<VehicleType version="any" id="VehicleType:1">
+							<Name>Bus</Name>
+							<DeckPlanRef ref="DeckPlan:1"></DeckPlanRef>
+						</VehicleType>
+					</vehicleTypes>
+
+					<deckPlans>
+						<DeckPlan version="any" id="DeckPlan:1">
+							<decks>
+								<Deck version="any" id="Deck:1">
+									<deckSpaces>
+										<PassengerSpace version="any" id="PassengerSpace:1">
+											<deckEntrances>
+												<!-- Front entrance -->
+												<PassengerEntrance version="any" id="PassengerEntrance:1">
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment>
+															<Units>1</Units>
+															<AccessVehicleEquipmentRef ref="AccessVehicleEquipment:1"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+												</PassengerEntrance>
+												<!-- Middle entrance -->
+												<PassengerEntrance version="any" id="PassengerEntrance:2">
+													<actualVehicleEquipments>
+														<ActualVehicleEquipment>
+															<Units>1</Units>
+															<AccessVehicleEquipmentRef ref="AccessVehicleEquipment:1"/>
+														</ActualVehicleEquipment>
+														<ActualVehicleEquipment>
+															<Units>1</Units>
+															<RampVehicleEquipmentRef ref="RampVehicleEquipment:1"/>
+														</ActualVehicleEquipment>
+													</actualVehicleEquipments>
+												</PassengerEntrance>
+											</deckEntrances>
+										</PassengerSpace>
+									</deckSpaces>
+								</Deck>
+							</decks>
+						</DeckPlan>
+					</deckPlans>
+				</ResourceFrame>
+			</frames>
+		</CompositeFrame>
+	</dataObjects>
+</PublicationDelivery>

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -2783,6 +2783,27 @@
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====RetractableStepVehicleEquipment============================== -->
+		<!-- =====RetractableStepVehicleEquipment unique========================== -->
+		<xsd:unique name="RetractableStepVehicleEquipment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [RetractableStepVehicleEquipment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:RetractableStepVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====RetractableStepVehicleEquipment Key ========================== -->
+		<xsd:keyref name="RetractableStepVehicleEquipment_AnyKeyRef" refer="netex:RetractableStepVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:RetractableStepVehicleEquipmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="RetractableStepVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:RetractableStepVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
 		<!-- =====CycleStorageEquipment=========================== -->
 		<!-- =====CycleStorageEquipment unique========================== -->
 		<xsd:unique name="CycleStorageEquipment_UniqueBy_Id_Version">

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -2825,6 +2825,27 @@
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====HoistVehicleEquipment============================== -->
+		<!-- =====HoistVehicleEquipment unique========================== -->
+		<xsd:unique name="HoistVehicleEquipment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [HoistVehicleEquipment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:HoistVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====HoistVehicleEquipment Key ========================== -->
+		<xsd:keyref name="HoistVehicleEquipment_AnyKeyRef" refer="netex:HoistVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:HoistVehicleEquipmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="HoistVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:HoistVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
 		<!-- =====CycleStorageEquipment=========================== -->
 		<!-- =====CycleStorageEquipment unique========================== -->
 		<xsd:unique name="CycleStorageEquipment_UniqueBy_Id_Version">

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -2804,6 +2804,27 @@
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====RampVehicleEquipment============================== -->
+		<!-- =====RampVehicleEquipment unique========================== -->
+		<xsd:unique name="RampVehicleEquipment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [RampVehicleEquipment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:RampVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====RampVehicleEquipment Key ========================== -->
+		<xsd:keyref name="RampVehicleEquipment_AnyKeyRef" refer="netex:RampVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:RampVehicleEquipmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="RampVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:RampVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
 		<!-- =====CycleStorageEquipment=========================== -->
 		<!-- =====CycleStorageEquipment unique========================== -->
 		<xsd:unique name="CycleStorageEquipment_UniqueBy_Id_Version">

--- a/xsd/NeTEx_publication_timetable.xsd
+++ b/xsd/NeTEx_publication_timetable.xsd
@@ -2278,6 +2278,27 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====RampVehicleEquipment============================== -->
+		<!-- =====RampVehicleEquipment unique========================== -->
+		<xsd:unique name="RampVehicleEquipment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [RampVehicleEquipment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:RampVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====RampVehicleEquipment Key ========================== -->
+		<xsd:keyref name="RampVehicleEquipment_AnyKeyRef" refer="netex:RampVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:RampVehicleEquipmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="RampVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:RampVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
 		<!-- =====CycleParkingEquipment============================== -->
 		<!-- =====CycleParkingEquipment unique========================== -->
 		<xsd:unique name="CycleParkingEquipment_UniqueBy_Id_Version">

--- a/xsd/NeTEx_publication_timetable.xsd
+++ b/xsd/NeTEx_publication_timetable.xsd
@@ -2299,6 +2299,27 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====HoistVehicleEquipment============================== -->
+		<!-- =====HoistVehicleEquipment unique========================== -->
+		<xsd:unique name="HoistVehicleEquipment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [HoistVehicleEquipment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:HoistVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====HoistVehicleEquipment Key ========================== -->
+		<xsd:keyref name="HoistVehicleEquipment_AnyKeyRef" refer="netex:HoistVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:HoistVehicleEquipmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="HoistVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:HoistVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
 		<!-- =====CycleParkingEquipment============================== -->
 		<!-- =====CycleParkingEquipment unique========================== -->
 		<xsd:unique name="CycleParkingEquipment_UniqueBy_Id_Version">

--- a/xsd/NeTEx_publication_timetable.xsd
+++ b/xsd/NeTEx_publication_timetable.xsd
@@ -2257,6 +2257,27 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====RetractableStepVehicleEquipment============================== -->
+		<!-- =====RetractableStepVehicleEquipment unique========================== -->
+		<xsd:unique name="RetractableStepVehicleEquipment_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [RetractableStepVehicleEquipment Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:RetractableStepVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====RetractableStepVehicleEquipment Key ========================== -->
+		<xsd:keyref name="RetractableStepVehicleEquipment_AnyKeyRef" refer="netex:RetractableStepVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:RetractableStepVehicleEquipmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="RetractableStepVehicleEquipment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:RetractableStepVehicleEquipment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
 		<!-- =====CycleParkingEquipment============================== -->
 		<!-- =====CycleParkingEquipment unique========================== -->
 		<xsd:unique name="CycleParkingEquipment_UniqueBy_Id_Version">

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
@@ -160,6 +160,33 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
+	<!-- ====== HOIST VEHICLE EQUIPMENT ================================================= -->
+	<xsd:simpleType name="HoistVehicleEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a HOIST VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="VehicleEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="HoistVehicleEquipmentRef" type="HoistVehicleEquipmentRefStructure" substitutionGroup="VehicleEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a HOIST VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="HoistVehicleEquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a HOIST VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VehicleEquipmentRefStructure">
+				<xsd:attribute name="ref" type="HoistVehicleEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a HOIST VEHICLE EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ====== WHEELCHAIR VEHICLE EQUIPMENT ================================================ -->
 	<xsd:simpleType name="WheelchairVehicleEquipmentIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
@@ -134,6 +134,32 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
+	<!-- ====== RAMP VEHICLE EQUIPMENT ================================================= -->
+	<xsd:simpleType name="RampVehicleEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a RAMP VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="VehicleEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="RampVehicleEquipmentRef" type="RampVehicleEquipmentRefStructure" substitutionGroup="VehicleEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a RAMP VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="RampVehicleEquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a RAMP VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VehicleEquipmentRefStructure">
+				<xsd:attribute name="ref" type="RampVehicleEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a RAMP VEHICLE EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
 	<xsd:simpleType name="WheelchairVehicleEquipmentIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_support.xsd
@@ -108,7 +108,32 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<!-- ====== WHEELCHAIR VEHICLE EQUIPMEN ================================================ -->
+	<!-- ====== RETRACTABLE STEP VEHICLE EQUIPMENT ================================================= -->
+	<xsd:simpleType name="RetractableStepVehicleEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a RETRACTABLE STEP VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="VehicleEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="RetractableStepVehicleEquipmentRef" type="RetractableStepVehicleEquipmentRefStructure" substitutionGroup="VehicleEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a RETRACTABLE STEP VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="RetractableStepVehicleEquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a RETRACTABLE STEP VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VehicleEquipmentRefStructure">
+				<xsd:attribute name="ref" type="RetractableStepVehicleEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a RETRACTABLE STEP VEHICLE EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
 	<xsd:simpleType name="WheelchairVehicleEquipmentIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a WHEELCHAIR VEHICLE EQUIPMENT.</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -241,12 +241,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="Kneeling" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether the VEHICLE supports kneeling to lower the boarding height.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="KneelingBoardingHeight" type="LengthType" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Lowest boarding height of the VEHICLE when kneeling.</xsd:documentation>
+					<xsd:documentation>When set, BoardingHeight and FloorHeight values reflect the height when kneeling is active/inactive.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="EquipmentLength" type="LengthType" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -73,6 +73,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="AccessVehicleEquipment"/>
 			<xsd:element ref="WheelchairVehicleEquipment"/>
 			<xsd:element ref="RetractableStepVehicleEquipment"/>
+			<xsd:element ref="RampVehicleEquipment"/>
 		</xsd:choice>
 	</xsd:group>
 	<xsd:complexType name="vehicleEquipments_RelStructure">
@@ -85,6 +86,7 @@ Rail transport, Roads and Road transport
 					<xsd:element ref="AccessVehicleEquipment"/>
 					<xsd:element ref="WheelchairVehicleEquipment"/>
 					<xsd:element ref="RetractableStepVehicleEquipment"/>
+					<xsd:element ref="RampVehicleEquipment"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -420,6 +422,47 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>The height difference of the individual steps or if only one step is described the height difference from the step BOARDING HEIGHT to the VEHICLE BOARDING HEIGHT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:element name="RampVehicleEquipment" substitutionGroup="PassengerEquipment">
+		<xsd:annotation>
+			<xsd:documentation>A special VEHICLE EQUIPMENT to model ramps used to bridge the horizontal and vertical gap between vehicle and platform.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="RampVehicleEquipment_VersionStructure">
+					<xsd:sequence>
+						<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						<xsd:group ref="DataManagedObjectGroup"/>
+						<xsd:group ref="EquipmentGroup"/>
+						<xsd:group ref="PassengerEquipmentGroup"/>
+						<xsd:group ref="RampVehicleEquipmentGroup"/>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="RampVehicleEquipmentIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="RampVehicleEquipment_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a RAMP VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="PassengerEquipment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="RampVehicleEquipmentGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="RampVehicleEquipmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a RAMP VEHICLE EQUIPMENT type.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:group ref="BoardingEquipmentOperationGroup"/>
+			<xsd:group ref="BoardingEquipmentHorizontalGapReductionGroup"/>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -152,11 +152,7 @@ Rail transport, Roads and Road transport
 							<xsd:group ref="EquipmentGroup"/>
 						</xsd:sequence>
 						<xsd:sequence>
-							<xsd:element name="Fixed" type="xsd:boolean" minOccurs="0">
-								<xsd:annotation>
-									<xsd:documentation>Whether the EQUIPMENT is fixed at a place or min a vehicle.</xsd:documentation>
-								</xsd:annotation>
-							</xsd:element>
+							<xsd:group ref="PassengerEquipmentGroup"/>
 						</xsd:sequence>
 						<xsd:sequence>
 							<xsd:group ref="ActualVehicleEquipmentGroup"/>
@@ -332,11 +328,7 @@ Rail transport, Roads and Road transport
 							<xsd:group ref="EquipmentGroup"/>
 						</xsd:sequence>
 						<xsd:sequence>
-							<xsd:element name="Fixed" type="xsd:boolean" minOccurs="0">
-								<xsd:annotation>
-									<xsd:documentation>Whether the EQUIPMENT is fixed at a place or min a vehicle.</xsd:documentation>
-								</xsd:annotation>
-							</xsd:element>
+							<xsd:group ref="PassengerEquipmentGroup"/>
 						</xsd:sequence>
 						<xsd:sequence>
 							<xsd:group ref="ActualVehicleEquipmentGroup"/>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -310,6 +310,34 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
+	<xsd:group name="BoardingEquipmentOperationGroup">
+		<xsd:annotation>
+			<xsd:documentation>Additional information about the operation of the EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="IsAutomatic" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether the EQUIPMENT operates automatically, meaning the entire operation from start to finish requires no manual handling (except of pressing e.g. a button).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="AssistanceRequired" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether the usage or operation of the EQUIPMENT requires assistance, meaning the passenger either physically or legally cannot board/alight independently.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="InOperationDuration" type="xsd:duration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The time it takes to retract the EQUIPMENT. For none automatic equipment an estimated or average usage time can be provided.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="OutOperationDuration" type="xsd:duration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The time it takes to deploy the EQUIPMENT. For none automatic equipment an estimated or average usage time can be provided.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
 	<xsd:element name="WheelchairVehicleEquipment" substitutionGroup="PassengerEquipment">
 		<xsd:annotation>
 			<xsd:documentation>Specialisation of VEHICLE EQUIPMENT for Wheel chair accessibility on board a VEHICLE providing information such as the number of wheel chair areas and the access dimensions.</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -344,7 +344,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Additional information about the horizontal gap the EQUIPMENT can bridge.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="EquipmentLength" type="LengthType" minOccurs="0">
+			<xsd:element name="ExternalLength" type="LengthType" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Length of the EQUIPMENT when fully extended and only the part outside the VEHICLE.</xsd:documentation>
 				</xsd:annotation>
@@ -354,7 +354,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Whether the EQUIPMENT (like a sliding step or telescopic ramp) can be adjusted to be used at shorter lengths. Useful if there is not enough space to deploy the equipment at its full length.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="EquipmentWidth" type="LengthType" minOccurs="0">
+			<xsd:element name="ExternalWidth" type="LengthType" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Width of the EQUIPMENT when fully extended and only the part outside the VEHICLE.</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -520,6 +520,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>The maximum height difference the lift can overcome. In other words the distance between the VEHICLE’s floor height and the lowest point the lift can reach.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="OperatingRadius" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Distance from VEHICLE needed to operate hoist.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -74,6 +74,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="WheelchairVehicleEquipment"/>
 			<xsd:element ref="RetractableStepVehicleEquipment"/>
 			<xsd:element ref="RampVehicleEquipment"/>
+			<xsd:element ref="HoistVehicleEquipment"/>
 		</xsd:choice>
 	</xsd:group>
 	<xsd:complexType name="vehicleEquipments_RelStructure">
@@ -87,6 +88,7 @@ Rail transport, Roads and Road transport
 					<xsd:element ref="WheelchairVehicleEquipment"/>
 					<xsd:element ref="RetractableStepVehicleEquipment"/>
 					<xsd:element ref="RampVehicleEquipment"/>
+					<xsd:element ref="HoistVehicleEquipment"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -463,6 +465,61 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:group ref="BoardingEquipmentOperationGroup"/>
 			<xsd:group ref="BoardingEquipmentHorizontalGapReductionGroup"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:element name="HoistVehicleEquipment" substitutionGroup="PassengerEquipment">
+		<xsd:annotation>
+			<xsd:documentation>A special VEHICLE EQUIPMENT to model hoists and lifts used to bridge the vertical and partially horizontal gap between vehicle and platform.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="HoistVehicleEquipment_VersionStructure">
+					<xsd:sequence>
+						<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						<xsd:group ref="DataManagedObjectGroup"/>
+						<xsd:group ref="EquipmentGroup"/>
+						<xsd:group ref="HoistVehicleEquipmentGroup"/>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="HoistVehicleEquipmentIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="HoistVehicleEquipment_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a HOIST VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="PassengerEquipment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="HoistVehicleEquipmentGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="HoistVehicleEquipmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a HOIST VEHICLE EQUIPMENT type.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:group ref="BoardingEquipmentOperationGroup"/>
+			<xsd:group ref="BoardingEquipmentHorizontalGapReductionGroup"/>
+			<xsd:element name="InnerLength" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The clearance length of the lifting platform. Can be used to determine if a wheelchair fits on the lift.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="InnerWidth" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The clearance width of the lifting platform. Can be used to determine if a wheelchair fits on the lift.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="LiftingHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The maximum height difference the lift can overcome. In other words the distance between the VEHICLE’s floor height and the lowest point the lift can reach.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -338,6 +338,34 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
+	<xsd:group name="BoardingEquipmentHorizontalGapReductionGroup">
+		<xsd:annotation>
+			<xsd:documentation>Additional information about the horizontal gap the EQUIPMENT can bridge.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="EquipmentLength" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Length of the EQUIPMENT when fully extended and only the part outside the VEHICLE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="IsAdjustableLength" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether the EQUIPMENT (like a sliding step or telescopic ramp) can be adjusted to be used at shorter lengths. Useful if there is not enough space to deploy the equipment at its full length.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="EquipmentWidth" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Width of the EQUIPMENT when fully extended and only the part outside the VEHICLE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="BearingCapacity" type="WeightType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Maximum weight that the EQUIPMENT can bear.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
 	<xsd:element name="WheelchairVehicleEquipment" substitutionGroup="PassengerEquipment">
 		<xsd:annotation>
 			<xsd:documentation>Specialisation of VEHICLE EQUIPMENT for Wheel chair accessibility on board a VEHICLE providing information such as the number of wheel chair areas and the access dimensions.</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -72,6 +72,7 @@ Rail transport, Roads and Road transport
 		<xsd:choice>
 			<xsd:element ref="AccessVehicleEquipment"/>
 			<xsd:element ref="WheelchairVehicleEquipment"/>
+			<xsd:element ref="RetractableStepVehicleEquipment"/>
 		</xsd:choice>
 	</xsd:group>
 	<xsd:complexType name="vehicleEquipments_RelStructure">
@@ -83,6 +84,7 @@ Rail transport, Roads and Road transport
 				<xsd:choice maxOccurs="unbounded">
 					<xsd:element ref="AccessVehicleEquipment"/>
 					<xsd:element ref="WheelchairVehicleEquipment"/>
+					<xsd:element ref="RetractableStepVehicleEquipment"/>
 				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -361,6 +363,61 @@ Rail transport, Roads and Road transport
 			<xsd:element name="BearingCapacity" type="WeightType" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Maximum weight that the EQUIPMENT can bear.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:element name="RetractableStepVehicleEquipment" substitutionGroup="PassengerEquipment">
+		<xsd:annotation>
+			<xsd:documentation>A special VEHICLE EQUIPMENT to sliding and folding steps which reduce the horizontal and partially vertical gap between vehicle and platform.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="RetractableStepVehicleEquipment_VersionStructure">
+					<xsd:sequence>
+						<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						<xsd:group ref="DataManagedObjectGroup"/>
+						<xsd:group ref="EquipmentGroup"/>
+						<xsd:group ref="RetractableStepVehicleEquipmentGroup"/>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="RetractableStepVehicleEquipmentIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="RetractableStepVehicleEquipment_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a RETRACTABLE STEP VEHICLE EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="PassengerEquipment_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="RetractableStepVehicleEquipmentGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="RetractableStepVehicleEquipmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a RETRACTABLE STEP VEHICLE EQUIPMENT type.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:group ref="BoardingEquipmentOperationGroup"/>
+			<xsd:group ref="BoardingEquipmentHorizontalGapReductionGroup"/>
+			<xsd:element name="BoardingHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The height from ground to the lowest retractable step. For a sliding step also know as gap filler which are used to bridge the horizontal gap, this is almost identical to the VEHICLE BOARDING HEIGHT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="NumberOfSteps" type="xsd:positiveInteger" minOccurs="0" default="1">
+				<xsd:annotation>
+					<xsd:documentation>Number of retractable steps.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="StepHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The height difference of the individual steps or if only one step is described the height difference from the step BOARDING HEIGHT to the VEHICLE BOARDING HEIGHT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -465,6 +465,11 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:group ref="BoardingEquipmentOperationGroup"/>
 			<xsd:group ref="BoardingEquipmentHorizontalGapReductionGroup"/>
+			<xsd:element name="Length" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The length of the ramp when fully extended. Can be used to calculate the slope together with FloorHeight and PlatformHeight.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -237,6 +237,16 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Maximum step height to board.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="Kneeling" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether the VEHICLE supports kneeling to lower the boarding height.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="KneelingBoardingHeight" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Lowest boarding height of the VEHICLE when kneeling.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="EquipmentLength" type="LengthType" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Length of the EQUIPMENT be it hoist or ramp. When fully extended and only the part outside the VEHICLE. +v2.0</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -512,12 +512,12 @@ Rail transport, Roads and Road transport
 			<xsd:group ref="BoardingEquipmentHorizontalGapReductionGroup"/>
 			<xsd:element name="InnerLength" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>The clearance length of the lifting platform. Can be used to determine if a wheelchair fits on the lift.</xsd:documentation>
+					<xsd:documentation>The usable length of the lifting platform. Can be used to determine if a wheelchair fits on the lift.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="InnerWidth" type="LengthType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>The clearance width of the lifting platform. Can be used to determine if a wheelchair fits on the lift.</xsd:documentation>
+					<xsd:documentation>The usable width of the lifting platform. Can be used to determine if a wheelchair fits on the lift.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="LiftingHeight" type="LengthType" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version.xsd
@@ -414,9 +414,14 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>The height from ground to the lowest retractable step. For a sliding step also know as gap filler which are used to bridge the horizontal gap, this is almost identical to the VEHICLE BOARDING HEIGHT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="NumberOfSteps" type="xsd:positiveInteger" minOccurs="0" default="1">
+			<xsd:element name="NumberOfTreads" type="xsd:positiveInteger" minOccurs="0" default="1">
 				<xsd:annotation>
 					<xsd:documentation>Number of retractable steps.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="NumberOfSteps" type="xsd:nonNegativeInteger" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Total number of steps, starting from the lowest step and also including any fixed steps, to access the VEHICLE. "Steps" is to be understood as rises wherefore it can be 0 for a single sliding step.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="StepHeight" type="LengthType" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_equipment_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_equipment_version.xsd
@@ -220,7 +220,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element name="Fixed" type="xsd:boolean" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether the EQUIPMENT is fixed at a place or min a vehicle.</xsd:documentation>
+					<xsd:documentation>Whether the EQUIPMENT is fixed at a place or in a vehicle.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>


### PR DESCRIPTION
Resolves #873

In general the proposal follows the idea of place equipments like `LiftEquipment` or `RampEquipment` which all derive from an abstract `AccessEquipment`.

This slightly deviates from the original proposal in the following ways:
- Dropped `MinimumEquipmentLength` and `MaximumEquipmentLength` to avoid choice element in favour of `IsAdjustableLength`. Also the minimum length for sliding steps and ramps would usually be close to 0 which isn't very valuable.
- Added `HoistOperatingRadius` to `HoistVehicleEquipment` for feature parity with `AccessVehicleEquipment`
- Added `NumberOfTreads` to `RetractableStepVehicleEquipment` to clarify some scenarios (see aa7c6e3674ec9f9b622cc056f9ffe02e278709c0)
- Modified `AccessVehicleEquipment` & `WheelchairVehicleEquipment` to reuse `PassengerEquipmentGroup` in order to avoid code duplication (see 563fdabf861ca3061a6207dfb067fbf17ae3db9f)
- Dropped `KneelingBoardingHeight` in favour of a more flexible modelling way
- Added real ramp length to reliably calculate the ramps slope because the external length can differ from the ramps length ([example](https://image.mono.ipros.com/public/product/image/42d/2000276458/IPROS1729633800501249010.jpg?w=560&h=560))
- Used "External" instead of "Equipment" to describe outer equipment dimensions