### PR TITLE
Fix Exchangable misspelling: add Exchangeable* components, deprecate misspelt forms

### DIFF
--- a/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
@@ -944,17 +944,17 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="EvenNumberRange"/>
 			<xsd:enumeration value="ExchangableFromAnyTime">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromAnyTime instead. -v2.1</xsd:documentation>
+					<xsd:documentation>DEPRECATED due to mispelling, use ExchangeableFromAnyTime instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangableFromDuration">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromDuration instead. -v2.1</xsd:documentation>
+					<xsd:documentation>DEPRECATED due to mispelling, use ExchangeableFromDuration instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangableFromIntervalRef">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromIntervalRef instead. -v2.1</xsd:documentation>
+					<xsd:documentation>DEPRECATED due to mispelling, use ExchangeableFromIntervalRef instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangableFromPercentUse">
@@ -964,38 +964,74 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangableTo">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableTo instead. -v2.1</xsd:documentation>
+					<xsd:documentation>DEPRECATED due to mispelling, use ExchangeableTo instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangableUntilAnyTime">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilAnyTime instead. -v2.1</xsd:documentation>
+					<xsd:documentation>DEPRECATED due to mispelling, use ExchangeableUntilAnyTime instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangableUntilDuration">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilDuration instead. -v2.1</xsd:documentation>
+					<xsd:documentation>DEPRECATED due to mispelling, use ExchangeableUntilDuration instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangableUntilIntervalRef">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilIntervalRef instead. -v2.1</xsd:documentation>
+					<xsd:documentation>DEPRECATED due to mispelling, use ExchangeableUntilIntervalRef instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangableUntilPercentUse">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilPercentUse instead. -v2.1</xsd:documentation>
+					<xsd:documentation>DEPRECATED due to mispelling, use ExchangeableUntilPercentUse instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
-			<xsd:enumeration value="ExchangeableFromAnyTime"/>
-			<xsd:enumeration value="ExchangeableFromDuration"/>
-			<xsd:enumeration value="ExchangeableFromIntervalRef"/>
-			<xsd:enumeration value="ExchangeableFromPercentUse"/>
-			<xsd:enumeration value="ExchangeableTo"/>
-			<xsd:enumeration value="ExchangeableUntilAnyTime"/>
-			<xsd:enumeration value="ExchangeableUntilDuration"/>
-			<xsd:enumeration value="ExchangeableUntilIntervalRef"/>
-			<xsd:enumeration value="ExchangeableUntilPercentUse"/>
+			<xsd:enumeration value="ExchangeableFromAnyTime">
+				<xsd:annotation>
+					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangeableFromDuration">
+					<xsd:annotation>
+					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangeableFromIntervalRef">
+					<xsd:annotation>
+					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangeableFromPercentUse">
+					<xsd:annotation>
+					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangeableTo">
+					<xsd:annotation>
+					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangeableUntilAnyTime">
+					<xsd:annotation>
+					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangeableUntilDuration">
+					<xsd:annotation>
+					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangeableUntilIntervalRef">
+					<xsd:annotation>
+					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangeableUntilPercentUse">
+					<xsd:annotation>
+					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="Exchanging"/>
 			<xsd:enumeration value="ExchangingRef"/>
 			<xsd:enumeration value="Exclude"/>

--- a/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
@@ -993,42 +993,42 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangeableFromDuration">
-					<xsd:annotation>
+				<xsd:annotation>
 					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangeableFromIntervalRef">
-					<xsd:annotation>
+				<xsd:annotation>
 					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangeableFromPercentUse">
-					<xsd:annotation>
+				<xsd:annotation>
 					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangeableTo">
-					<xsd:annotation>
+				<xsd:annotation>
 					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangeableUntilAnyTime">
-					<xsd:annotation>
+				<xsd:annotation>
 					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangeableUntilDuration">
-					<xsd:annotation>
+				<xsd:annotation>
 					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangeableUntilIntervalRef">
-					<xsd:annotation>
+				<xsd:annotation>
 					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="ExchangeableUntilPercentUse">
-					<xsd:annotation>
+				<xsd:annotation>
 					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>

--- a/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
@@ -942,15 +942,51 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="EstimatedPassingTimeView"/>
 			<xsd:enumeration value="EuroClass"/>
 			<xsd:enumeration value="EvenNumberRange"/>
