### PR TITLE
Resolve conflicting element names in fares: StepLimitUnit, FulfilmentMethodTypes, NumberOfUnits

### DIFF
--- a/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_entity_support.xsd
@@ -17,6 +17,8 @@
 				<Date>
 					<Modified>2010-11-05</Modified>
 				</Date>
+				<Date><Modified>2026-07-10</Modified>Add FulfilmentMethodTypes and StepLimitUnit values to NameOfClass.
+				</Date>
 				<Description>
 					<p>NeTEx - Network Exchange. This subschema defines data Modification base types.</p>
 				</Description>
@@ -1145,6 +1147,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="FulfilmentMethodPriceRef"/>
 			<xsd:enumeration value="FulfilmentMethodRef"/>
 			<xsd:enumeration value="FulfilmentMethodType"/>
+			<xsd:enumeration value="FulfilmentMethodTypes"/>
 			<xsd:enumeration value="FullCharge"/>
 			<xsd:enumeration value="FunicularSubmode"/>
 			<xsd:enumeration value="FurtherDetails"/>
@@ -2713,6 +2716,7 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="StepLength"/>
 			<xsd:enumeration value="StepLimit"/>
 			<xsd:enumeration value="StepLimitRef"/>
+			<xsd:enumeration value="StepLimitUnit"/>
 			<xsd:enumeration value="StopArea"/>
 			<xsd:enumeration value="StopAreaRef"/>
 			<xsd:enumeration value="StopAssignment"/>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -128,6 +128,8 @@
 				</Date>
 				<Date><Modified>2023-12-14</Modified>FIX - Rename RoutingValidityParametersGroup to align with Transmodel. Add missing TransferRestriction, ServiceExclusion, RoutingRestrictionnZone and Border Point parametrers.
 				</Date>
+				<Date><Modified>2026-07-10</Modified>Add FulfilmentMethodTypes to DistributionParametersGroup; deprecate FulfilmentMethodType (singular name for a list of values).
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the FARE ACCESS RIGHT PARAMETER types.</p>
@@ -772,11 +774,18 @@ Rail transport, Roads and Road transport
 				<xsd:element ref="DistributionChannelRef" minOccurs="0"/>
 				<xsd:element ref="GroupOfDistributionChannelsRef" minOccurs="0"/>
 			</xsd:choice>
-			<xsd:element name="FulfilmentMethodType" type="FulfilmentMethodListOfEnumerations" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Fulfillment MEthod +v2.0</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:choice minOccurs="0">
+				<xsd:element name="FulfilmentMethodTypes" type="FulfilmentMethodListOfEnumerations">
+					<xsd:annotation>
+						<xsd:documentation>Allowed FULFILMENT METHOD types. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="FulfilmentMethodType" type="FulfilmentMethodListOfEnumerations">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED - singular name for a list of values, use FulfilmentMethodTypes instead. -v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
 			<xsd:element ref="FulfilmentMethodRef" minOccurs="0"/>
 			<xsd:element name="PaymentMethod" type="PaymentMethodEnumeration" minOccurs="0">
 				<xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_fareProduct_version.xsd
@@ -41,6 +41,8 @@
 				</Date>
 				<Date><Modified>2023-11-07</Modified>CR0544 Deprecate PrivateCode.
 				</Date>
+				<Date><Modified>2026-07-10</Modified>Add NumberOfUnits to AMOUNT OF PRICE UNIT; deprecate Amount (a number of units, not a monetary amount).
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the FARE PRODUCT types.</p>
@@ -854,11 +856,18 @@ Rail transport, Roads and Road transport
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="PriceUnitRef" minOccurs="0"/>
-			<xsd:element name="Amount" type="xsd:decimal" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Number of units. If only ine. Otherwise use TARIFF with FARE QUALITY FACTOR to specify a range</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:choice minOccurs="0">
+				<xsd:element name="NumberOfUnits" type="xsd:decimal">
+					<xsd:annotation>
+						<xsd:documentation>Number of units, if there is only one. Otherwise use TARIFF with FARE QUALITY FACTOR to specify a range. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="Amount" type="xsd:decimal">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED - despite its name this is a number of units, not a monetary amount; use NumberOfUnits instead. -v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== PREASSIGNED FARE PRODUC=============================================== -->

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_version.xsd
@@ -36,6 +36,8 @@
 				</Date>
 				<Date><Modified>2020-12-10</Modified>FIX - Make ActivationMeans into list
 				</Date>
+				<Date><Modified>2026-07-10</Modified>Add StepLimitUnit to STEP LIMIT; deprecate AdjustmentUnits (name clash with numeric AdjustmentUnits on RULE STEP RESULT).
+				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
 					<p>This sub-schema describes the Travel USAGE PARAMETER  types.</p>
