### PR TITLE
Make DeckPlan elements inherit Zone

### DIFF
--- a/examples/functions/deckPlans/DeckPlans-Example.xml
+++ b/examples/functions/deckPlans/DeckPlans-Example.xml
@@ -10,7 +10,7 @@
     There is a wheelchair space at 4D.
     There is a button to request a stop by the exit door and at the top of the staircase.
     The Stair case has Stair equipment describing the step height and handrail.
- 
+
 @@@@ Lower Front @@@@
 @@@@@@@@@@@@@@@@@@@@@
 / Entrance   @Driver@
@@ -51,23 +51,23 @@
 @@@@Upper Back@@@@@@@
 
      DECK PLAN (Doouble decker bus)
-         DECK (lower)           
+         DECK (lower)
             OTHERSPACE (Driver)
             PASSENGER SPACE
               DECK ENTRANCEs (Front, Rear, Stairwell)
                 ENTRANCE EQUIPMENT
                 ENTRANCE SENSOR
               PASSENGER SPOTs (x23)
- 
+
 			  SPOT ROWs (x8)
 			  SPOT COLUMNs (x5)
             OTHER SPACE (Stairwell)
-        DECK (upper)                
+        DECK (upper)
             PASSENGER SPACE
                DECK ENTRANCE (Stairwell)
                PASSENGER SPOTs (x37)
                  SEAT EQUIPMENT
-                 SPOT SENSOR  
+                 SPOT SENSOR
 			  SPOT ROWs (x10)
 			  SPOT COLUMNs (x5)
 
@@ -321,8 +321,8 @@
 											<SmokingAllowed>false</SmokingAllowed>
 											<deckEntrances>
 												<PassengerEntrance version="any" id="dd@deck_1@front">
-													<Label>D1</Label>
 													<Name>Front Door</Name>
+													<Label>D1</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -345,8 +345,8 @@
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="dd@deck_1@rear">
-													<Label>D2</Label>
 													<Name>Rear Door</Name>
+													<Label>D2</Label>
 													<Width>0.95</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -371,8 +371,8 @@
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="dd@deck_1@stairs">
-													<Label>Ii</Label>
 													<Name>Entrance to stairs</Name>
+													<Label>Ii</Label>
 													<Width>0.80</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -790,16 +790,16 @@
 											<SmokingAllowed>false</SmokingAllowed>
 											<deckEntrances>
 												<DeckVehicleEntrance version="any" id="dd@stairwell@base">
-													<Label>Up</Label>
 													<Name>Bottom of stairwell</Name>
+													<Label>Up</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<DeckEntranceType>internal</DeckEntranceType>
 													<IsAutomatic>true</IsAutomatic>
 												</DeckVehicleEntrance>
 												<DeckVehicleEntrance version="any" id="dd@stairwell@top">
-													<Label>Down</Label>
 													<Name>Top of Stairwell</Name>
+													<Label>Down</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<DeckEntranceType>internal</DeckEntranceType>

--- a/examples/functions/deckPlans/DeckPlans-Example_bus.xml
+++ b/examples/functions/deckPlans/DeckPlans-Example_bus.xml
@@ -2,14 +2,14 @@
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2.2" xsi:schemaLocation="http://www.netex.org.uk/netex ../../../xsd/NeTEx_publication.xsd">
 	<!-- Example  DECK PLAN of a double decker bus
 
-   A DECK PLAN is provided for a double decker bus with spiral staircase.  
+   A DECK PLAN is provided for a double decker bus with spiral staircase.
      All the seats are individually identified and have seat equipment.
 
-Lower deck   
+Lower deck
     The Entrances have sensors.
-    The lower deck has a compartment for the driver by the entrance door  at the front and an exit door towards the rear. 
-    
-    The lower deck has fold 3 up seats facing inwards either side at the front, and 4 rows of  bench seats at the back, as 2 either side of the aisle) and with an extra seat in the back middle. 
+    The lower deck has a compartment for the driver by the entrance door  at the front and an exit door towards the rear.
+
+    The lower deck has fold 3 up seats facing inwards either side at the front, and 4 rows of  bench seats at the back, as 2 either side of the aisle) and with an extra seat in the back middle.
     The front area seats can be labelled a Columns A and D and rows 1 to 4
     The back area seats can be labelled as Columns A, B, C, D and rows 5 to 8.
     There is a wheelchair space at 4D.
@@ -64,10 +64,10 @@ Lower deck
 @:::::::::+     +:::::::::@
 @ 03A 03B +     + 03C 03D @
 @:::::::::+     @@@@@@@@@@@
-@ 04A 04B +     | [Stairs]@    
-@:::::::::@     | to lower@ 
+@ 04A 04B +     | [Stairs]@
+@:::::::::@     | to lower@
 @ 05A 05B +     @         @
-@:::::::::@     @@@@@@@@@@@ 
+@:::::::::@     @@@@@@@@@@@
 @ 06A 06B +     + 06C 06D @
 @:::::::::+     +:::::::::@
 @ 07A 07B +     + 07C 07D @
