### PR TITLE
Edit repo url after move + fix new org CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: push
 
+permissions:
+  contents: write
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is a major release, with work going back to as far as late 2020.
 
 Data producers are encouraged to use XSD validation tooling in order to detect & upgrade their data feeds. To do so, clone the repository locally & validate against `xsd/NeTEx_publication.xsd` (the entry point).
 
-If you think you found a bug, or have a question, [please provide feedback here](https://github.com/NeTEx-CEN/NeTEx/issues).
+If you think you found a bug, or have a question, [please provide feedback here](https://github.com/TransmodelEcosystem/NeTEx/issues).
 
 ### Structural changes:
 
@@ -34,13 +34,13 @@ Functional evolutions are largely additive, but existing datasets should be reva
 ---
 ## v1.3.1 (EPIAP)
 
-* EPIAP to Master by @skinkie in https://github.com/NeTEx-CEN/NeTEx/pull/705
-* Add properties to describe the height of a Lift by @juliustens-db in https://github.com/NeTEx-CEN/NeTEx/pull/696
-* Fix typo by @skinkie in https://github.com/NeTEx-CEN/NeTEx/pull/722
-* Update neTactileActuators attribute on Escalators and Travelators #665tex_ifopt_equipmentAccess_version.xsd by @ue71603 in https://github.com/NeTEx-CEN/NeTEx/pull/720
-* Update netex_facility_support.xsd by @ue71603 in https://github.com/NeTEx-CEN/NeTEx/pull/724
-* TypeOfEntity is abstract by @skinkie in https://github.com/NeTEx-CEN/NeTEx/pull/723
-* Fixes from #721 by @skinkie in https://github.com/NeTEx-CEN/NeTEx/pull/725
+* EPIAP to Master by @skinkie in https://github.com/TransmodelEcosystem/NeTEx/pull/705
+* Add properties to describe the height of a Lift by @juliustens-db in https://github.com/TransmodelEcosystem/NeTEx/pull/696
+* Fix typo by @skinkie in https://github.com/TransmodelEcosystem/NeTEx/pull/722
+* Update neTactileActuators attribute on Escalators and Travelators #665tex_ifopt_equipmentAccess_version.xsd by @ue71603 in https://github.com/TransmodelEcosystem/NeTEx/pull/720
+* Update netex_facility_support.xsd by @ue71603 in https://github.com/TransmodelEcosystem/NeTEx/pull/724
+* TypeOfEntity is abstract by @skinkie in https://github.com/TransmodelEcosystem/NeTEx/pull/723
+* Fixes from #721 by @skinkie in https://github.com/TransmodelEcosystem/NeTEx/pull/725
 
 ---
 ## Version 1.2.2 - Revised to add New Modes

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ At the root of the `xsd` folder, the file `NeTEx_publication.xsd` should be used
 
 | Branch Name | Description                                             | Maintenance status                                    | Link                                            |
 | ----------- | ------------------------------------------------------- | ----------------------------------------------- |----------------------------------------------- 
-| v2.0        | The last stable branch of the XML Schema, result of the NeTEx revision made during 2022-2026 | Bug fixes only | [Direct link](https://github.com/NeTEx-CEN/NeTEx)    |
-| v1.3        | The previous branch of the XML Schema that was published prior to the 2026 revision of NeTEx, it matches the state of the XSD at the date of the publication of Part 6 (CEN/TS 16614-6:2024) with the correction of bugs and typos -- **Important note**: this branch is not longer maintained | Not maintained | [Direct link](https://github.com/NeTEx-CEN/NeTEx/tree/v1.3) |
-| v2.1-wip    | All the upcoming work to improve v2.0     | In development   | [GitHub](https://github.com/NeTEx-CEN/NeTEx/tree/v2.1-wip) |
-| v3.0-wip    | All the upcoming work preparing the migration from CEN/TS to CEN/EN for the entire NeTEx series        | In development | [GitHub](https://github.com/NeTEx-CEN/NeTEx/tree/v3.0-wip) |
+| v2.0        | The last stable branch of the XML Schema, result of the NeTEx revision made during 2022-2026 | Bug fixes only | [Direct link](https://github.com/TransmodelEcosystem/NeTEx)    |
+| v1.3        | The previous branch of the XML Schema that was published prior to the 2026 revision of NeTEx, it matches the state of the XSD at the date of the publication of Part 6 (CEN/TS 16614-6:2024) with the correction of bugs and typos -- **Important note**: this branch is not longer maintained | Not maintained | [Direct link](https://github.com/TransmodelEcosystem/NeTEx/tree/v1.3) |
+| v2.1-wip    | All the upcoming work to improve v2.0     | In development   | [GitHub](https://github.com/TransmodelEcosystem/NeTEx/tree/v2.1-wip) |
+| v3.0-wip    | All the upcoming work preparing the migration from CEN/TS to CEN/EN for the entire NeTEx series        | In development | [GitHub](https://github.com/TransmodelEcosystem/NeTEx/tree/v3.0-wip) |
 
 All other branches are considered as feature branches, meaning that they are used for development only and are to be deleted once a Pull Request is merged. See below for more details on contributions.
 
@@ -92,7 +92,7 @@ The folder contains more comprehensive NeTEx files that aim to represent either 
 
 ### Starting a discussion 💬
 
-Either for a modelling question or a request for change, please start a discussion using the [GitHub issues](https://github.com/NeTEx-CEN/NeTEx/issues). 
+Either for a modelling question or a request for change, please start a discussion using the [GitHub issues](https://github.com/TransmodelEcosystem/NeTEx/issues). 
 In your issue, make sure that:
 - The title is a clear summary of your question / requst for change,
 - The content sufficiently details:
@@ -119,11 +119,11 @@ _Upcoming: templates for Pull Request_
 ### Releases
 | Release Number | Release Date  | Description                                    | Link          |
 | -------------- | ------------- | ---------------------------------------------- | ------------- |
-| v1.2            | March 2022    | Before the extension to alternative modes of operation | [Code](https://github.com/NeTEx-CEN/NeTEx/releases/tag/v1.2)    |
-| v1.2.2          | August 2023   | With the inclusion of NeTEx Part 5 (Alternative modes) | [Code](https://github.com/NeTEx-CEN/NeTEx/releases/tag/v1.2.2)  |
-| v1.2.3          | May 2024      | Improvement on the v1.2.2 before the release of NeTEx Part 6 (EPIAP) | [Code](https://github.com/NeTEx-CEN/NeTEx/releases/tag/v1.2.3)  |
-| v1.3.1          | May 2024      | Release of NeTex Part 6, the European Passenger Information Accessibility Profile (EPIAP) | [Code](https://github.com/NeTEx-CEN/NeTEx/releases/tag/v1.3.1) |
-| v2.0.0          | February 2026 | Matches the CEN documentation published in February 2026 for NeTEx Parts 1, 2, 3 and 5. Considered as the latest version of NeTEx to be used for production. | [Code](https://github.com/NeTEx-CEN/NeTEx/releases/tag/v2.0.0) |
+| v1.2            | March 2022    | Before the extension to alternative modes of operation | [Code](https://github.com/TransmodelEcosystem/NeTEx/releases/tag/v1.2)    |
+| v1.2.2          | August 2023   | With the inclusion of NeTEx Part 5 (Alternative modes) | [Code](https://github.com/TransmodelEcosystem/NeTEx/releases/tag/v1.2.2)  |
+| v1.2.3          | May 2024      | Improvement on the v1.2.2 before the release of NeTEx Part 6 (EPIAP) | [Code](https://github.com/TransmodelEcosystem/NeTEx/releases/tag/v1.2.3)  |
+| v1.3.1          | May 2024      | Release of NeTex Part 6, the European Passenger Information Accessibility Profile (EPIAP) | [Code](https://github.com/TransmodelEcosystem/NeTEx/releases/tag/v1.3.1) |
+| v2.0.0          | February 2026 | Matches the CEN documentation published in February 2026 for NeTEx Parts 1, 2, 3 and 5. Considered as the latest version of NeTEx to be used for production. | [Code](https://github.com/TransmodelEcosystem/NeTEx/releases/tag/v2.0.0) |
 
 **Important notes:** 
 - Releases (and their tags) are a snapshot of the corresponding working branch in time.
@@ -131,4 +131,4 @@ _Upcoming: templates for Pull Request_
 - For any development work, it is recommended to use the latest 3-digit version of NeTEx XML Schema.
 
 ### Comprehensive version history
-The comprehensive versions history is available in [CHANGELOG.md](https://github.com/NeTEx-CEN/NeTEx/blob/v2.0/CHANGELOG.md)
+The comprehensive versions history is available in [CHANGELOG.md](https://github.com/TransmodelEcosystem/NeTEx/blob/v2.0/CHANGELOG.md)

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_publication">
-	<!-- ===SIRI system IDs for  request =========================================================== -->
+  <!-- ===SIRI system IDs for  request =========================================================== -->
 	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri/siri_base-v2.0.xsd"/>
 	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri_utility/siri_participant-v2.0.xsd"/>
 	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri/siri_requests-v2.0.xsd"/>

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="netex_publication">
-  <!-- ===SIRI system IDs for  request =========================================================== -->
+	<!-- ===SIRI system IDs for  request =========================================================== -->
 	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri/siri_base-v2.0.xsd"/>
 	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri_utility/siri_participant-v2.0.xsd"/>
 	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri/siri_requests-v2.0.xsd"/>

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_routingConstraint_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_routingConstraint_version.xsd
@@ -75,7 +75,7 @@ Rail transport, Roads and Road transport
 				</Date>
 				<Date><Modified>2011-02-05</Modified>Name Space changes
 				</Date>
-				<Date><Modified>2023-12-13</Modified>#391 https://github.com/NeTEx-CEN/NeTEx/issues/391
+				<Date><Modified>2023-12-13</Modified>#391 https://github.com/TransmodelEcosystem/NeTEx/issues/391
 					           Enhancements: Add constraints of LINE to SERVICE EXCLUSION
 					           Add constraints of LINE DIRECTION to ROUTING CONSTRAINT ZONE.
 				</Date>


### PR DESCRIPTION
After the repository was moved to its new organisation, I edited the repo URL in the following files:
- README.md
- CHANGELOG.md
- xsd/netex_part_1/part1_tacticalPlanning/netex_routingConstraint_version.xsd

The change was to replace "NeTEx-CEN" with "TransmodelEcosystem"

Also: includes a fix for CI failures since moving org (#1018)