### PR TITLE
Fix-Buggy SIRI import in occupancy

### DIFF
--- a/xsd/netex_part_2/part2_occupancy/netex_oc_occupancy_version.xsd
+++ b/xsd/netex_part_2/part2_occupancy/netex_oc_occupancy_version.xsd
@@ -7,7 +7,6 @@
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_trainElement_version.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_dayType_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_dayType_version.xsd"/>
-	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../../siri/siri_base-v2.0.xsd"/>
 	<xsd:group name="OccupancyScopeFilterGroup">
 		<xsd:annotation>
 			<xsd:documentation>The intersection of supplied elements describes the extent that the Occupancy values applies to. (since SIRI 2.1)
@@ -20,7 +19,7 @@ Only vehicle-centric filter (measurement in a part or at an entrance of a TRAIN)
 					<xsd:documentation>Fare class in VEHICLE for which occupancy or capacities are specified.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="PassengerCategory" type="siri:NaturalLanguageStringStructure" minOccurs="0">
+			<xsd:element name="PassengerCategory" type="MultilingualString" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Adult, child, wheelchair etc.</xsd:documentation>
 				</xsd:annotation>
@@ -90,7 +89,7 @@ More accurate data can be provided by the individual occupancies or capacities b
 			<xsd:documentation>Used to specify that a travel group has booked a section of the vehicle for a part of the journey, and if so under what name. (since SIRI 2.1)</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="NameOfGroup" type="siri:NaturalLanguageStringStructure">
+			<xsd:element name="NameOfGroup" type="MultilingualString">
 				<xsd:annotation>
 					<xsd:documentation>Name for which the travel group has made the reservation.</xsd:documentation>
 				</xsd:annotation>


### PR DESCRIPTION
The SIRI import is probably coming from a SIRI copy/paste since the NeTEx occupancy is following the SIRI one. 

The _NaturalLanguageStringStructure_ is not NeTEx type, and is only used in this file, and doesn't follow NeTEx style/rules. It's replaced with the more "traditional" _MultilingualString_

The SIRI import is crashing some generic NeTEx import  (especially if SIRI is also used) in some implementation (one of them being OpRa). The reason for this crash is difficult to analyse (and is partially depending on the validation engine), but is basically related to object redefinition. As a result this import was a useless and dangerous breaking change and has to be removed.

The SIRI import was there only to allow the use of _NaturalLanguageStringStructure_ and can just be removed.

This is a fix 100% backward compatible at XML Level