-			<xsd:enumeration value="ExchangableFromAnyTime"/>
-			<xsd:enumeration value="ExchangableFromDuration"/>
-			<xsd:enumeration value="ExchangableFromIntervalRef"/>
-			<xsd:enumeration value="ExchangableFromPercentUse"/>
-			<xsd:enumeration value="ExchangableTo"/>
-			<xsd:enumeration value="ExchangableUntilAnyTime"/>
-			<xsd:enumeration value="ExchangableUntilDuration"/>
-			<xsd:enumeration value="ExchangableUntilIntervalRef"/>
-			<xsd:enumeration value="ExchangableUntilPercentUse"/>
+			<xsd:enumeration value="ExchangableFromAnyTime">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromAnyTime instead. -v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangableFromDuration">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromDuration instead. -v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangableFromIntervalRef">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromIntervalRef instead. -v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangableFromPercentUse">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromPercentUse instead. -v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangableTo">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableTo instead. -v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangableUntilAnyTime">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilAnyTime instead. -v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangableUntilDuration">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilDuration instead. -v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangableUntilIntervalRef">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilIntervalRef instead. -v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ExchangableUntilPercentUse">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilPercentUse instead. -v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="ExchangeableFromAnyTime"/>
 			<xsd:enumeration value="ExchangeableFromDuration"/>
 			<xsd:enumeration value="ExchangeableFromIntervalRef"/>
@@ -1386,7 +1422,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="IsDirect"/>
 			<xsd:enumeration value="IsEmergencyExit"/>
 			<xsd:enumeration value="IsEntry"/>
-			<xsd:enumeration value="IsExchangable"/>
+			<xsd:enumeration value="IsExchangable">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED - misspelt, use IsExchangeable instead. -v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="IsExchangeable"/>
 			<xsd:enumeration value="IsExit"/>
 			<xsd:enumeration value="IsExternal"/>

--- a/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
@@ -1463,7 +1463,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>DEPRECATED due to misspelling, use IsExchangeable instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
-			<xsd:enumeration value="IsExchangeable"/>
+			<xsd:enumeration value="IsExchangeable">
 				<xsd:annotation>
 					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
@@ -1460,10 +1460,14 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="IsEntry"/>
 			<xsd:enumeration value="IsExchangable">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - misspelt, use IsExchangeable instead. -v2.1</xsd:documentation>
+					<xsd:documentation>DEPRECATED due to misspelling, use IsExchangeable instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="IsExchangeable"/>
+				<xsd:annotation>
+					<xsd:documentation>Replaces previously missplet value. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="IsExit"/>
 			<xsd:enumeration value="IsExternal"/>
 			<xsd:enumeration value="IsFacingAisle"/>

--- a/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
@@ -17,6 +17,8 @@
 				<Date>
 					<Modified>2010-11-05</Modified>
 				</Date>
+				<Date><Modified>2026-07-09</Modified>Add correctly spelt Exchangeable* / IsExchangeable values to NameOfClass alongside deprecated misspelt forms.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines data Modification base types.</p>
 				</Description>
@@ -949,6 +951,15 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="ExchangableUntilDuration"/>
 			<xsd:enumeration value="ExchangableUntilIntervalRef"/>
 			<xsd:enumeration value="ExchangableUntilPercentUse"/>
+			<xsd:enumeration value="ExchangeableFromAnyTime"/>
+			<xsd:enumeration value="ExchangeableFromDuration"/>
+			<xsd:enumeration value="ExchangeableFromIntervalRef"/>
+			<xsd:enumeration value="ExchangeableFromPercentUse"/>
+			<xsd:enumeration value="ExchangeableTo"/>
+			<xsd:enumeration value="ExchangeableUntilAnyTime"/>
+			<xsd:enumeration value="ExchangeableUntilDuration"/>
+			<xsd:enumeration value="ExchangeableUntilIntervalRef"/>
+			<xsd:enumeration value="ExchangeableUntilPercentUse"/>
 			<xsd:enumeration value="Exchanging"/>
 			<xsd:enumeration value="ExchangingRef"/>
 			<xsd:enumeration value="Exclude"/>
@@ -1376,6 +1387,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="IsEmergencyExit"/>
 			<xsd:enumeration value="IsEntry"/>
 			<xsd:enumeration value="IsExchangable"/>
