### PR TITLE
Adding replacement-submodes

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_submode_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_submode_version.xsd
@@ -301,6 +301,8 @@ Local train adapted for running in mountain railway lines.</xsd:documentation>
 			<xsd:enumeration value="schoolBus"/>
 			<xsd:enumeration value="schoolAndPublicServiceBus"/>
 			<xsd:enumeration value="railReplacementBus"/>
+			<xsd:enumeration value="metroReplacementBus"/>
+			<xsd:enumeration value="tramReplacementBus"/>
 			<xsd:enumeration value="demandAndResponseBus"/>
 			<xsd:enumeration value="airportLinkBus"/>
 		</xsd:restriction>
@@ -451,6 +453,7 @@ Local train adapted for running in mountain railway lines.</xsd:documentation>
 			<xsd:enumeration value="charterTaxi"/>
 			<xsd:enumeration value="waterTaxi"/>
 			<xsd:enumeration value="railTaxi"/>
+			<xsd:enumeration value="railReplacementTaxi"/>
 			<xsd:enumeration value="bikeTaxi"/>
 			<xsd:enumeration value="blackCab"/>
 			<xsd:enumeration value="miniCab"/>


### PR DESCRIPTION
Due to actual traffic needs, we would like to add a few more enums to NeTEx to properly cover the granulation of transport offers.

This also proves my old point about the need to reform TransportMode/TransportSubmode :)