### PR TITLE
Fix spelling errors in part3_fares documentation and comments

### DIFF
--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -170,7 +170,7 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEx ACCESS RIGHT ASSIGNMENT types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
 	<xsd:complexType name="accessRightParameterAssignmentsInFrame_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a fare collection parameter (referring to geography, time, quality or usage) to an element of a fare system (access right, validated access, control mean, etc.).</xsd:documentation>
@@ -184,7 +184,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
 	<xsd:complexType name="validityParameterAssignmentsInFrame_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>The assignment of a fare collection parameter (referring to geography, time, quality or usage) to an element of a fare system (access right, validated access, control mean, etc.).</xsd:documentation>
@@ -294,7 +294,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfAccessRightAssignmentRef" minOccurs="0"/>
 			<xsd:element name="ChargingBasis" type="ChargingBasisEnumeration" default="any" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether ACCESS RIGHT ASSIGNMENT is chargable or not.</xsd:documentation>
+					<xsd:documentation>Whether ACCESS RIGHT ASSIGNMENT is chargeable or not.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -947,7 +947,7 @@ Rail transport, Roads and Road transport
 		<xsd:sequence>
 			<xsd:group ref="GenericParameterAssignmentIncludesGroup">
 				<xsd:annotation>
-					<xsd:documentation>Elements for compound GENERIC PARAMETER ASSIGNMENT. May only be compounded with parameters fo the same type.</xsd:documentation>
+					<xsd:documentation>Elements for compound GENERIC PARAMETER ASSIGNMENT. May only be compounded with parameters of the same type.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
@@ -60,7 +60,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: PRICING PARAMATER SET types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in FARE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in FARE FRAME)=================================================== -->
 	<xsd:group name="CalculationParametersInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>Elements for calculating fares.</xsd:documentation>
@@ -766,7 +766,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:element name="LimitingRuleInContext" substitutionGroup="PricingRule_Dummy">
 		<xsd:annotation>
-			<xsd:documentation>OPTIMISED version whcih can be be used only in line assues ID of comtainign context -no id checking. A price for which a discount can be offered.</xsd:documentation>
+			<xsd:documentation>OPTIMISED version which can be used only in line; assumes ID of containing context -no id checking. A price for which a discount can be offered.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
@@ -766,7 +766,7 @@ Rail transport, Roads and Road transport
 	</xsd:group>
 	<xsd:element name="LimitingRuleInContext" substitutionGroup="PricingRule_Dummy">
 		<xsd:annotation>
-			<xsd:documentation>OPTIMISED version which can be used only in line; assumes ID of containing context -no id checking. A price for which a discount can be offered.</xsd:documentation>
+			<xsd:documentation>OPTIMISED version which can be used only in line; assumes ID of containing context - no ID checking. A price for which a discount can be offered.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>

--- a/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_calculationParameters_version.xsd
@@ -58,7 +58,7 @@ Rail transport, Roads and Road transport
 				<Type>Standard</Type>
 			</Metadata>
 		</xsd:appinfo>
-		<xsd:documentation>NeTEx: PRICING PARAMATER SET types.</xsd:documentation>
+		<xsd:documentation>NeTEx: PRICING PARAMETER SET types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ===ENTITY IN VERSION IN FRAME====Used in FARE FRAME)=================================================== -->
 	<xsd:group name="CalculationParametersInFrameGroup">

--- a/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_version.xsd
@@ -73,7 +73,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx DISTANCE MATRIX ELEMENT types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- === ENTIITY IN VERSION IN FRAME= === ================================================== -->
+	<!-- === ENTITY IN VERSION IN FRAME= === ================================================== -->
 	<xsd:group name="DistanceMatrixElementsInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>DISTANCE MATRIX ELEMENTs in FRAME.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_farePrice_version.xsd
@@ -83,7 +83,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: FARE PRICE types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in FARE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in FARE FRAME)=================================================== -->
 	<xsd:complexType name="farePricesInFrame_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for containment in frame of FARE Prices.</xsd:documentation>
@@ -364,7 +364,7 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>Record of amount deducted by a price rule calculation, e.g. an additional tax step. If PRICING RULES are chained there may be multiple steps to record.  
 The source of the input price can be indicated by a FARE PRICE REF of some sort. 
 The RULE STEP RESULT Amount is the resulting  net price after the pricing rule has been applied to the input amount.  
-The RULE STEP RESULT  Adjustment Amount is  the difference beteen the original input price and the RULE STEP RESULT  Amount (so it is possible to derive the input price amount  by adding the the Adjustment to the  Net Amount.  A similar computation can be done for any units.</xsd:documentation>
+The RULE STEP RESULT  Adjustment Amount is  the difference between the original input price and the RULE STEP RESULT  Amount (so it is possible to derive the input price amount  by adding the Adjustment to the  Net Amount.  A similar computation can be done for any units.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
 				</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
@@ -82,8 +82,8 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: FARE PRODUCT types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in FARE FRAME)=================================================== -->
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in FARE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in FARE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in FARE FRAME)=================================================== -->
 	<xsd:group name="FareProductsInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>Fare Product Elements contained in a FARE FRAME.</xsd:documentation>
