### PR TITLE
Addition of AI guidelines in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ For new features, the decision between targetting v2.1-wip or v3.0-wip will be m
 
 _Upcoming: templates for Pull Request_
 
+### The use of AI in this repo 🤖
+
+In this repository, the use of AI should follow these guidelines. The guiding principle is that any contributor is the ultimate reponsible for their work on NeTEx and they should be the last reviewer of any AI work before submitting it for peer-review.
+
+AI **can** be used for:
+- Generation of code for contributors to work on the XSD by themselves,
+- Analysis of any change proposed to the XSD before it is edited / commented / approved,
+- Improve the general language in the documentation (i.e, anyting in `<xsd:annotation>` and `<xsd:documentation>`) or to check for typos in any work.
+
+AI **cannot** be used for:
+- Committing a change in a Pull Request, i.e. the AI agent is seen as the author of the commit and not the contributor,
+- Automated code review as a stand alone, i.e. without the result being proof-read by the contributor,
+- Produce documentation from scratch (i.e, anyting in `<xsd:annotation>` and `<xsd:documentation>` should be proof-read by the contributor if it was suggested by AI).
+
+In case you have a GitHub Pro account, please disable the feature `Automated Copilot code review`before contributing here.
+
 ----
 
 ## Changelog 📰

--- a/README.md
+++ b/README.md
@@ -114,18 +114,18 @@ _Upcoming: templates for Pull Request_
 
 ### The use of AI in this repo 🤖
 
-In this repository, the use of AI should follow these guidelines. The guiding principle is that any contributor is the ultimate reponsible for their work on NeTEx and they should be the last reviewer of any AI work before submitting it for peer-review; in other words, only contributors can be autors or co-authors of any change made to NeTEx.
+In this repository, the use of AI should follow these guidelines. The guiding principle is that any contributor is ultimatly reponsible for their work on NeTEx and they should be the last reviewer of any AI work before submitting it for peer-review; in other words, only contributors can be authors or co-authors of any change made to NeTEx.
 
 AI **can** be used for:
 - Generation of code for contributors to work on the XSD by themselves,
 - Analysis of any change proposed to the XSD before it is edited / commented / approved,
-- Improve the general language in the documentation (i.e, anyting in `<xsd:annotation>` and `<xsd:documentation>`) or to check for typos in any work.
+- Improve the general language in the documentation (i.e, anything in `<xsd:annotation>` and `<xsd:documentation>`) or to check for typos in any work.
 
 AI **cannot** be used for:
 - Committing a change in a Pull Request, i.e. the AI agent cannot be an author or co-author of any commit,
 - Authoring a change, i.e. the AI agent cannot be an author or co-author of any Pull Request,
-- Automated code review as a stand alone, i.e. the result of a review must be proof-read by a contributor,
-- Produce documentation from scratch (i.e, anyting in `<xsd:annotation>` and `<xsd:documentation>` should be proof-read by a contributor if it was suggested by AI).
+- Automated code review as a stand alone action, i.e. the result of a review must be proof-read by a contributor,
+- Produce documentation from scratch (i.e, anything in `<xsd:annotation>` and `<xsd:documentation>` should be proof-read by a contributor if it was suggested by AI).
 
 In case you have a GitHub Pro account, please disable the feature `Automated Copilot code review`before contributing here.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ _Upcoming: templates for Pull Request_
 
 ### The use of AI in this repo 🤖
 
-In this repository, the use of AI should follow these guidelines. The guiding principle is that any contributor is ultimatly reponsible for their work on NeTEx and they should be the last reviewer of any AI work before submitting it for peer-review; in other words, only contributors can be authors or co-authors of any change made to NeTEx.
+In this repository, the use of AI should follow these guidelines. The guiding principle is that any contributor is ultimately reponsible for their work on NeTEx and they should be the last reviewer of any AI-guided work before submitting it for peer-review; in other words, only contributors can be authors or co-authors of any change made to NeTEx.
 
 AI **can** be used for:
 - Generation of code for contributors to work on the XSD by themselves,

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ AI **cannot** be used for:
 - Automated code review as a stand alone action, i.e. the result of a review must be proof-read by a contributor,
 - Produce documentation from scratch (i.e, anything in `<xsd:annotation>` and `<xsd:documentation>` should be proof-read by a contributor if it was suggested by AI).
 
-In case you have a GitHub Pro account, please disable the feature `Automated Copilot code review`before contributing here.
+In case you have a GitHub Pro account, please disable the feature `Automated Copilot code review` before contributing here.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ _Upcoming: templates for Pull Request_
 
 ### The use of AI in this repo 🤖
 
-In this repository, the use of AI should follow these guidelines. The guiding principle is that any contributor is the ultimate reponsible for their work on NeTEx and they should be the last reviewer of any AI work before submitting it for peer-review.
+In this repository, the use of AI should follow these guidelines. The guiding principle is that any contributor is the ultimate reponsible for their work on NeTEx and they should be the last reviewer of any AI work before submitting it for peer-review; in other words, only contributors can be autors or co-authors of any change made to NeTEx.
 
 AI **can** be used for:
 - Generation of code for contributors to work on the XSD by themselves,
@@ -122,9 +122,10 @@ AI **can** be used for:
 - Improve the general language in the documentation (i.e, anyting in `<xsd:annotation>` and `<xsd:documentation>`) or to check for typos in any work.
 
 AI **cannot** be used for:
-- Committing a change in a Pull Request, i.e. the AI agent is seen as the author of the commit and not the contributor,
-- Automated code review as a stand alone, i.e. without the result being proof-read by the contributor,
-- Produce documentation from scratch (i.e, anyting in `<xsd:annotation>` and `<xsd:documentation>` should be proof-read by the contributor if it was suggested by AI).
+- Committing a change in a Pull Request, i.e. the AI agent cannot be an author or co-author of any commit,
+- Authoring a change, i.e. the AI agent cannot be an author or co-author of any Pull Request,
+- Automated code review as a stand alone, i.e. the result of a review must be proof-read by a contributor,
+- Produce documentation from scratch (i.e, anyting in `<xsd:annotation>` and `<xsd:documentation>` should be proof-read by a contributor if it was suggested by AI).
 
 In case you have a GitHub Pro account, please disable the feature `Automated Copilot code review`before contributing here.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ In this repository, the use of AI should follow these guidelines. The guiding pr
 AI **can** be used for:
 - Generation of code for contributors to work on the XSD by themselves,
 - Analysis of any change proposed to the XSD before it is edited / commented / approved,
-- Improve the general language in the documentation (i.e, anything in `<xsd:annotation>` and `<xsd:documentation>`) or to check for typos in any work.
+- Improvements to the general language in the documentation (i.e, anything in `<xsd:annotation>` and `<xsd:documentation>`) or to check for typos in any work.
 
 AI **cannot** be used for:
 - Committing a change in a Pull Request, i.e. the AI agent cannot be an author or co-author of any commit,


### PR DESCRIPTION
This is an attempt to clarify the guidelines around the use of AI that were discussed on 24 June 2026 during the Transmodel week.

This builds upon a clarification on [Basecamp](https://3.basecamp.com/3256016/buckets/2570434/messages/10109139015#__recording_10109151918) after I made a comment on PR #1041 