+			<xsd:enumeration value="IsExchangeable"/>
 			<xsd:enumeration value="IsExit"/>
 			<xsd:enumeration value="IsExternal"/>
 			<xsd:enumeration value="IsFacingAisle"/>

--- a/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
@@ -224,16 +224,18 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Whether the ticket can be refunded.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="IsExchangeable" type="xsd:boolean" default="true" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Whether the ticket can be exchanged. +v2.1</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="IsExchangable" type="xsd:boolean" default="true" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - misspelt, use IsExchangeable instead. -v2.1</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:choice minOccurs="0">
+				<xsd:element name="IsExchangeable" type="xsd:boolean" default="true">
+					<xsd:annotation>
+						<xsd:documentation>Whether the ticket can be exchanged. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="IsExchangable" type="xsd:boolean" default="true">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED - misspelt, use IsExchangeable instead. -v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
 			<xsd:element name="HasExchangeFee" type="xsd:boolean" default="false" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Whether there is a charge for exchanges.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
@@ -25,6 +25,8 @@
 							Add __RequiresDepost__ and __noCashPayment__ to CommercialCondition summary.
 							Add __VehicleCOlelction_
 				</Date>
+				<Date><Modified>2026-07-09</Modified>Add correctly spelt IsExchangeable; deprecate misspelt IsExchangable.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the   CONDITION SUMMARY types.</p>
@@ -222,9 +224,14 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Whether the ticket can be refunded.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="IsExchangeable" type="xsd:boolean" default="true" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether the ticket can be exchanged. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="IsExchangable" type="xsd:boolean" default="true" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Whether the ticket can be exchanged.</xsd:documentation>
+					<xsd:documentation>DEPRECATED - misspelt, use IsExchangeable instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="HasExchangeFee" type="xsd:boolean" default="false" minOccurs="0">

--- a/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareConditionSummary_version.xsd
@@ -232,7 +232,7 @@ Rail transport, Roads and Road transport
 				</xsd:element>
 				<xsd:element name="IsExchangable" type="xsd:boolean" default="true">
 					<xsd:annotation>
-						<xsd:documentation>DEPRECATED - misspelt, use IsExchangeable instead. -v2.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED due to misspelling, use IsExchangeable instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_support.xsd
@@ -34,6 +34,8 @@
 				</Date>
 				<Date><Modified>2019-03-12</Modified>NORWAY-103 *FARES*   Add purchaseGracePeriod  new enum value   to  Reselling  \  ResellWhen 
 				</Date>
+				<Date><Modified>2026-07-09</Modified>Add correctly spelt ExchangeableToEnumeration; deprecate misspelt ExchangableToEnumeration.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the After Sales  USAGE PARAMETER types.</p>
@@ -226,9 +228,9 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<xsd:simpleType name="ExchangableToEnumeration">
+	<xsd:simpleType name="ExchangeableToEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for Exchangeable to.</xsd:documentation>
+			<xsd:documentation>Allowed values for Exchangeable to. +v2.1</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="anyProduct"/>
@@ -243,6 +245,12 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="changeGroupSize"/>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="ExchangableToEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>DEPRECATED - misspelt, use ExchangeableToEnumeration instead. -v2.1</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ExchangeableToEnumeration"/>
 	</xsd:simpleType>
 	<!-- === REFUNDING PARAMETER====================================================== -->
 	<xsd:simpleType name="RefundingIdType">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_support.xsd
@@ -34,7 +34,7 @@
 				</Date>
 				<Date><Modified>2019-03-12</Modified>NORWAY-103 *FARES*   Add purchaseGracePeriod  new enum value   to  Reselling  \  ResellWhen 
 				</Date>
-				<Date><Modified>2026-07-09</Modified>Add correctly spelt ExchangeableToEnumeration; deprecate misspelt ExchangableToEnumeration.
+				<Date><Modified>2026-07-09</Modified>Rename misspelt ExchangableToEnumeration to ExchangeableToEnumeration.
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -245,12 +245,6 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="changeGroupSize"/>
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="ExchangableToEnumeration">
-		<xsd:annotation>
-			<xsd:documentation>DEPRECATED - misspelt, use ExchangeableToEnumeration instead. -v2.1</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="ExchangeableToEnumeration"/>
 	</xsd:simpleType>
 	<!-- === REFUNDING PARAMETER====================================================== -->
 	<xsd:simpleType name="RefundingIdType">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