@@ -81,23 +81,23 @@ Lower deck
 @@@@@@  Upper Back   @@@@@@
 
      DECK PLAN (Doouble decker bus)
-         DECK (lower)           
+         DECK (lower)
             OTHERSPACE (Driver)
             PASSENGER SPACE Upper Seating
               DECK ENTRANCEs (Front, Rear, Stairwell)
                 ENTRANCE EQUIPMENT
                 ENTRANCE SENSOR
               PASSENGER SPOTs (x25)
- 
+
 			  SPOT ROWs (x8)
 			  SPOT COLUMNs (x5)
             OTHER SPACE (Stairwell)
-        DECK (upper)                
+        DECK (upper)
             PASSENGER SPACE
                DECK ENTRANCE ( Stairwell)
                PASSENGER SPOTs (x41)
                  SEAT EQUIPMENT Bench
-                 SPOT SENSOR  
+                 SPOT SENSOR
 			  SPOT ROWs (x10)
 			  SPOT COLUMNs (x5)
 -->
@@ -406,8 +406,8 @@ Lower deck
 											<SmokingAllowed>false</SmokingAllowed>
 											<deckEntrances>
 												<PassengerEntrance version="any" id="mb:PE-ddb_deck_1@seating_area@forward_left_entrance">
-													<Label>D1</Label>
 													<Name>Front Door</Name>
+													<Label>D1</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -431,8 +431,8 @@ Lower deck
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="mb:PE-ddb_deck_1@seating_area@rear_entrance">
-													<Label>D2</Label>
 													<Name>Rear Door</Name>
+													<Label>D2</Label>
 													<Width>0.95</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -459,8 +459,8 @@ Lower deck
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="mb:PE-ddb_deck_1@seating_area@stairs_bottom_entrance">
-													<Label>Ii</Label>
 													<Name>Downstairs Entrance to stairs</Name>
+													<Label>Ii</Label>
 													<Width>0.80</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -901,16 +901,16 @@ Lower deck
 											<SmokingAllowed>false</SmokingAllowed>
 											<deckEntrances>
 												<PassengerEntrance version="any" id="mb:PE-ddb_deck_1@stairwell@base">
-													<Label>Up</Label>
 													<Name>Bottom of stairwell</Name>
+													<Label>Up</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<DeckEntranceType>internal</DeckEntranceType>
 													<IsAutomatic>true</IsAutomatic>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="mb:PE-ddb_deck_1@stairwell@top">
-													<Label>Down</Label>
 													<Name>Top of Stairwell</Name>
+													<Label>Down</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<DeckEntranceType>internal</DeckEntranceType>

--- a/examples/functions/deckPlans/DeckPlans-Example_bus.xml
+++ b/examples/functions/deckPlans/DeckPlans-Example_bus.xml
@@ -887,6 +887,12 @@ Lower deck
 										</PassengerSpace>
 										<PassengerSpace version="any" id="mb:PS-ddb_deck_1@stairwell">
 											<Name>Stairwell to upper deck</Name>
+											<!-- Define exact position of the stair case relative to the DECK -->
+											<Centroid>
+												<Location>
+													<gml:pos srsName="urn:ietf:params:geopriv:relative:2d" srsDimension="2">3 10</gml:pos>
+												</Location>
+											</Centroid>
 											<ServiceFacilitySetRef version="any" ref="mb:SFS-ddb_facilities"/>
 											<actualVehicleEquipments>
 												<ActualVehicleEquipment version="any" id="mb:AVE-ddb_deck_1@seating_area@stairwell@staircase">

--- a/examples/functions/deckPlans/DeckPlans-Example_train.xml
+++ b/examples/functions/deckPlans/DeckPlans-Example_train.xml
@@ -850,8 +850,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 											<deckEntrances>
 												<!-- external doors to  carriage -->
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@forward_external_left">
-													<Label>FL</Label>
 													<Name>Left Front Door</Name>
+													<Label>FL</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -882,8 +882,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@forward_external_right">
-													<Label>FR</Label>
 													<Name>Front Right  External  Door</Name>
+													<Label>FR</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -911,8 +911,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@rear_external_left">
-													<Label>RL</Label>
 													<Name>Rear External Door</Name>
+													<Label>RL</Label>
 													<Width>0.95</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -942,8 +942,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@rear_external_right">
-													<Label>RR</Label>
 													<Name>Rear Right External Door</Name>
+													<Label>RR</Label>
 													<Width>0.95</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -971,8 +971,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 												</PassengerEntrance>
 												<!-- end doors to next carriage -->
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@front_end_connecting">
-													<Label>FE</Label>
 													<Name>Rear end door connecting to next carriage</Name>
+													<Label>FE</Label>
 													<Width>0.80</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -993,8 +993,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@back_end_connecting">
-													<Label>RE</Label>
 													<Name>Rear end door connecting to next carriage</Name>
