### PR TITLE
Make `TransportType` abstract

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_vehicleType_version.xsd
@@ -109,7 +109,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Dummy type to work around SG limitations</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:element name="TransportType" substitutionGroup="TransportType_DummyType">
+	<xsd:element name="TransportType" abstract="true" substitutionGroup="TransportType_DummyType">
 		<xsd:annotation>
 			<xsd:documentation>A classification of any type of VEHICLE according to its properties.</xsd:documentation>
 		</xsd:annotation>


### PR DESCRIPTION
`TransportType` is declared abstract in Transmodel. As far as I understand it acts as a base type for `VehicleType`, `Train` etc.

Also something like `ref="TransportType"` does not exist anywhere in the NeTEx schema. So there is also no way to define a `TransportType`.