@@ -435,7 +435,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:group ref="OtherProductGroup" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Other products to which SALE DISCONT applies to</xsd:documentation>
+					<xsd:documentation>Other products to which SALE DISCOUNT RIGHT applies</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
 		</xsd:sequence>
@@ -856,7 +856,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="PriceUnitRef" minOccurs="0"/>
 			<xsd:element name="Amount" type="xsd:decimal" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Number of units. If only ine. Otherwise use TARIFF with FARE QUALITY FACTOR to specify a range</xsd:documentation>
+					<xsd:documentation>Number of units. If only one. Otherwise use TARIFF with FARE QUALITY FACTOR to specify a range</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_fareSeries_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareSeries_version.xsd
@@ -66,7 +66,7 @@
 		<xsd:documentation>NetEx SERIES CONSTRAINT types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
 	<xsd:group name="FareSeriesInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>Additional descriptive properties of a FARE FRAME.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_fareStructureElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareStructureElement_version.xsd
@@ -70,7 +70,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEX FARE STRUCTURE ELEMENT types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ===ENTIITY IN VERSION IN FRAME==== ================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME==== ================================================== -->
 	<xsd:group name="FareFactorsInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>Fare factors in FRAME.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_fareStructure_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareStructure_version.xsd
@@ -196,7 +196,7 @@ Rail transport, Roads and Road transport
 							<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>
 							<xsd:element name="Factor" type="xsd:anyType" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>Factor value assoictaed with init.</xsd:documentation>
+									<xsd:documentation>Factor value associated with the unit.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 						</xsd:sequence>
@@ -229,7 +229,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>
 			<xsd:element name="Factor" type="xsd:anyType" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Factor value assoictaed with init.</xsd:documentation>
+					<xsd:documentation>Factor value associated with the unit.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareTable_version.xsd
@@ -116,8 +116,8 @@ Rail transport, Roads and Road transport
 		<xsd:documentation>NeTEx: FARE TABLE types.</xsd:documentation>
 	</xsd:annotation>
 	<!-- ======================================================================= -->
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
 	<xsd:group name="FarePricesInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>FARE TABLEs in frame.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_geographicStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_geographicStructureFactor_version.xsd
@@ -66,7 +66,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEX: GEOGRAPHICAL STRUCTURE FACTOR types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- === ENTIITY IN VERSION IN FRAME= === ================================================== -->
+	<!-- === ENTITY IN VERSION IN FRAME= === ================================================== -->
 	<xsd:group name="GeographicFactorsInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>Geographic factors in FRAME.</xsd:documentation>
@@ -301,7 +301,7 @@ Rail transport, Roads and Road transport
 							<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>
 							<xsd:element name="Factor" type="xsd:anyType" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>Factor value assoictaed with init.</xsd:documentation>
+									<xsd:documentation>Factor value associated with the unit.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 						</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_qualityStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_qualityStructureFactor_version.xsd
@@ -69,7 +69,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: QUALITY STRUCTURE FACTOR types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
 	<xsd:group name="QualityFactorsInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>Quality factors in FRAME.</xsd:documentation>
@@ -274,7 +274,7 @@ Rail transport, Roads and Road transport
 							<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>
 							<xsd:element name="Factor" type="xsd:anyType" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>Factor value associated with FARE EDMAND FACTOR.</xsd:documentation>
+									<xsd:documentation>Factor value associated with FARE DEMAND FACTOR.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 						</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_salesDistribution_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesDistribution_version.xsd
@@ -65,7 +65,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx SALES DISTRIBUTION types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
 	<xsd:group name="SalesDistributionInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>Distribution properties of a FARE FRAME.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
@@ -74,7 +74,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: SALES OFFER PACKAGE types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
 	<xsd:group name="SalesOfferPackageInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>SALES OFFER PACKAGEs of a FARE FRAME.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_timeStructureFactor_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_timeStructureFactor_version.xsd
@@ -64,7 +64,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: TIME STRUCTURE FACTOR types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ===ENTIITY IN VERSION IN FRAME==== ================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME==== ================================================== -->
 	<xsd:group name="TimeFactorsInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>Time factors in FRAME.</xsd:documentation>
@@ -311,7 +311,7 @@ Rail transport, Roads and Road transport
 							<xsd:element ref="TypeOfFareStructureFactorRef" minOccurs="0"/>
 							<xsd:element name="Factor" type="xsd:anyType" minOccurs="0">
 								<xsd:annotation>
-									<xsd:documentation>Factor value assoictaed with init.</xsd:documentation>
+									<xsd:documentation>Factor value associated with the unit.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 						</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_typeOfTravelDocument_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_typeOfTravelDocument_version.xsd
@@ -64,7 +64,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: TYPE OF TRAVEL DOCUMENT types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
 	<xsd:group name="TypesOfTravelDocumentsInFrameGroup">
 		<xsd:annotation>
 			<xsd:documentation>Elements for TYPES of TRAVEL DOCUMENT.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_support.xsd
@@ -490,7 +490,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="concurrentDesignatedUsers">
 				<xsd:annotation>