+													<Label>RE</Label>
 													<Width>0.80</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -1033,8 +1033,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 												</PassengerEntrance>
 												<!--Compartment doors internal to carriage -->
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@corridor@compartment_1">
-													<Label>C1</Label>
 													<Name>Compartment 1 door</Name>
+													<Label>C1</Label>
 													<Width>0.80</Width>
 													<Height>1.80</Height>
 													<actualVehicleEquipments>
@@ -1047,36 +1047,36 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsAutomatic>false</IsAutomatic>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@corridor@compartment_2">
-													<Label>C2</Label>
 													<Name>Compartment 2 door</Name>
+													<Label>C2</Label>
 													<DeckEntranceType>internal</DeckEntranceType>
 													<HasDoor>true</HasDoor>
 													<IsAutomatic>false</IsAutomatic>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@corridor@compartment_3">
-													<Label>C3</Label>
 													<Name>Compartment 3 door</Name>
+													<Label>C3</Label>
 													<DeckEntranceType>internal</DeckEntranceType>
 													<HasDoor>true</HasDoor>
 													<IsAutomatic>false</IsAutomatic>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@corridor@compartment_4">
-													<Label>C4</Label>
 													<Name>Compartment 4 door</Name>
+													<Label>C4</Label>
 													<DeckEntranceType>internal</DeckEntranceType>
 													<HasDoor>true</HasDoor>
 													<IsAutomatic>false</IsAutomatic>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@corridor@compartment_5">
-													<Label>C5</Label>
 													<Name>Compartment 5 door</Name>
+													<Label>C5</Label>
 													<DeckEntranceType>internal</DeckEntranceType>
 													<HasDoor>true</HasDoor>
 													<IsAutomatic>false</IsAutomatic>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@corridor@compartment_6">
-													<Label>C6</Label>
 													<Name>Compartment 6 door</Name>
+													<Label>C6</Label>
 													<DeckEntranceType>internal</DeckEntranceType>
 													<HasDoor>true</HasDoor>
 													<IsAutomatic>false</IsAutomatic>
@@ -1171,8 +1171,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 											<SmokingAllowed>false</SmokingAllowed>
 											<deckEntrances>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@toilet">
-													<Label>WC</Label>
 													<Name>Toilet door   connecting to  corridor </Name>
+													<Label>WC</Label>
 													<Width>0.80</Width>
 													<Height>1.80</Height>
 													<actualVehicleEquipments>
@@ -1203,9 +1203,9 @@ The train reverse in  the station and departs, oriented backwards to the right
 										</PassengerSpace>
 										<!-- == 1st class compartments == -->
 										<PassengerSpace version="any" id="rc:PS-slw_deck_1@compartment_1-1st_class">
-											<Label>C1&gt;</Label>
 											<Name>Compartment 1: Seats 01-02</Name>
 											<Description>First class compartment with two beds</Description>
+											<Label>C1&gt;</Label>
 											<ServiceFacilitySetRef version="any" ref="rc:SFS-slw_1st_class_facilities"/>
 											<PublicUse>true</PublicUse>
 											<FareClass>standardClass</FareClass>
@@ -1223,8 +1223,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 											<SmokingAllowed>false</SmokingAllowed>
 											<deckEntrances>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@compartment_1">
-													<Label>C1</Label>
 													<Name>Compartment 1 door   connecting to  corridor </Name>
+													<Label>C1</Label>
 													<Width>0.80</Width>
 													<Height>1.80</Height>
 													<actualVehicleEquipments>
@@ -1336,9 +1336,9 @@ The train reverse in  the station and departs, oriented backwards to the right
 											</passengerSpots>
 										</PassengerSpace>
 										<PassengerSpace version="any" id="rc:PS-slw_deck_1@compartment_2-1st_class">
-											<Label>C2&gt;</Label>
 											<Name>Compartment 2: Seats 02-03</Name>
 											<Description> Rirst class with two beds</Description>
+											<Label>C2&gt;</Label>
 											<ServiceFacilitySetRef version="any" ref="rc:SFS-slw_1st_class_facilities"/>
 											<PublicUse>true</PublicUse>
 											<FareClass>standardClass</FareClass>
@@ -1356,8 +1356,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 											<SmokingAllowed>false</SmokingAllowed>
 											<deckEntrances>
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@compartment_2">
-													<Label>C1</Label>
 													<Name>Compartment 1 door   connecting to  corridor </Name>
+													<Label>C1</Label>
 													<Width>0.80</Width>
 													<Height>1.80</Height>
 													<actualVehicleEquipments>
@@ -1459,9 +1459,9 @@ The train reverse in  the station and departs, oriented backwards to the right
 										</PassengerSpace>
 										<!-- == 2nd class compartments == -->
 										<PassengerSpace version="any" id="rc:PS-slw_deck_1@compartment_3-2nd_class">
