### PR TITLE
Backport to v2.1-wip -- Addition of AI guidelines in the readme (#1050)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ For new features, the decision between targetting v2.1-wip or v3.0-wip will be m
 
 _Upcoming: templates for Pull Request_
 
+### The use of AI in this repo 🤖
+
+In this repository, the use of AI should follow these guidelines. The guiding principle is that any contributor is ultimately reponsible for their work on NeTEx and they should be the last reviewer of any AI-guided work before submitting it for peer-review; in other words, only contributors can be authors or co-authors of any change made to NeTEx.
+
+AI **can** be used for:
+- Generation of code for contributors to work on the XSD by themselves,
+- Analysis of any change proposed to the XSD before it is edited / commented / approved,
+- Improvements to the general language in the documentation (i.e, anything in `<xsd:annotation>` and `<xsd:documentation>`) or to check for typos in any work.
+
+AI **cannot** be used for:
+- Committing a change in a Pull Request, i.e. the AI agent cannot be an author or co-author of any commit,
+- Authoring a change, i.e. the AI agent cannot be an author or co-author of any Pull Request,
+- Automated code review as a stand alone action, i.e. the result of a review must be proof-read by a contributor,
+- Produce documentation from scratch (i.e, anything in `<xsd:annotation>` and `<xsd:documentation>` should be proof-read by a contributor if it was suggested by AI).
+
+In case you have a GitHub Pro account, please disable the feature `Automated Copilot code review` before contributing here.
+
 ----
 
 ## Changelog 📰


### PR DESCRIPTION
* addition of AI guidelines: attempt for write what has been discussed previously on the use of AI

* clarification on roles: clarifying that only contributors can be seen as authors or co-authors of commits and pull requests