@@ -267,11 +269,18 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Whether restricted to a number of stops.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="AdjustmentUnits" type="StepLimitUnitEnumeration" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Units in which steps atre counted.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:choice minOccurs="0">
+				<xsd:element name="StepLimitUnit" type="StepLimitUnitEnumeration">
+					<xsd:annotation>
+						<xsd:documentation>Units in which steps are counted. +v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="AdjustmentUnits" type="StepLimitUnitEnumeration">
+					<xsd:annotation>
+						<xsd:documentation>DEPRECATED - use StepLimitUnit instead; the name clashes with the numeric AdjustmentUnits on RULE STEP RESULT. -v2.1</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
 			<xsd:element name="MinimumNumberOfSteps" type="xsd:nonNegativeInteger" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Minimum number of steps allowed.</xsd:documentation>


### PR DESCRIPTION
Following my semantic wave... because better machine reasoning depends on humans describing semantics with precision and without ambiguity.

Several fares elements share a name with an element of a **different type or meaning** in another context, which misleads implementers and produces confusing generated bindings. This PR resolves the three genuine cases **without breaking existing documents**, using the same pattern as #1041: the correctly named element is added, the old one is deprecated, and both are wrapped in an `xsd:choice` so a document cannot state the same fact twice. New components are marked `+v2.1`, deprecations `-v2.1`.

## Proposed changes

### 1. `AdjustmentUnits` / quantity vs unit kind
- On RULE STEP RESULT (`netex_farePrice_version.xsd`) `AdjustmentUnits` is `xsd:decimal` (a step-calculation quantity);  **unchanged**.
- On STEP LIMIT (`netex_usageParameterTravel_version.xsd`) the same name `AdjustmentUnits` was an enumeration (`StepLimitUnitEnumeration`: stops, sections, zones, networks, …) defined as 'Geographical parameter limiting the access rights by counts of stops, sections or zones'. New element **`StepLimitUnit`** added (name follows the enumeration and the owning STEP LIMIT entity); `AdjustmentUnits` deprecated.

### 2. `FulfilmentMethodType` / singular name, list type
- On FULFILMENT METHOD (`netex_salesDistribution_version.xsd`) it is a single enumeration value;  **unchanged** (name matches type).
- In `DistributionParametersGroup` (`netex_accessRightParameter_version.xsd`) the same name `FulfilmentMethodType` held a `FulfilmentMethodListOfEnumerations`. New element **`FulfilmentMethodTypes`** added; the singular-named list deprecated.

### 3. `Amount` on AMOUNT OF PRICE UNIT / not a monetary amount
- On FARE PRICE (`netex_farePrice_version.xsd`) `Amount` is `CurrencyAmountType` (money); **unchanged**.
- On AMOUNT OF PRICE UNIT PRODUCT (`netex_fareProduct_version.xsd`) `Amount` is `xsd:decimal` documented as "Number of units". New element **`NumberOfUnits`** added; `Amount` deprecated.

### Framework
- `NameOfClass` enumeration (`netex_entity_support.xsd`): values `FulfilmentMethodTypes` and `StepLimitUnit` added in alphabetical position (`NumberOfUnits` already present).

All four files have a `<Modified>` changelog entry added.

## Related cases checked but not changed

- `PaymentMethod` on REFUNDING (`netex_usageParameterAfterSales_version.xsd`) also carries a list type under a singular name, but it is **already deprecated** in the schema ("DEPRECATED - use PaymentMethods on RESELLING"), so no change is needed.
- The single-valued `PaymentMethod` elements on `DistributionParametersGroup` and fare table cells are internally consistent (singular name, singular type); whether they should allow multiple values is a modelling question for the team, not a naming defect, so they were left as-is.

## Backwards compatibility

- Old element names remain valid; the `xsd:choice` wrapping only prevents using both the old and new name simultaneously. No example uses the affected elements in the changed contexts (checked: no `<AmountOfPriceUnit>`, `<AdjustmentUnits>` or `<FulfilmentMethodType>` instances in `examples/`), so no example changes are needed.
- Generated bindings gain new members but lose none.

## Verification (xmllint)

- `NeTEx_publication.xsd` compiles (proves the new choice content models are UPA-valid).
- Examples validate unchanged, including those with `<Amount>` in other (unaffected) contexts: `ENTUR-SchoolTwiceADayTripCarnet_2020120.xml`, `Netex_101.21_TfL_GeographicFares_UnitZone_MultipleProduct.xml`, `rail/Netex_era_crossborder_de.xml`.