-											<Label>C3</Label>
 											<Name>Compartment 3 : Seats 05-12</Name>
 											<Description>2nd class configurable as 2 x 4 seats or 2 x 3 bunk berths</Description>
+											<Label>C3</Label>
 											<ServiceFacilitySetRef version="any" ref="rc:SFS-slw_2nd_class_facilities"/>
 											<PublicUse>true</PublicUse>
 											<FareClass>standardClass</FareClass>
@@ -1470,8 +1470,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 											<deckEntrances>
 												<!--Compartment 3 door to corridor carriage -->
 												<PassengerEntrance version="any" id="rc:PE-slw_deck_1@compartment_3">
-													<Label>C1</Label>
 													<Name>Compartment 1 door   connecting to  corridor </Name>
+													<Label>C1</Label>
 													<Width>0.80</Width>
 													<Height>1.80</Height>
 													<actualVehicleEquipments>
@@ -1515,8 +1515,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 											<passengerSpots>
 												<!-- Row 05 Facing Backwards -->
 												<PassengerSpot version="any" id="rc:PSp-slw_deck_1@compartment_3@row_05_col_A">
-													<Label>05</Label>
 													<Name>Seat 05 turns into bottom Bunk</Name>
+													<Label>05</Label>
 													<Orientation>backwards</Orientation>
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment version="any" id="rc:AVE-slw_deck_1@compartment_3@row_05_col_A@seat">
@@ -1540,8 +1540,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsByAisle>false</IsByAisle>
 												</PassengerSpot>
 												<PassengerSpot version="any" id="rc:PSp-slw_deck_1@compartment_3@row_05_col_B">
-													<Label>06</Label>
 													<Name>Seat 06 turns into middle Bunk</Name>
+													<Label>06</Label>
 													<Orientation>backwards</Orientation>
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment version="any" id="rc:AVE-slw_deck_1@compartment_3@row_05_col_B@seat">
@@ -1564,8 +1564,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsBetweenSeats>true</IsBetweenSeats>
 												</PassengerSpot>
 												<PassengerSpot version="any" id="rc:PSp-slw_deck_1@compartment_3@row_05_col_C">
-													<Label>07</Label>
 													<Name>Seat 06 turns into top Bunk</Name>
+													<Label>07</Label>
 													<Orientation>backwards</Orientation>
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment version="any" id="rc:AVE-slw_deck_1@compartment_3@row_05_col_C@seat">
@@ -1588,8 +1588,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsBetweenSeats>true</IsBetweenSeats>
 												</PassengerSpot>
 												<PassengerSpot version="any" id="rc:PSp-slw_deck_1@compartment_3@row_05_col_D">
-													<Label>08</Label>
 													<Description>Seat only available in daytime</Description>
+													<Label>08</Label>
 													<Orientation>backwards</Orientation>
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment version="any" id="rc:AVE-slw_deck_1@compartment_3@row_05_col_D@seat">
@@ -1677,8 +1677,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsBetweenSeats>true</IsBetweenSeats>
 												</PassengerSpot>
 												<PassengerSpot version="any" id="rc:PSp-slw_deck_1@compartment_3@row_06_col_D">
-													<Label>12</Label>
 													<Description>Seat only available in daytime</Description>
+													<Label>12</Label>
 													<Orientation>forwards</Orientation>
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment version="any" id="rc:AVE-slw_deck_1@compartment_3@row_06_col_D@seat">
@@ -1697,9 +1697,9 @@ The train reverse in  the station and departs, oriented backwards to the right
 											</passengerSpots>
 										</PassengerSpace>
 										<PassengerSpace version="any" id="rc:PS-slw_deck_1@compartment_4-2nd_class">
-											<Label>C4&gt;</Label>
 											<Name>Compartment 4 : Seats 12-20</Name>
 											<Description>2nd class configurable as 2 x 4 seats or 2 x 3 bunk berths</Description>
+											<Label>C4&gt;</Label>
 											<ServiceFacilitySetRef version="any" ref="rc:SFS-slw_2nd_class_facilities"/>
 											<PublicUse>true</PublicUse>
 											<FareClass>standardClass</FareClass>
@@ -1822,8 +1822,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsBetweenSeats>true</IsBetweenSeats>
 												</PassengerSpot>
 												<PassengerSpot version="any" id="rc:PSp-slw_deck_1@compartment_4@row_07_col_D">
-													<Label>16</Label>
 													<Description>Seat only available in daytime</Description>
+													<Label>16</Label>
 													<Orientation>backwards</Orientation>
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment version="any" id="rc:AVE-slw_deck_1@compartment_4@row_07_col_D@seat">
@@ -1911,8 +1911,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsBetweenSeats>true</IsBetweenSeats>
 												</PassengerSpot>
 												<PassengerSpot version="any" id="rc:PSp-slw_deck_1@compartment_4@row_08_col_D">
-													<Label>20</Label>
 													<Description>Seat only available in daytime</Description>