-					<xsd:documentation>Several users (but only of a specifed type of companion) may use the same product at a time. E.g. a mobile app carnet of tickets may be shared with children but not others.</xsd:documentation>
+					<xsd:documentation>Several users (but only of a specified type of companion) may use the same product at a time. E.g. a mobile app carnet of tickets may be shared with children but not others.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 		</xsd:restriction>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterEligibility_version.xsd
@@ -377,7 +377,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="GroupSizeChanges" type="GroupSizeChangesEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Possibilities for changiing the numbe of people in the group.</xsd:documentation>
+					<xsd:documentation>Possibilities for changing the number of people in the group.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
@@ -440,7 +440,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="dayOffsetBeforeCalendarPeriod">
 				<xsd:annotation>
-					<xsd:documentation>Validity period starts a specified number of days before beginning of specified start date .</xsd:documentation>
+					<xsd:documentation>Validity period starts a specified number of days before beginning of specified start date.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 		</xsd:restriction>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
@@ -440,7 +440,7 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="dayOffsetBeforeCalendarPeriod">
 				<xsd:annotation>
-					<xsd:documentation>Validity period starts a specifed number of days before beginning of specified start date .</xsd:documentation>
+					<xsd:documentation>Validity period starts a specified number of days before beginning of specified start date .</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 		</xsd:restriction>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_version.xsd
@@ -269,7 +269,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="AdjustmentUnits" type="StepLimitUnitEnumeration" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Units in which steps atre counted.</xsd:documentation>
+					<xsd:documentation>Units in which steps are counted.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="MinimumNumberOfSteps" type="xsd:nonNegativeInteger" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameter_version.xsd
@@ -63,7 +63,7 @@ Rail transport, Roads and Road transport
 		</xsd:appinfo>
 		<xsd:documentation>NeTEX: USAGE PARAMETER types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in SERVICE FRAME)=================================================== -->
 	<xsd:complexType name="usageParametersInFrame_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for containment in frame of USAGE PARAMETER.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_validableElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_validableElement_version.xsd
@@ -265,7 +265,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<!-- ===ENTIITY IN VERSION IN FRAME====Used in FARE FRAME)=================================================== -->
+	<!-- ===ENTITY IN VERSION IN FRAME====Used in FARE FRAME)=================================================== -->
 	<xsd:complexType name="controllableElementsInFrame_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for containment in frame of CONTROLLABLE ELEMENTs.</xsd:documentation>


### PR DESCRIPTION
Dear NeTExians,

While working on the NAPCORE Helpdesk app, which uses the NeTex documentation as the source of truth, I found spelling mistakes that can be easily corrected without breaking anything.


Therefore, this PR fixes spelling errors in the `xsd/netex_part_3/part3_fares` schemas. All changes are confined to `<xsd:documentation>` text and XML comments — **no schema components (elements, types, enumeration values) are modified**, so there is no impact on validation or backward compatibility.

## Changes

- `ENTIITY` → `ENTITY` in section-divider comments (17 occurrences across the fares files)
- "Factor value assoictaed with init." → "Factor value associated with the unit." (`netex_fareStructure_version.xsd`, `netex_geographicStructureFactor_version.xsd`, `netex_timeStructureFactor_version.xsd`)
- "Units in which steps atre counted" → "…are counted" (`netex_usageParameterTravel_version.xsd`)
- "Number of units. If only ine." → "…If only one." (`netex_fareProduct_version.xsd`)
- "Other products to which SALE DISCONT applies to" → "Other products to which SALE DISCOUNT RIGHT applies" (`netex_fareProduct_version.xsd`)
- "OPTIMISED version whcih can be be used only in line assues ID of comtainign context" → "…which can be used only in line; assumes ID of containing context" (`netex_calculationParameters_version.xsd`)
- "parameters fo the same type" → "parameters of the same type" (`netex_accessRightParameter_version.xsd`)
- "chargable" → "chargeable" (`netex_accessRightParameter_version.xsd`)
- "specifed" → "specified" (`netex_usageParameterAfterSales_support.xsd`, `netex_usageParameterTravel_support.xsd`)
- "FARE EDMAND FACTOR" → "FARE DEMAND FACTOR" (`netex_qualityStructureFactor_version.xsd`)
- "difference beteen" → "difference between", "adding the the Adjustment" → "adding the Adjustment" (`netex_farePrice_version.xsd`)
- "changiing the numbe of people" → "changing the number of people" (`netex_usageParameterEligibility_version.xsd`)

## Deliberately left out (breaking change!)

- The `Exchangable*` misspelling (e.g. `ExchangableToEnumeration`, `ExchangableTo`, `IsExchangable`, `ExchangableFrom*`/`ExchangableUntil*` and the matching enumeration values in `netex_entity_support.xsd`) is **not** fixed here: those are schema component names used in instance documents, so renaming them is a breaking change that needs a separate decision (e.g. deprecated aliases at the next version).

## Verification

- All changed files are well-formed XML.
- `NeTEx_publication.xsd` compiles and `examples/functions/fares/Netex_51.1_Bus_SimpleFares_PointToPoint_SingleProduct.xml` validates against it (xmllint).
