### PR TITLE
DirectionType allowed in LineInDirectionRef structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ fabric.properties
 # Editor-based Rest Client
 .idea/httpRequests
 
+/.idea

--- a/examples/functions/timetable/Netex_09.1_Bus_InterchangeRule.xml
+++ b/examples/functions/timetable/Netex_09.1_Bus_InterchangeRule.xml
@@ -314,6 +314,7 @@ The Calendar is shown coded as
 								<LineInDirectionRef>
 									<LineRef version="any" ref="mybus:LN_1"/>
 									<DirectionRef version="any" ref="mybus:DR_hbf"/>
+									<DirectionType>inbound</DirectionType>
 								</LineInDirectionRef>
 								<ScheduledStopPointRef version="any" ref="mybus:SSP_025"/>
 								<AdjacentStopPointRef version="any" ref="mybus:SSP_003"/>

--- a/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
+++ b/xsd/netex_part_1/part1_networkDescription/netex_line_version.xsd
@@ -987,6 +987,11 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:element ref="LineRef" minOccurs="0"/>
 			<xsd:element ref="DirectionRef" minOccurs="0"/>
+			<xsd:element name="DirectionType" type="DirectionTypeEnumeration" default="outbound" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>A Direction of a ROUTE. One of a restricted set of values. Default is "Outbound". V2.1.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="ExternalLineRef" type="ExternalObjectRefStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Alternative LINE Reference for AVMS system. DEPRECATED - v2.0</xsd:documentation>


### PR DESCRIPTION
In JourneyPattern DirectionType is allowed instead of Direction. This was not done in LineInDirection. We believe that this harmonisation is needed.