@@ -361,16 +361,18 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Fare class to which can exchange, if specifically limited.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="ExchangeableTo" type="ExchangeableToEnumeration" default="anyProduct" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Type of fare for which product can be exchanged. +v2.1</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="ExchangableTo" type="ExchangableToEnumeration" default="anyProduct" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableTo instead. -v2.1</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:choice minOccurs="0">
+				<xsd:element name="ExchangeableTo" type="ExchangeableToEnumeration" default="anyProduct">
+					<xsd:annotation>
+						<xsd:documentation>Type of fare for which product can be exchanged. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="ExchangableTo" type="ExchangableToEnumeration" default="anyProduct">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableTo instead. -v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== REFUNDING================================================= -->

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
@@ -180,17 +180,17 @@ Rail transport, Roads and Road transport
 				</xsd:element>
 				<xsd:element name="ExchangableFromAnyTime" type="EmptyType">
 					<xsd:annotation>
-						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromAnyTime instead. -v2.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED due to misspelling, use ExchangeableFromAnyTime instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ExchangableFromDuration" type="xsd:duration">
 					<xsd:annotation>
-						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromDuration instead. -v2.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED due to misspelling, use ExchangeableFromDuration instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ExchangableFromPercentUse" type="xsd:decimal">
 					<xsd:annotation>
-						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromPercentUse instead. -v2.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED due to misspelling, use ExchangeableFromPercentUse instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
@@ -202,7 +202,7 @@ Rail transport, Roads and Road transport
 				</xsd:element>
 				<xsd:element name="ExchangableFromIntervalRef" type="TimeIntervalRefStructure">
 					<xsd:annotation>
-						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromIntervalRef instead. -v2.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED due to misspelling, use ExchangeableFromIntervalRef instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
@@ -224,17 +224,17 @@ Rail transport, Roads and Road transport
 				</xsd:element>
 				<xsd:element name="ExchangableUntilAnyTime" type="EmptyType">
 					<xsd:annotation>
-						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilAnyTime instead. -v2.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED due to misspelling, use ExchangeableUntilAnyTime instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ExchangableUntilDuration" type="xsd:duration">
 					<xsd:annotation>
-						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilDuration instead. -v2.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED due to misspelling, use ExchangeableUntilDuration instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ExchangableUntilPercentUse" type="xsd:decimal">
 					<xsd:annotation>
-						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilPercentUse instead. -v2.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED due to misspelling, use ExchangeableUntilPercentUse instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
@@ -246,7 +246,7 @@ Rail transport, Roads and Road transport
 				</xsd:element>
 				<xsd:element name="ExchangableUntilIntervalRef" type="TimeIntervalRefStructure">
 					<xsd:annotation>
-						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilIntervalRef instead. -v2.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED due to misspelling, use ExchangeableUntilIntervalRef instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
@@ -369,7 +369,7 @@ Rail transport, Roads and Road transport
 				</xsd:element>
 				<xsd:element name="ExchangableTo" type="ExchangeableToEnumeration" default="anyProduct">
 					<xsd:annotation>
-						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableTo instead. -v2.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED due to misspelling, use ExchangeableTo instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
@@ -214,7 +214,7 @@ Rail transport, Roads and Road transport
 				</xsd:element>
 				<xsd:element name="ExchangeableUntilDuration" type="xsd:duration">
 					<xsd:annotation>
-						<xsd:documentation>Duration to end of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) or that ticket. +v2.1</xsd:documentation>
+						<xsd:documentation>Duration to end of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) of that ticket. +v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ExchangeableUntilPercentUse" type="xsd:decimal">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
@@ -33,6 +33,8 @@
 					Move TypeOfProductCategory amnd TypeOfService from netex_journey_version  to  Framework reusable components (netex_travelRights_version)  so they are visible from part 1	
 		  	Can  therefore drop include of netex_travelRights_version from  File netex_usageParameterAfterSales_version.xsd.
 				</Date>
