### PR TITLE
Remove required 'id' attribute from accessibility schema

### DIFF
--- a/xsd/netex_framework/netex_genericFramework/netex_accessibility/netex_acsb_accessibility.xsd
+++ b/xsd/netex_framework/netex_genericFramework/netex_accessibility/netex_acsb_accessibility.xsd
@@ -90,7 +90,6 @@ Rail transport, Roads and Road transport
 							<xsd:group ref="SensoryLimitationGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="LimitationIdType" use="required"/>
 				</xsd:restriction>
 			</xsd:complexContent>
 		</xsd:complexType>


### PR DESCRIPTION
Based on the merge of #970, I have looked more into details in elements that I believe do not need an "id" since they are not referened anywhere else.
One element addressed in this PR is "AccessibilityLimitation". As it is embedded within an physical item for which it describes its accessibility, I believe that having an "id" in the first place was a bug in the XSD. It does not appear in the documentation.