+													<Label>20</Label>
 													<Orientation>forwards</Orientation>
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment version="any" id="rc:AVE-slw_deck_1@compartment_4@row_08_col_D@seat">
@@ -1931,9 +1931,9 @@ The train reverse in  the station and departs, oriented backwards to the right
 											</passengerSpots>
 										</PassengerSpace>
 										<PassengerSpace version="any" id="rc:PS-slw_deck_1@compartment_5-2nd_class">
-											<Label>C5&gt;</Label>
 											<Name>Compartment 5 : Seats 21-28</Name>
 											<Description>2nd class configurable as 2 x 4 seats or 2 x 3 bunk berths</Description>
+											<Label>C5&gt;</Label>
 											<ServiceFacilitySetRef version="any" ref="rc:SFS-slw_2nd_class_facilities"/>
 											<PublicUse>true</PublicUse>
 											<FareClass>standardClass</FareClass>
@@ -2056,8 +2056,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsBetweenSeats>true</IsBetweenSeats>
 												</PassengerSpot>
 												<PassengerSpot version="any" id="rc:PSp-slw_deck_1@compartment_5@row_09_col_D">
-													<Label>24</Label>
 													<Description>Seat only available in daytime</Description>
+													<Label>24</Label>
 													<Orientation>backwards</Orientation>
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment version="any" id="rc:AVE-slw_deck_1@compartment_5@row_09_col_D@seat">
@@ -2145,8 +2145,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsBetweenSeats>true</IsBetweenSeats>
 												</PassengerSpot>
 												<PassengerSpot version="any" id="rc:PSp-slw_deck_1@compartment_5@row_10_col_D">
-													<Label>20</Label>
 													<Description>Seat only available in daytime</Description>
+													<Label>20</Label>
 													<Orientation>forwards</Orientation>
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment version="any" id="rc:AVE-slw_deck_1@compartment_5@row_10_col_D@seat">
@@ -2165,9 +2165,9 @@ The train reverse in  the station and departs, oriented backwards to the right
 											</passengerSpots>
 										</PassengerSpace>
 										<PassengerSpace version="any" id="rc:PS-slw_deck_1@compartment_6-2nd_class">
-											<Label>C6</Label>
 											<Name>compartment 6 : Seats 21-28</Name>
 											<Description>2nd class configurable as 2 x 4 seats or 2 x 3 bunk berths</Description>
+											<Label>C6</Label>
 											<ServiceFacilitySetRef version="any" ref="rc:SFS-slw_2nd_class_facilities"/>
 											<PublicUse>true</PublicUse>
 											<FareClass>standardClass</FareClass>
@@ -2290,8 +2290,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsBetweenSeats>true</IsBetweenSeats>
 												</PassengerSpot>
 												<PassengerSpot version="any" id="rc:PSp-slw_deck_1@compartment_6@row_11_col_D">
-													<Label>24</Label>
 													<Description>Seat only available in daytime</Description>
+													<Label>24</Label>
 													<Orientation>backwards</Orientation>
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment version="any" id="rc:AVE-slw_deck_1@compartment_6@row_11_col_D@seat">
@@ -2379,8 +2379,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsByAisle>true</IsByAisle>
 												</PassengerSpot>
 												<PassengerSpot version="any" id="rc:PSp-slw_deck_1@compartment_6@row_12_col_D">
-													<Label>28</Label>
 													<Description>Seat only available in daytime</Description>
+													<Label>28</Label>
 													<Orientation>forwards</Orientation>
 													<actualVehicleEquipments>
 														<ActualVehicleEquipment version="any" id="rc:AVE-slw_deck_1@compartment_6@row_12_col_D@seat">
@@ -2657,8 +2657,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 											<deckEntrances>
 												<!-- external doors to  carriage -->
 												<PassengerEntrance version="any" id="rc:PE-ctw_deck_1@forward_external_left">
-													<Label>D1</Label>
 													<Name>Passenger access left Door</Name>
+													<Label>D1</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -2676,8 +2676,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													<IsAutomatic>false</IsAutomatic>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-ctw_deck_1@forward_external_right">
-													<Label>D2</Label>
 													<Name>&gt;Passenger access Right  External  Door</Name>
+													<Label>D2</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -2895,8 +2895,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 											<deckEntrances>
 												<!-- external doors to  carriage -->
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@forward_external_left">
-													<Label>D1</Label>
 													<Name>Front Door</Name>
+													<Label>D1</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -2927,8 +2927,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@forward_external_right">
-													<Label>D2</Label>
 													<Name>Front Right  External  Door</Name>
+													<Label>D2</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -2956,8 +2956,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@rear_external_left">
-													<Label>D2</Label>
 													<Name>Rear External Door</Name>
+													<Label>D2</Label>
 													<Width>0.95</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -2987,8 +2987,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@rear_external_right">
-													<Label>D2</Label>
 													<Name>Rear Right External Door</Name>