+				<Date><Modified>2026-07-09</Modified>Add correctly spelt Exchangeable* elements; deprecate misspelt Exchangable* forms.
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the After Sales USAGE PARAMETER types.</p>
@@ -161,49 +163,93 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:choice minOccurs="0">
+				<xsd:element name="ExchangeableFromAnyTime" type="EmptyType">
+					<xsd:annotation>
+						<xsd:documentation>Special value - Can be resold from any point after purchase. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="ExchangeableFromDuration" type="xsd:duration">
+					<xsd:annotation>
+						<xsd:documentation>Duration to start of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) after which ticket may be resold. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="ExchangeableFromPercentUse" type="xsd:decimal">
+					<xsd:annotation>
+						<xsd:documentation>Can be resold once a certain percentage of duration or use has been achieved. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
 				<xsd:element name="ExchangableFromAnyTime" type="EmptyType">
 					<xsd:annotation>
-						<xsd:documentation>Special value - Can be resold from any point after purchase.</xsd:documentation>
+						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromAnyTime instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ExchangableFromDuration" type="xsd:duration">
 					<xsd:annotation>
-						<xsd:documentation>Duration to start of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) after which ticket may be resold.</xsd:documentation>
+						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromDuration instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ExchangableFromPercentUse" type="xsd:decimal">
 					<xsd:annotation>
-						<xsd:documentation>Can be resold once a certain percentage of duration or use has been achieved. +v1.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromPercentUse instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
-			<xsd:element name="ExchangableFromIntervalRef" type="TimeIntervalRefStructure" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Reference to arbitrary TimeInterval determining period from which reselling can be done relative to trigger point.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
 			<xsd:choice minOccurs="0">
+				<xsd:element name="ExchangeableFromIntervalRef" type="TimeIntervalRefStructure">
+					<xsd:annotation>
+						<xsd:documentation>Reference to arbitrary TimeInterval determining period from which reselling can be done relative to trigger point. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="ExchangableFromIntervalRef" type="TimeIntervalRefStructure">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableFromIntervalRef instead. -v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
+			<xsd:choice minOccurs="0">
+				<xsd:element name="ExchangeableUntilAnyTime" type="EmptyType">
+					<xsd:annotation>
+						<xsd:documentation>Can be resold anyTime. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="ExchangeableUntilDuration" type="xsd:duration">
+					<xsd:annotation>
+						<xsd:documentation>Duration to end of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) or that ticket. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="ExchangeableUntilPercentUse" type="xsd:decimal">
+					<xsd:annotation>
+						<xsd:documentation>Can be resold until a certain percentage of duration or use has been achieved. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
 				<xsd:element name="ExchangableUntilAnyTime" type="EmptyType">
 					<xsd:annotation>
-						<xsd:documentation>Can be resold anyTime.</xsd:documentation>
+						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilAnyTime instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ExchangableUntilDuration" type="xsd:duration">
 					<xsd:annotation>
-						<xsd:documentation>Duration to end of period before (negative) or after (positive) the trigger point (i.e. either Start of Validity or First Use ) or that ticket.</xsd:documentation>
+						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilDuration instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="ExchangableUntilPercentUse" type="xsd:decimal">
 					<xsd:annotation>
-						<xsd:documentation>Can be resold until a certain percentage of duration or use has been achieved. +v1.1</xsd:documentation>
+						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilPercentUse instead. -v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
-			<xsd:element name="ExchangableUntilIntervalRef" type="TimeIntervalRefStructure" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Reference to arbitrary TimeInterval determining period up until which reselling can be done relative to trigger point.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:choice minOccurs="0">
+				<xsd:element name="ExchangeableUntilIntervalRef" type="TimeIntervalRefStructure">
+					<xsd:annotation>
+						<xsd:documentation>Reference to arbitrary TimeInterval determining period up until which reselling can be done relative to trigger point. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="ExchangableUntilIntervalRef" type="TimeIntervalRefStructure">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableUntilIntervalRef instead. -v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
 			<xsd:element name="EffectiveFrom" type="EffectiveFromEnumeration" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Constraint on when change can be made +v1.1</xsd:documentation>
@@ -315,9 +361,14 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Fare class to which can exchange, if specifically limited.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="ExchangeableTo" type="ExchangeableToEnumeration" default="anyProduct" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Type of fare for which product can be exchanged. +v2.1</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="ExchangableTo" type="ExchangableToEnumeration" default="anyProduct" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Type of fare for which product can be exchanged.</xsd:documentation>
+					<xsd:documentation>DEPRECATED - misspelt, use ExchangeableTo instead. -v2.1</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterAfterSales_version.xsd
@@ -367,7 +367,7 @@ Rail transport, Roads and Road transport
 						<xsd:documentation>Type of fare for which product can be exchanged. +v2.1</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
