### PR TITLE
New property to indicate an interchange within the same vehicle

### DIFF
--- a/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
@@ -533,6 +533,12 @@ Default is false.</xsd:documentation>
  Default is false.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="ChangeWithinVehicle" type="xsd:boolean" default="false" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>In case of train splitting, the passenger may have to change to a different part of the train to continue the journey.
+Default is false.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:group ref="InterchangeManagementGroup"/>
 		</xsd:sequence>
 	</xsd:group>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_interchange_version.xsd
@@ -535,8 +535,7 @@ Default is false.</xsd:documentation>
 			</xsd:element>
 			<xsd:element name="ChangeWithinVehicle" type="xsd:boolean" default="false" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>In case of train splitting, the passenger may have to change to a different part of the train to continue the journey.
-Default is false.</xsd:documentation>
+					<xsd:documentation>In case of train splitting, the passenger may have to change to a different part of the train to continue the journey. Default is false. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:group ref="InterchangeManagementGroup"/>


### PR DESCRIPTION
In the case where trains split for different final destinations, this can be modelled as two (or more) **ServiceJourneys** with a **ServiceJourneyInterchange**. A passenger may remain seated if he/she entered the correct train part in the first place. Setting "StaySeated" true seems to be somwhat unsafe in this situation, as the passenger may end up in the wrong destination. We therefore propose to introduce a new Element "ChangeWithinVehicle" in **InterchangePropertiesGroup**. If set to true, the passenger may have to change within the vehicle.