+													<Label>D2</Label>
 													<Width>0.95</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -3016,8 +3016,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 												</PassengerEntrance>
 												<!-- end doors to next carriage -->
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@front_end_connecting">
-													<Label>F1</Label>
 													<Name>Rear end door connecting to next carriage</Name>
+													<Label>F1</Label>
 													<Width>0.80</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -3038,8 +3038,8 @@ The train reverse in  the station and departs, oriented backwards to the right
 													</sensorsInEntrance>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@back_end_connecting">
-													<Label>Rear</Label>
 													<Name>Rear end door connecting to next carriage</Name>
+													<Label>Rear</Label>
 													<Width>0.80</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>

--- a/examples/functions/deckPlans/DeckPlans-Example_train_simple.xml
+++ b/examples/functions/deckPlans/DeckPlans-Example_train_simple.xml
@@ -71,7 +71,7 @@
 |@++++++++++       ++++++++++@|
 |@:::::::::+       +:::::::::@|
 |@ 101+103 +       + 107+105 @| r18  backwards
-|@++++++++++       ++++++++++@|     
+|@++++++++++       ++++++++++@|
 |@:::::::::+       +:::::::::@|
 |@ 102+108 +       + 104+106 @| r19  backwards
 |@++++++++++       ++++++++++@|
@@ -339,8 +339,8 @@
 											<deckEntrances>
 												<!-- external doors to  carriage -->
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@forward_external_left">
-													<Label>D1</Label>
 													<Name>Front Door</Name>
+													<Label>D1</Label>
 													<Width>0.80</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -359,8 +359,8 @@
 													<IsAutomatic>true</IsAutomatic>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@forward_external_right">
-													<Label>D2</Label>
 													<Name>Front Right  External  Door</Name>
+													<Label>D2</Label>
 													<Width>1.00</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -379,8 +379,8 @@
 													<IsAutomatic>true</IsAutomatic>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@rear_external_left">
-													<Label>D2</Label>
 													<Name>Rear External Door</Name>
+													<Label>D2</Label>
 													<Width>0.95</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -399,8 +399,8 @@
 													<IsAutomatic>true</IsAutomatic>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@rear_external_right">
-													<Label>D2</Label>
 													<Name>Rear Right External Door</Name>
+													<Label>D2</Label>
 													<Width>0.95</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -420,8 +420,8 @@
 												</PassengerEntrance>
 												<!-- end doors to next carriage -->
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@front_end_connecting">
-													<Label>F1</Label>
 													<Name>Rear end door connecting to next carriage</Name>
+													<Label>F1</Label>
 													<Width>0.80</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>
@@ -437,8 +437,8 @@
 													<IsAutomatic>true</IsAutomatic>
 												</PassengerEntrance>
 												<PassengerEntrance version="any" id="rc:PE-bfc_deck_1@seating_area@back_end_connecting">
-													<Label>Rear</Label>
 													<Name>Rear end door connecting to next carriage</Name>
+													<Label>Rear</Label>
 													<Width>0.80</Width>
 													<Height>1.90</Height>
 													<actualVehicleEquipments>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -187,9 +187,9 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="Deck" substitutionGroup="DataManagedObject">
+	<xsd:element name="Deck" substitutionGroup="Zone">
 		<xsd:annotation>
-			<xsd:documentation>An area within a VEHICLE (i.e. bus, boat, coach, car, plan, etc.) or TRAIN ELEMENT made up of one or more DECK SPACEs. A subdivision of a DECK PLAN. +V2.0</xsd:documentation>
+			<xsd:documentation>An area within a VEHICLE (i.e. bus, boat, coach, car, plane, etc.) or TRAIN ELEMENT made up of one or more DECK SPACEs. A subdivision of a DECK PLAN. +V2.0</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -217,7 +217,7 @@
 			<xsd:documentation>Type for a DECK.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="DataManagedObjectStructure">
+			<xsd:extension base="Zone_VersionStructure">
 				<xsd:group ref="DeckGroup">
 					<xsd:annotation>
 						<xsd:documentation>Elements for an DECK.</xsd:documentation>
@@ -231,11 +231,6 @@
 			<xsd:documentation>Elements for a DECK.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Name of DECK.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
 			<xsd:element name="Label" type="MultilingualString" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Name of DECK.</xsd:documentation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_deckPlan_version.xsd
@@ -201,6 +201,9 @@
 						<xsd:sequence>
 							<xsd:group ref="DataManagedObjectGroup"/>
 						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
 						<xsd:group ref="DeckGroup"/>
 					</xsd:sequence>
 					<xsd:attribute name="id" type="DeckIdType">
@@ -330,6 +333,9 @@
 						<xsd:sequence>
 							<xsd:group ref="DataManagedObjectGroup"/>
 						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
 						<xsd:sequence>
 							<xsd:group ref="OnboardSpaceGroup">
 								<xsd:annotation>