-				<xsd:element name="ExchangableTo" type="ExchangableToEnumeration" default="anyProduct">
+				<xsd:element name="ExchangableTo" type="ExchangeableToEnumeration" default="anyProduct">
 					<xsd:annotation>
 						<xsd:documentation>DEPRECATED - misspelt, use ExchangeableTo instead. -v2.1</xsd:documentation>
 					</xsd:annotation>


### PR DESCRIPTION
Fixes the long-standing "Exchangable" misspelling in the fares model **without breaking existing documents**.

Two different treatments, depending on visibility:

- **Type names** (not visible in instance documents) are **renamed outright**: `ExchangableToEnumeration` → `ExchangeableToEnumeration`. No alias is kept — only schema-internal references and generated bindings see type names.
- **Element names and `NameOfClass` values** (visible in instance documents) get correctly spelt forms added alongside, with the misspelt forms kept as **deprecated aliases** for removal at a later major version, following the deprecation pattern already used in the schema (e.g. `DEPRECATED - use privateCodes. -v2.0`). New components are marked `+v2.1`, deprecations `-v2.1`.

Related: the misspelling was noted in the "Deliberately left out" section of #1039.

## Changes

### `netex_usageParameterAfterSales_support.xsd`
- simpleType `ExchangableToEnumeration` renamed to `ExchangeableToEnumeration` (same 11 values).

### `netex_usageParameterAfterSales_version.xsd`
- `ResellingPeriodGroup`: correctly spelt alternatives added for all seven elements — `ExchangeableFromAnyTime` / `ExchangeableFromDuration` / `ExchangeableFromPercentUse`, `ExchangeableFromIntervalRef`, `ExchangeableUntilAnyTime` / `ExchangeableUntilDuration` / `ExchangeableUntilPercentUse`, `ExchangeableUntilIntervalRef`. The new spellings were added to the existing `xsd:choice` groups; the two standalone `…IntervalRef` elements became two-member choices (old name | new name), so a document can use either spelling but not both.
- `ExchangingConditionsGroup`: new `ExchangeableTo` element; `ExchangableTo` deprecated (now typed with the renamed enumeration, `default="anyProduct"` retained). Both are wrapped in an `xsd:choice` so the two spellings cannot appear simultaneously.

### `netex_fareConditionSummary_version.xsd`
- `ConditionSummaryCommercialGroup`: new `IsExchangeable` element; `IsExchangable` deprecated but unchanged otherwise. Both wrapped in an `xsd:choice`.

### `netex_framework/netex_responsibility/netex_entity_support.xsd`
- `NameOfClass` enumeration: the nine `Exchangeable*` names and `IsExchangeable` added in alphabetical position; misspelt values retained for backwards compatibility and annotated `DEPRECATED - misspelt, use … instead. -v2.1` (same style as the deprecated mode values in `netex_mode_support.xsd`).

All four files have a `<Modified>` changelog entry added.

## Backwards compatibility

- **Instance documents:** old element names and old `NameOfClass` values remain valid — no existing document breaks. The choice-wrapping means a document cannot state the same fact twice in both spellings; documents using a single spelling (i.e. all existing ones) are unaffected.
- **Generated bindings (JAXB etc.):** the type rename changes one generated class/type name; code referencing `ExchangableToEnumeration` needs a one-line update on regeneration. Element additions are purely additive.
- Documents relying on element defaults are unaffected (defaults kept on the deprecated forms).

## Not in scope

- The official examples still use the old spelling; they remain valid. They can be migrated in a follow-up once the new spelling is agreed.
- Removal of the deprecated element forms — proposed for the next major version.

## Verification (xmllint)

- `NeTEx_publication.xsd` compiles.
- All three examples that use the misspelt elements still validate: `ENTUR-SchoolTwiceADayTripCarnet_2020120.xml`, `Netex_91.1_Rail_RailCard_MultipleProduct.xml`, `rail/Netex_era_distance_ro.xml`.
- A copy of `Netex_era_distance_ro.xml` with all `Exchangable*` elements renamed to `Exchangeable*` also validates (forward test).
