### PR TITLE
Fixed typo in nta examples in years (+ CI fix for forks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: push
+on:
+  push:
+  pull_request:
 
 permissions:
   contents: write
@@ -26,7 +28,11 @@ jobs:
       - name: Validate NeTEx XML examples
         run: ./.github/scripts/validate-examples.sh
 
+      # Only on push: a pull_request run from a fork gets a read-only token
+      # and cannot commit back. Target branches are still normalized by the
+      # push-triggered run that follows the merge.
       - name: Commit changes
+        if: github.event_name == 'push'
         uses: EndBug/add-and-commit@v9 # https://github.com/marketplace/actions/add-commit
         with:
           default_author: github_actions

--- a/examples/standards/nta/NTA-PI-01_EI_IR_LINE_OFFER__Journey00122_20200801.xml
+++ b/examples/standards/nta/NTA-PI-01_EI_IR_LINE_OFFER__Journey00122_20200801.xml
@@ -410,7 +410,7 @@ RS 0 100 10 Reservations available#
 
 (C) NTA 2020
   -->
-	<PublicationTimestamp>2019-12-17T09:30:46.0Z</PublicationTimestamp>
+	<PublicationTimestamp>2019-12-17T09:30:47.0Z</PublicationTimestamp>
 	<ParticipantRef>SYS001</ParticipantRef>
 	<!-- ======WHAT WAS REQUESTED ========== -->
 	<PublicationRequest version="1.0">

--- a/examples/standards/nta/NTA-PI-01_EI_IR_LINE_OFFER__Journey00122_20200801.xml
+++ b/examples/standards/nta/NTA-PI-01_EI_IR_LINE_OFFER__Journey00122_20200801.xml
@@ -410,7 +410,7 @@ RS 0 100 10 Reservations available#
 
 (C) NTA 2020
   -->
-	<PublicationTimestamp>20209-12-17T09:30:46.0Z</PublicationTimestamp>
+	<PublicationTimestamp>2019-12-17T09:30:46.0Z</PublicationTimestamp>
 	<ParticipantRef>SYS001</ParticipantRef>
 	<!-- ======WHAT WAS REQUESTED ========== -->
 	<PublicationRequest version="1.0">

--- a/examples/standards/nta/NTA-PI-01_EI_IR_STOP_OFFER__AllStations_20200801.xml
+++ b/examples/standards/nta/NTA-PI-01_EI_IR_STOP_OFFER__AllStations_20200801.xml
@@ -11,7 +11,7 @@ HRDF records NeTEx  format .
  
 (C) NTA , IR 2020
   -->
-	<PublicationTimestamp>20209-12-17T09:30:46.0Z</PublicationTimestamp>
+	<PublicationTimestamp>2019-12-17T09:30:46.0Z</PublicationTimestamp>
 	<ParticipantRef>SYS001</ParticipantRef>
 	<!-- ======WHAT WAS REQUESTED ========== -->
 	<PublicationRequest version="1.0">

--- a/examples/standards/nta/NTA-PI-01_EI_LUAS_LINE_OFFER_LUAS_Line93Calls_20200701.xml
+++ b/examples/standards/nta/NTA-PI-01_EI_LUAS_LINE_OFFER_LUAS_Line93Calls_20200701.xml
@@ -309,7 +309,7 @@ attribution002,0,1,Transdev,12345
 
 (C) NTA 2020
   -->
-	<PublicationTimestamp>20209-12-17T09:30:46.0Z</PublicationTimestamp>
+	<PublicationTimestamp>2019-12-17T09:30:46.0Z</PublicationTimestamp>
 	<ParticipantRef>SYS001</ParticipantRef>
 	<!-- ======WHAT WAS REQUESTED ========== -->
 	<PublicationRequest version="1.0">

--- a/examples/standards/nta/NTA-PI-01_EI_LUAS_LINE_OFFER_LUAS_Line93_20200701.xml
+++ b/examples/standards/nta/NTA-PI-01_EI_LUAS_LINE_OFFER_LUAS_Line93_20200701.xml
@@ -312,7 +312,7 @@ attribution002,0,1,Transdev,12345
 
 (C) NTA 2020
   -->
-	<PublicationTimestamp>20209-12-17T09:30:46.0Z</PublicationTimestamp>
+	<PublicationTimestamp>2019-12-17T09:30:46.0Z</PublicationTimestamp>
 	<ParticipantRef>SYS001</ParticipantRef>
 	<!-- ======WHAT WAS REQUESTED ========== -->
 	<PublicationRequest version="1.0">

--- a/examples/standards/nta/NTA-PI-01_EI_NOC_Operator_20200601.xml
+++ b/examples/standards/nta/NTA-PI-01_EI_NOC_Operator_20200601.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" version="1.0" xsi:schemaLocation="http://www.netex.org.uk/netex ../../../xsd/NeTEx_publication.xsd">
-	<PublicationTimestamp>20209-12-17T09:30:46.0Z</PublicationTimestamp>
+	<PublicationTimestamp>2019-12-17T09:30:46.0Z</PublicationTimestamp>
 	<ParticipantRef>SYS001</ParticipantRef>
 	<!-- ======WHAT WAS REQUESTED ========== -->
 	<PublicationRequest version="1.0">

--- a/examples/standards/nta/NTA-PI-01_EI_NOC_Operator_LUAS_20200601.xml
+++ b/examples/standards/nta/NTA-PI-01_EI_NOC_Operator_LUAS_20200601.xml
@@ -7,7 +7,7 @@ This Example shows an extract of  encoding a single  Operator  data     encoded 
  
 (C) NTA 2020
   -->
-	<PublicationTimestamp>20209-12-17T09:30:46.0Z</PublicationTimestamp>
+	<PublicationTimestamp>2019-12-17T09:30:46.0Z</PublicationTimestamp>
 	<ParticipantRef>SYS001</ParticipantRef>
 	<!-- ======WHAT WAS REQUESTED ========== -->
 	<PublicationRequest version="1.0">

--- a/examples/standards/nta/NTA-PI-01_EI_NTA_Luas_20200715.xml
+++ b/examples/standards/nta/NTA-PI-01_EI_NTA_Luas_20200715.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" version="1.0" xsi:schemaLocation="http://www.netex.org.uk/netex ../../../xsd/NeTEx_publication.xsd">
-	<PublicationTimestamp>20209-12-17T09:30:46.0Z</PublicationTimestamp>
+	<PublicationTimestamp>2019-12-17T09:30:46.0Z</PublicationTimestamp>
 	<ParticipantRef>SYS001</ParticipantRef>
 	<!-- ======WHAT WAS REQUESTED ========== -->
 	<PublicationRequest version="1.0">


### PR DESCRIPTION
Fixed typo  '20209-12-17T09:30:46.0Z' with '2019-12-17T09:30:46.0Z' in nta examples.

In the linked issue I mentioned it should be 2020 but given that the `/PublicationDelivery/PublicationRequest/RequestTimestamp` is `2019-12-17T09:30:46.0Z` and not `2020-12-17T09:30:46.0Z` I believe I was originally mistaken.

Fixes: #1048 

EDIT @thbar: also in this PR, a fix to ensure the test workflow (`run`) will run when we get PR from forks.