@@ -463,6 +469,9 @@
 						<xsd:sequence>
 							<xsd:group ref="DataManagedObjectGroup"/>
 						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
 						<xsd:sequence>
 							<xsd:group ref="OnboardSpaceGroup">
 								<xsd:annotation>
@@ -570,6 +579,9 @@
 						<xsd:sequence>
 							<xsd:group ref="DataManagedObjectGroup"/>
 						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
 						<xsd:sequence>
 							<xsd:group ref="OnboardSpaceGroup">
 								<xsd:annotation>
@@ -651,6 +663,9 @@
 						<xsd:sequence>
 							<xsd:group ref="DataManagedObjectGroup"/>
 						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
 						<xsd:sequence>
 							<xsd:group ref="OnboardSpaceGroup">
 								<xsd:annotation>
@@ -778,6 +793,9 @@
 						<xsd:sequence>
 							<xsd:group ref="DataManagedObjectGroup"/>
 						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
 						<xsd:sequence>
 							<xsd:group ref="OnboardSpaceGroup">
 								<xsd:annotation>
@@ -841,6 +859,9 @@
 						<xsd:sequence>
 							<xsd:group ref="DataManagedObjectGroup"/>
 						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
 						<xsd:sequence>
 							<xsd:group ref="OnboardSpaceGroup">
 								<xsd:annotation>
@@ -915,6 +936,9 @@
 						<xsd:sequence>
 							<xsd:group ref="DataManagedObjectGroup"/>
 						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
 						<xsd:sequence>
 							<xsd:group ref="OnboardSpaceGroup">
 								<xsd:annotation>
@@ -1144,6 +1168,9 @@
 						<xsd:sequence>
 							<xsd:group ref="DataManagedObjectGroup"/>
 						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
 						<xsd:sequence>
 							<xsd:group ref="OnboardSpaceGroup">
 								<xsd:annotation>

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
@@ -4,6 +4,7 @@
 	<xsd:include schemaLocation="netex_seatingPlan_support.xsd"/>
 	<xsd:include schemaLocation="netex_sensorEquipment_version.xsd"/>
 	<xsd:include schemaLocation="netex_equipmentVehiclePassenger_version.xsd"/>
+	<xsd:include schemaLocation="../netex_genericFramework/netex_zone_version.xsd"/>
 	<!-- ======================================================================= -->
 	<xsd:annotation>
 		<xsd:appinfo>
@@ -209,7 +210,7 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== ONBOARD SPACE ======================================================= -->
-	<xsd:element name="OnboardSpace" type="OnboardSpace_VersionStructure" abstract="true" substitutionGroup="DataManagedObject">
+	<xsd:element name="OnboardSpace" type="OnboardSpace_VersionStructure" abstract="true" substitutionGroup="Zone">
 		<xsd:annotation>
 			<xsd:documentation>A place aboard a vehicle where ACTUAL VEHICLE EQUIPMENT may be located. +v2.0</xsd:documentation>
 		</xsd:annotation>
@@ -219,7 +220,7 @@
 			<xsd:documentation>Type for a ONBOARD SPACE.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="DataManagedObjectStructure">
+			<xsd:extension base="Zone_VersionStructure">
 				<xsd:sequence>
 					<xsd:group ref="OnboardSpaceGroup">
 						<xsd:annotation>
@@ -237,17 +238,7 @@
 		<xsd:sequence>
 			<xsd:element name="Label" type="MultilingualString" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Lavel of ONBOARD SPACE. e.g. seat number.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Name of DECK COMPONENT.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="Description" type="MultilingualString" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Description of ONBOARD SPACE.</xsd:documentation>
+					<xsd:documentation>Label of ONBOARD SPACE. e.g. seat number.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="Orientation" type="ComponentOrientationEnumeration" default="forwards" minOccurs="0">

--- a/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_seatingPlan_version.xsd
@@ -363,6 +363,50 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
+	<xsd:element name="PassengerSpot" substitutionGroup="LocatableSpot">
+		<xsd:annotation>
+			<xsd:documentation>A designated seat or other space for a passenger within a given DECK SPACE. +v2.0.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="PassengerSpot_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
+						<xsd:sequence>
+							<xsd:group ref="OnboardSpaceGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a ONBOARD SPACE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LocatableSpotGroup">
+								<xsd:annotation>
+									<xsd:documentation>Elements for a LOCATABLE SPOT.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="PassengerSpotGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="PassengerSpotIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of PASSENGER SPOT.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
 	<xsd:complexType name="PassengerSpot_VersionStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a PASSENGER SPOT.</xsd:documentation>
@@ -438,47 +482,6 @@
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ====== PASSENGER VEHICLE SPOT =================================== -->
-	<xsd:element name="PassengerSpot" substitutionGroup="LocatableSpot">
-		<xsd:annotation>
-			<xsd:documentation>A designated seat or other space for a passenger within a given DECK SPACE. +v2.0.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexType>
-			<xsd:complexContent>
-				<xsd:restriction base="PassengerSpot_VersionStructure">
-					<xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="DataManagedObjectGroup"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="OnboardSpaceGroup">
-								<xsd:annotation>
-									<xsd:documentation>Elements for a ONBOARD SPACE.</xsd:documentation>
-								</xsd:annotation>
-							</xsd:group>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="LocatableSpotGroup">
-								<xsd:annotation>
-									<xsd:documentation>Elements for a LOCATABLE SPOT.</xsd:documentation>
-								</xsd:annotation>
-							</xsd:group>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="PassengerSpotGroup"/>
-						</xsd:sequence>
-					</xsd:sequence>
-					<xsd:attribute name="id" type="PassengerSpotIdType" use="optional">
-						<xsd:annotation>
-							<xsd:documentation>Identifier of PASSENGER SPOT.</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
-				</xsd:restriction>
-			</xsd:complexContent>
-		</xsd:complexType>
-	</xsd:element>
 	<xsd:complexType name="passengerVehicleSpots_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a list of PASSENGER VEHICLE SPOTs.</xsd:documentation>
@@ -494,7 +497,7 @@
 	</xsd:complexType>
 	<xsd:element name="PassengerVehicleSpot" substitutionGroup="LocatableSpot">
 		<xsd:annotation>
-			<xsd:documentation> A designated space to stow a passenger's luggage onboard.+v2.0.</xsd:documentation>
+			<xsd:documentation>A designated space to park a passenger's vehicle onboard.+v2.0.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -506,6 +509,9 @@
 						<xsd:sequence>
 							<xsd:group ref="DataManagedObjectGroup"/>
 						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
 						<xsd:sequence>
 							<xsd:group ref="OnboardSpaceGroup">
 								<xsd:annotation>
@@ -578,7 +584,7 @@
 	</xsd:complexType>
 	<xsd:element name="LuggageSpot" substitutionGroup="LocatableSpot">
 		<xsd:annotation>
-			<xsd:documentation> A specified space to stow a passenger's luggage onboard.+v2.0.</xsd:documentation>
+			<xsd:documentation>A designated space to stow a passenger's luggage onboard.+v2.0.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -590,6 +596,9 @@
 						<xsd:sequence>
 							<xsd:group ref="DataManagedObjectGroup"/>
 						</xsd:sequence>
+						<xsd:group ref="GroupOfEntitiesGroup"/>
+						<xsd:group ref="GroupOfPointsGroup"/>
+						<xsd:group ref="ZoneGroup"/>
 						<xsd:sequence>
 							<xsd:group ref="OnboardSpaceGroup">
 								<xsd:annotation>


### PR DESCRIPTION
Add Zone element as defined in Transmodel to allow adding X/Y coordinates to DeckPlan elements.
Partially resolves: #702

<img width="1287" height="902" alt="image(1)" src="https://github.com/user-attachments/assets/960587be-3bf2-4e7f-9320-782a8f9d3e68" />

-------------------

If I understood correctly from @Aurige the reason why elements like `Deck` are modelled like **A** and not simply as **B** is that this allows to specialise the Type of the ID (overriding the ID Type from `DataManagedObject` ).
However I noticed that currently the `ref` attributes of any `OnboardSpaceRefs` like `PassengerSpotRef` or `DeckVehicleEntranceRef` are not validated at all by the schema. So it is possible to have `Refs` pointing into the void.
I couldn't figure out why it works for e.g. `EquipmentRefs` but not for `OnboardSpaceRefs`. At least currently it seems that the modelling of **A** does not add any benefit over **B**.

### A
```xsd
<xsd:element name="Deck" substitutionGroup="Zone">
	<xsd:annotation>
		<xsd:documentation>An area within a VEHICLE (i.e. bus, boat, coach, car, plane, etc.) or TRAIN ELEMENT made up of one or more DECK SPACEs. A subdivision of a DECK PLAN. +V2.0</xsd:documentation>
	</xsd:annotation>
	<xsd:complexType>
		<xsd:complexContent>
			<xsd:restriction base="Deck_VersionStructure">
				<xsd:sequence>
					<xsd:sequence>
						<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
					</xsd:sequence>
					<xsd:sequence>
						<xsd:group ref="DataManagedObjectGroup"/>
					</xsd:sequence>
					<xsd:group ref="GroupOfEntitiesGroup"/>
					<xsd:group ref="GroupOfPointsGroup"/>
					<xsd:group ref="ZoneGroup"/>
					<xsd:group ref="DeckGroup"/>
				</xsd:sequence>
				<xsd:attribute name="id" type="DeckIdType">
					<xsd:annotation>
						<xsd:documentation>Identifier of VEHICLE EQUIPMENT PROFILE.</xsd:documentation>
					</xsd:annotation>
				</xsd:attribute>
			</xsd:restriction>
		</xsd:complexContent>
	</xsd:complexType>
</xsd:element>
```

### B
```xsd
<xsd:element name="Deck" type="Deck_VersionStructure" substitutionGroup="Zone"/>
```